### PR TITLE
prototype: drf-spectacular

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.idea/
 
 # C extensions
 *.so

--- a/enterprise_access/oas.py
+++ b/enterprise_access/oas.py
@@ -16,3 +16,161 @@
 #                     #     del parameter['oneOf']
 #
 #         return schema
+
+import re
+from collections import defaultdict
+
+from inflection import camelize
+from rest_framework.settings import api_settings
+
+from drf_spectacular.plumbing import (
+    ResolvedComponent, list_hash, load_enum_name_overrides, safe_ref, warn,
+)
+from drf_spectacular.settings import spectacular_settings
+
+
+def postprocess_schema_enums(result, generator, **kwargs):
+    """
+    simple replacement of Enum/Choices that globally share the same name and have
+    the same choices. Aids client generation to not generate a separate enum for
+    every occurrence. only takes effect when replacement is guaranteed to be correct.
+    """
+
+    def iter_prop_containers(schema, component_name=None):
+        if not component_name:
+            for component_name, schema in schema.items():
+                if spectacular_settings.COMPONENT_SPLIT_PATCH:
+                    component_name = re.sub('^Patched(.+)', r'\1', component_name)
+                if spectacular_settings.COMPONENT_SPLIT_REQUEST:
+                    component_name = re.sub('(.+)Request$', r'\1', component_name)
+                yield from iter_prop_containers(schema, component_name)
+        elif isinstance(schema, list):
+            for item in schema:
+                yield from iter_prop_containers(item, component_name)
+        elif isinstance(schema, dict):
+            if schema.get('properties'):
+                yield component_name, schema['properties']
+            yield from iter_prop_containers(schema.get('oneOf', []), component_name)
+            yield from iter_prop_containers(schema.get('allOf', []), component_name)
+            yield from iter_prop_containers(schema.get('anyOf', []), component_name)
+
+    def create_enum_component(name, schema):
+        component = ResolvedComponent(
+            name=name,
+            type=ResolvedComponent.SCHEMA,
+            schema=schema,
+            object=name,
+        )
+        generator.registry.register_on_missing(component)
+        return component
+
+    schemas = result.get('components', {}).get('schemas', {})
+
+    overrides = load_enum_name_overrides()
+
+    prop_hash_mapping = defaultdict(set)
+    hash_name_mapping = defaultdict(set)
+    # collect all enums, their names and choice sets
+    for component_name, props in iter_prop_containers(schemas):
+        for prop_name, prop_schema in props.items():
+            if prop_schema.get('type') == 'array':
+                prop_schema = prop_schema.get('items', {})
+            if 'enum' not in prop_schema:
+                continue
+            # remove blank/null entry for hashing. will be reconstructed in the last step
+            prop_enum_cleaned_hash = list_hash([i for i in prop_schema['enum'] if i not in ['', None]])
+            prop_hash_mapping[prop_name].add(prop_enum_cleaned_hash)
+            hash_name_mapping[prop_enum_cleaned_hash].add((component_name, prop_name))
+
+    # traverse all enum properties and generate a name for the choice set. naming collisions
+    # are resolved and a warning is emitted. giving a choice set multiple names is technically
+    # correct but potentially unwanted. also emit a warning there to make the user aware.
+    enum_name_mapping = {}
+    for prop_name, prop_hash_set in prop_hash_mapping.items():
+        for prop_hash in prop_hash_set:
+            if prop_hash in overrides:
+                enum_name = overrides[prop_hash]
+            elif len(prop_hash_set) == 1:
+                # prop_name has been used exclusively for one choice set (best case)
+                enum_name = f'{camelize(prop_name)}Enum'
+            elif len(hash_name_mapping[prop_hash]) == 1:
+                # prop_name has multiple choice sets, but each one limited to one component only
+                component_name, _ = next(iter(hash_name_mapping[prop_hash]))
+                enum_name = f'{camelize(component_name)}{camelize(prop_name)}Enum'
+            else:
+                enum_name = f'{camelize(prop_name)}{prop_hash[:3].capitalize()}Enum'
+                warn(
+                    f'enum naming encountered a non-optimally resolvable collision for fields '
+                    f'named "{prop_name}". The same name has been used for multiple choice sets '
+                    f'in multiple components. The collision was resolved with "{enum_name}". '
+                    f'add an entry to ENUM_NAME_OVERRIDES to fix the naming.'
+                )
+            if enum_name_mapping.get(prop_hash, enum_name) != enum_name:
+                warn(
+                    f'encountered multiple names for the same choice set ({enum_name}). This '
+                    f'may be unwanted even though the generated schema is technically correct. '
+                    f'Add an entry to ENUM_NAME_OVERRIDES to fix the naming.'
+                )
+                del enum_name_mapping[prop_hash]
+            else:
+                enum_name_mapping[prop_hash] = enum_name
+            enum_name_mapping[(prop_hash, prop_name)] = enum_name
+
+    # replace all enum occurrences with a enum schema component. cut out the
+    # enum, replace it with a reference and add a corresponding component.
+    for _, props in iter_prop_containers(schemas):
+        for prop_name, prop_schema in props.items():
+            is_array = prop_schema.get('type') == 'array'
+            if is_array:
+                prop_schema = prop_schema.get('items', {})
+
+            if 'enum' not in prop_schema:
+                continue
+
+            prop_enum_original_list = prop_schema['enum']
+            prop_schema['enum'] = [i for i in prop_schema['enum'] if i not in ['', None]]
+            prop_hash = list_hash(prop_schema['enum'])
+            # when choice sets are reused under multiple names, the generated name cannot be
+            # resolved from the hash alone. fall back to prop_name and hash for resolution.
+            enum_name = enum_name_mapping.get(prop_hash) or enum_name_mapping[prop_hash, prop_name]
+
+            # split property into remaining property and enum component parts
+            enum_schema = {k: v for k, v in prop_schema.items() if k in ['type', 'enum']}
+            prop_schema = {k: v for k, v in prop_schema.items() if k not in ['type', 'enum']}
+
+            if '' in prop_enum_original_list:
+                enum_schema['enum'].append('')
+
+            if None in prop_enum_original_list:
+                enum_schema['nullable'] = True
+
+            components = [
+                create_enum_component(enum_name, schema=enum_schema)
+            ]
+
+            if len(components) == 1:
+                prop_schema.update(components[0].ref)
+            else:
+                prop_schema.update({'oneOf': [c.ref for c in components]})
+
+            if is_array:
+                props[prop_name]['items'] = safe_ref(prop_schema)
+            else:
+                props[prop_name] = safe_ref(prop_schema)
+
+    # sort again with additional components
+    result['components'] = generator.registry.build(spectacular_settings.APPEND_COMPONENTS)
+    return result
+
+
+def preprocess_exclude_path_format(endpoints, **kwargs):
+    """
+        preprocessing hook that filters out {format} suffixed paths, in case
+        format_suffix_patterns is used and {format} path params are unwanted.
+    """
+    format_path = f'{{{api_settings.FORMAT_SUFFIX_KWARG}}}'
+    return [
+        (path, path_regex, method, callback)
+        for path, path_regex, method, callback in endpoints
+        if not (path.endswith(format_path) or path.endswith(format_path + '/'))
+    ]

