### PR TITLE
fix: fix decline notification email, add braze trigger prop

### DIFF
--- a/enterprise_access/apps/api/tasks.py
+++ b/enterprise_access/apps/api/tasks.py
@@ -140,6 +140,7 @@ def send_notification_emails_for_requests(
             subsidy_request.course_id
         )
         braze_trigger_properties['course_about_page_url'] = course_about_page_url
+        braze_trigger_properties['course_title'] = subsidy_request.course_title
 
         logger.info(f'Sending braze campaign message for subsidy request {subsidy_request}')
         braze_client_instance.send_campaign_message(

--- a/enterprise_access/apps/api/tests/test_tasks.py
+++ b/enterprise_access/apps/api/tests/test_tasks.py
@@ -176,6 +176,7 @@ class TestTasks(APITestWithMocks):
             recipients=[expected_recipient],
             trigger_properties={
                 'contact_email': 'example2@example.com',
+                'course_title': self.license_requests[0].course_title,
                 'course_about_page_url': expected_course_about_page_url},
             )
         assert mock_braze_client().send_campaign_message.call_count == 1

--- a/enterprise_access/apps/api/v1/tests/test_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_views.py
@@ -29,7 +29,7 @@ from enterprise_access.apps.subsidy_request.tests.factories import (
     LicenseRequestFactory,
     SubsidyRequestCustomerConfigurationFactory
 )
-from test_utils import COURSE_TITLE_ABOUT_PIE, APITestWithMocks
+from test_utils import APITestWithMocks
 
 LICENSE_REQUESTS_LIST_ENDPOINT = reverse('api:v1:license-requests-list')
 LICENSE_REQUESTS_APPROVE_ENDPOINT = reverse('api:v1:license-requests-approve')
@@ -513,9 +513,6 @@ class TestLicenseRequestViewSet(TestSubsidyRequestViewSet):
             SubsidyTypeChoices.LICENSE,
         )
 