--- a/enterprise_access/oas.py
+++ b/enterprise_access/oas.py
@@ -1,0 +1,18 @@
+# from drf_yasg import openapi
+#
+#
+# class CustomSchemaGenerator(openapi.SchemaGenerator):
+#     def get_schema(self, *args, **kwargs):
+#         schema = super().get_schema(*args, **kwargs)
+#
+#         # Convert oneOf fields to enums
+#         for path, path_data in schema['paths'].items():
+#             for method, method_data in path_data.items():
+#                 for parameter in method_data.get('parameters', []):
+#                     pass
+#                     # if 'oneOf' in parameter:
+#                     #     from pdb import set_trace; set_trace()
+#                     #     parameter['enum'] = parameter.pop('oneOf')
+#                     #     del parameter['oneOf']
+#
+#         return schema

--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -146,6 +146,7 @@ SPECTACULAR_SETTINGS = {
     'DESCRIPTION': 'API for controlling request-based access to enterprise subsidized enrollments.',
     'VERSION': '1.0.0',
     'SERVE_INCLUDE_SCHEMA': False,
+    'POSTPROCESSING_HOOKS': []
 }
 
 # SWAGGER_SETTINGS = {

--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -148,6 +148,10 @@ SPECTACULAR_SETTINGS = {
     'SERVE_INCLUDE_SCHEMA': False,
 }
 
+# SWAGGER_SETTINGS = {
+#     'DEFAULT_SCHEMA_GENERATOR_CLASS': 'enterprise_access.oas.CustomSchemaGenerator',
+# }
+
 # Internationalization
 # https://docs.djangoproject.com/en/dev/topics/i18n/
 

--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -37,7 +37,6 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'drf_yasg',
     'edx_api_doc_tools',
     'release_util',
 )
@@ -48,6 +47,8 @@ THIRD_PARTY_APPS = (
     'djangoql',
     'django_celery_results',
     'django_filters',
+    'drf_spectacular',
+    'drf_yasg',
     'rest_framework',
     'rest_framework_swagger',
     'rules.apps.AutodiscoverRulesConfig',
@@ -135,9 +136,16 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAuthenticated',
         'rest_framework.permissions.IsAdminUser',
     ],
-    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     'PAGE_SIZE': 100,
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
+}
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'Enterprise Access API',
+    'DESCRIPTION': 'API for controlling request-based access to enterprise subsidized enrollments.',
+    'VERSION': '1.0.0',
+    'SERVE_INCLUDE_SCHEMA': False,
 }
 
 # Internationalization

--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -146,7 +146,8 @@ SPECTACULAR_SETTINGS = {
     'DESCRIPTION': 'API for controlling request-based access to enterprise subsidized enrollments.',
     'VERSION': '1.0.0',
     'SERVE_INCLUDE_SCHEMA': False,
-    'POSTPROCESSING_HOOKS': []
+    'ENUM_ADD_EXPLICIT_BLANK_NULL_CHOICE': False,
+    'POSTPROCESSING_HOOKS': ['enterprise_access.oas.postprocess_schema_enums']
 }
 
 # SWAGGER_SETTINGS = {

--- a/enterprise_access/urls.py
+++ b/enterprise_access/urls.py
@@ -21,6 +21,12 @@ from auth_backends.urls import oauth2_urlpatterns
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
+from django.urls import path
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularRedocView,
+    SpectacularSwaggerView,
+)
 from edx_api_doc_tools import make_api_info, make_docs_urls
 from rest_framework_swagger.views import get_swagger_view
 
@@ -37,6 +43,10 @@ urlpatterns = oauth2_urlpatterns + make_docs_urls(api_info) + [
     url(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
     url(r'', include('csrf.urls')),  # Include csrf urls from edx-drf-extensions
     url(r'^health/$', core_views.health, name='health'),
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    # Optional UI:
+    path('api/schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('api/schema/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 ]
 
 if settings.DEBUG and os.environ.get('ENABLE_DJANGO_TOOLBAR', False):  # pragma: no cover


### PR DESCRIPTION
* Installs [drf-spectacular](https://github.com/tfranzel/drf-spectacular) so that an Open API schema is generated automatically.
* Visit http://localhost:18270/api/schema/swagger-ui/#/ or http://localhost:18270/api/schema/redoc/ to see way, way better api docs than our current, bespoke implementation.
* http://localhost:18270/api/schema/ will download a YAML schema file.
* And we can use https://github.com/openapi-generators/openapi-python-client to generate client code automatically from that schema.

Remaining work:
* The generated client is convoluted and not well-organized.  There are some _tags_ we could add to our endpoints to make it more organized.
* How to do Open edX approved auth with this generated client?
* ... 