-        # Set via celery task on post_save event
-        assert self.user_license_request_1.course_title == COURSE_TITLE_ABOUT_PIE
-
     def test_decline_no_subsidy_request_uuids(self):
         """ 400 thrown if no subsidy requests provided """
         self.set_jwt_cookie([{
@@ -606,10 +603,7 @@ class TestLicenseRequestViewSet(TestSubsidyRequestViewSet):
             state=SubsidyRequestStates.DECLINED
         ).count() == 1
 
-        # Set via celery task on post_save event
-        assert self.user_license_request_1.course_title == COURSE_TITLE_ABOUT_PIE
-
-    @mock.patch('enterprise_access.apps.api.v1.views.send_notification_emails_for_requests.apply_async')
+    @mock.patch('enterprise_access.apps.api.v1.views.send_notification_emails_for_requests.delay')
     def test_decline_send_notification(self, mock_notify):
         """ Test braze task called if send_notification is True """
         self.set_jwt_cookie([{
@@ -987,9 +981,6 @@ class TestCouponCodeRequestViewSet(TestSubsidyRequestViewSet):
             SubsidyTypeChoices.COUPON,
         )
 
-        # Set via celery task on post_save event
-        assert self.coupon_code_request_1.course_title == COURSE_TITLE_ABOUT_PIE
-
     def test_decline_no_subsidy_request_uuids(self):
         """ 400 thrown if no subsidy requests provided """
         self.set_jwt_cookie([{
@@ -1079,10 +1070,7 @@ class TestCouponCodeRequestViewSet(TestSubsidyRequestViewSet):
             state=SubsidyRequestStates.DECLINED
         ).count() == 1
 
-        # Set via celery task on post_save event
-        assert self.coupon_code_request_1.course_title == COURSE_TITLE_ABOUT_PIE
-
-    @mock.patch('enterprise_access.apps.api.v1.views.send_notification_emails_for_requests.apply_async')
+    @mock.patch('enterprise_access.apps.api.v1.views.send_notification_emails_for_requests.delay')
     def test_decline_send_notification(self, mock_notify):
         """ Test braze task called if send_notification is True """
         self.set_jwt_cookie([{

--- a/enterprise_access/apps/api/v1/views.py
+++ b/enterprise_access/apps/api/v1/views.py
@@ -399,10 +399,10 @@ class LicenseRequestViewSet(SubsidyRequestViewSet):
 
         subsidy_request_uuids = [subsidy_request.uuid for subsidy_request in subsidies_to_decline]
         if send_notification:
-            send_notification_emails_for_requests.apply_async(
+            send_notification_emails_for_requests.delay(
                 subsidy_request_uuids,
                 settings.BRAZE_DECLINE_NOTIFICATION_CAMPAIGN,
-                SubsidyTypeChoices.LICENSE,
+                SubsidyTypeChoices.LICENSE
             )
 
         serialized_subsidy_requests = serializers.LicenseRequestSerializer(subsidies_to_decline, many=True)
@@ -580,10 +580,10 @@ class CouponCodeRequestViewSet(SubsidyRequestViewSet):
 
         subsidy_request_uuids = [subsidy_request.uuid for subsidy_request in subsidies_to_decline]
         if send_notification:
-            send_notification_emails_for_requests.apply_async(
+            send_notification_emails_for_requests.delay(
                 subsidy_request_uuids,
                 settings.BRAZE_DECLINE_NOTIFICATION_CAMPAIGN,
-                SubsidyTypeChoices.COUPON,
+                SubsidyTypeChoices.COUPON
             )
 
         serialized_subsidy_requests = serializers.CouponCodeRequestSerializer(subsidies_to_decline, many=True)

--- a/enterprise_access/apps/subsidy_request/tests/factories.py
+++ b/enterprise_access/apps/subsidy_request/tests/factories.py
@@ -26,6 +26,7 @@ class SubsidyRequestFactory(factory.django.DjangoModelFactory):
     uuid = factory.LazyFunction(uuid4)
     user = factory.SubFactory(UserFactory)
     course_id = factory.LazyFunction(uuid4)
+    course_title = factory.LazyAttribute(lambda _: FAKER.word())
     enterprise_customer_uuid = factory.LazyFunction(uuid4)
     state = SubsidyRequestStates.REQUESTED
     reviewed_at = datetime.utcnow()
@@ -50,7 +51,7 @@ class CouponCodeRequestFactory(SubsidyRequestFactory):
     Test factory for the `CouponCodeRequest` model.
     """
 
-    coupon_id = factory.LazyAttribute(lambda x: FAKER.pyint())
+    coupon_id = factory.LazyAttribute(lambda _: FAKER.pyint())
     coupon_code = factory.LazyFunction(uuid4)
 
     class Meta:

--- a/enterprise_access/apps/subsidy_request/tests/test_models.py
+++ b/enterprise_access/apps/subsidy_request/tests/test_models.py
@@ -66,7 +66,7 @@ class LicenseRequestTests(TestCaseWithMockedDiscoveryApiClient):
         """
         original_call_count = self.mock_discovery_client.call_count
 
-        subsidy = LicenseRequestFactory()
+        subsidy = LicenseRequestFactory(course_title=None)
         assert self.mock_discovery_client.call_count == original_call_count + 1
 
         subsidy.refresh_from_db()
@@ -105,7 +105,7 @@ class CouponCodeRequestTests(TestCaseWithMockedDiscoveryApiClient):
         """
         original_call_count = self.mock_discovery_client.call_count
 
-        subsidy = CouponCodeRequestFactory()
+        subsidy = CouponCodeRequestFactory(course_title=None)
         assert self.mock_discovery_client.call_count == original_call_count + 1
 
         subsidy.refresh_from_db()


### PR DESCRIPTION
- fix apply_async usage, need to use args=[...] for apply_async, switching to delay since we don't need to pass extra args
- add course title to braze trigger properties