### PR TITLE
feat: Handle null and empty string values in OpenAPI Enum field

### DIFF
--- a/enterprise_access/apps/core/oas.py
+++ b/enterprise_access/apps/core/oas.py
@@ -1,0 +1,160 @@
+"""
+Extended DRF_SPECTACULAR hooks.
+"""
+
+import re
+from collections import defaultdict
+
+from drf_spectacular.plumbing import ResolvedComponent, list_hash, load_enum_name_overrides, safe_ref, warn
+from drf_spectacular.settings import spectacular_settings
+from inflection import camelize
+from rest_framework.settings import api_settings
+
+
+def postprocess_schema_enums(result, generator, **kwargs):  # pylint: disable=too-many-statements
+    """
+    This code has been taken from
+    https://github.com/tfranzel/drf-spectacular/blob/1a124eef42f5ed2aaf13907ba89cc78ae2e0b250/drf_spectacular/hooks.py
+    Extra thing we are handling in this hook is we are setting nullable = True for null values and inserting empty
+    strings for empty values. We need this for graphQL package which doesn't support union of
+    enums(using oneOf or anyOf) correctly.
+    """
+
+    def iter_prop_containers(schema, component_name=None):
+        if not component_name:
+            for component_name, schema in schema.items():  # lint-amnesty, pylint: disable=redefined-argument-from-local
+                if spectacular_settings.COMPONENT_SPLIT_PATCH:
+                    component_name = re.sub('^Patched(.+)', r'\1', component_name)
+                if spectacular_settings.COMPONENT_SPLIT_REQUEST:
+                    component_name = re.sub('(.+)Request$', r'\1', component_name)
+                yield from iter_prop_containers(schema, component_name)
+        elif isinstance(schema, list):
+            for item in schema:
+                yield from iter_prop_containers(item, component_name)
+        elif isinstance(schema, dict):
+            if schema.get('properties'):
+                yield component_name, schema['properties']
+            yield from iter_prop_containers(schema.get('oneOf', []), component_name)
+            yield from iter_prop_containers(schema.get('allOf', []), component_name)
+            yield from iter_prop_containers(schema.get('anyOf', []), component_name)
+
+    def create_enum_component(name, schema):
+        component = ResolvedComponent(
+            name=name,
+            type=ResolvedComponent.SCHEMA,
+            schema=schema,
+            object=name,
+        )
+        generator.registry.register_on_missing(component)
+        return component
+
+    schemas = result.get('components', {}).get('schemas', {})
+
+    overrides = load_enum_name_overrides()
+
+    prop_hash_mapping = defaultdict(set)
+    hash_name_mapping = defaultdict(set)
+    # collect all enums, their names and choice sets
+    for component_name, props in iter_prop_containers(schemas):
+        for prop_name, prop_schema in props.items():
+            if prop_schema.get('type') == 'array':
+                prop_schema = prop_schema.get('items', {})
+            if 'enum' not in prop_schema:
+                continue
+            # remove blank/null entry for hashing. will be reconstructed in the last step
+            prop_enum_cleaned_hash = list_hash([i for i in prop_schema['enum'] if i not in ['', None]])
+            prop_hash_mapping[prop_name].add(prop_enum_cleaned_hash)
+            hash_name_mapping[prop_enum_cleaned_hash].add((component_name, prop_name))
+
+    # traverse all enum properties and generate a name for the choice set. naming collisions
+    # are resolved and a warning is emitted. giving a choice set multiple names is technically
+    # correct but potentially unwanted. also emit a warning there to make the user aware.
+    enum_name_mapping = {}
+    for prop_name, prop_hash_set in prop_hash_mapping.items():
+        for prop_hash in prop_hash_set:
+            if prop_hash in overrides:
+                enum_name = overrides[prop_hash]
+            elif len(prop_hash_set) == 1:
+                # prop_name has been used exclusively for one choice set (best case)
+                enum_name = f'{camelize(prop_name)}Enum'
+            elif len(hash_name_mapping[prop_hash]) == 1:
+                # prop_name has multiple choice sets, but each one limited to one component only
+                component_name, _ = next(iter(hash_name_mapping[prop_hash]))
+                enum_name = f'{camelize(component_name)}{camelize(prop_name)}Enum'
+            else:
+                enum_name = f'{camelize(prop_name)}{prop_hash[:3].capitalize()}Enum'
+                warn(
+                    f'enum naming encountered a non-optimally resolvable collision for fields '
+                    f'named "{prop_name}". The same name has been used for multiple choice sets '
+                    f'in multiple components. The collision was resolved with "{enum_name}". '
+                    f'add an entry to ENUM_NAME_OVERRIDES to fix the naming.'
+                )
+            if enum_name_mapping.get(prop_hash, enum_name) != enum_name:
+                warn(
+                    f'encountered multiple names for the same choice set ({enum_name}). This '
+                    f'may be unwanted even though the generated schema is technically correct. '
+                    f'Add an entry to ENUM_NAME_OVERRIDES to fix the naming.'
+                )
+                del enum_name_mapping[prop_hash]
+            else:
+                enum_name_mapping[prop_hash] = enum_name
+            enum_name_mapping[(prop_hash, prop_name)] = enum_name
+
+    # replace all enum occurrences with a enum schema component. cut out the
+    # enum, replace it with a reference and add a corresponding component.
+    for _, props in iter_prop_containers(schemas):
+        for prop_name, prop_schema in props.items():
+            is_array = prop_schema.get('type') == 'array'
+            if is_array:
+                prop_schema = prop_schema.get('items', {})
+
+            if 'enum' not in prop_schema:
+                continue
+
+            prop_enum_original_list = prop_schema['enum']
+            prop_schema['enum'] = [i for i in prop_schema['enum'] if i not in ['', None]]
+            prop_hash = list_hash(prop_schema['enum'])
+            # when choice sets are reused under multiple names, the generated name cannot be
+            # resolved from the hash alone. fall back to prop_name and hash for resolution.
+            enum_name = enum_name_mapping.get(prop_hash) or enum_name_mapping[prop_hash, prop_name]
+
+            # split property into remaining property and enum component parts
+            enum_schema = {k: v for k, v in prop_schema.items() if k in ['type', 'enum']}
+            prop_schema = {k: v for k, v in prop_schema.items() if k not in ['type', 'enum']}
+
+            if '' in prop_enum_original_list:
+                enum_schema['enum'].append('')
+
+            if None in prop_enum_original_list:
+                enum_schema['nullable'] = True
+
+            components = [
+                create_enum_component(enum_name, schema=enum_schema)
+            ]
+
+            if len(components) == 1:
+                prop_schema.update(components[0].ref)
+            else:
+                prop_schema.update({'oneOf': [c.ref for c in components]})
+
+            if is_array:
+                props[prop_name]['items'] = safe_ref(prop_schema)
+            else:
+                props[prop_name] = safe_ref(prop_schema)
+
+    # sort again with additional components
+    result['components'] = generator.registry.build(spectacular_settings.APPEND_COMPONENTS)
+    return result
+
+
+def preprocess_exclude_path_format(endpoints, **kwargs):
+    """
+        preprocessing hook that filters out {format} suffixed paths, in case
+        format_suffix_patterns is used and {format} path params are unwanted.
+    """
+    format_path = f'{{{api_settings.FORMAT_SUFFIX_KWARG}}}'
+    return [
+        (path, path_regex, method, callback)
+        for path, path_regex, method, callback in endpoints
+        if not (path.endswith(format_path) or path.endswith(format_path + '/'))
+    ]

--- a/enterprise_access/apps/core/tests/__init__.py
+++ b/enterprise_access/apps/core/tests/__init__.py
@@ -1,0 +1,103 @@
+# pylint: skip-file
+import difflib
+import json
+import os
+
+from drf_spectacular.validation import validate_schema
+
+
+def build_absolute_file_path(relative_path):
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+        relative_path
+    )
+
+
+def assert_schema(schema, reference_filename, transforms=None, reverse_transforms=None):
+    from drf_spectacular.renderers import OpenApiJsonRenderer, OpenApiYamlRenderer
+
+    schema_yml = OpenApiYamlRenderer().render(schema, renderer_context={})
+    # render also a json and provoke serialization issues
+    OpenApiJsonRenderer().render(schema, renderer_context={})
+
+    reference_filename = build_absolute_file_path(reference_filename)
+
+    with open(reference_filename.replace('.yml', '_out.yml'), 'wb') as fh:
+        fh.write(schema_yml)
+
+    if not os.path.exists(reference_filename):
+        raise RuntimeError(
+            f'{reference_filename} was not found for comparison. Carefully inspect '
+            f'the generated {reference_filename.replace(".yml", "_out.yml")} and '
+            f'copy it to {reference_filename} to serve as new ground truth.'
+        )
+
+    generated = schema_yml.decode()
+
+    with open(reference_filename) as fh:
+        expected = fh.read()
+
+    # apply optional transformations to generated result. this mainly serves to unify
+    # discrepancies between Django, DRF and library versions.
+    for t in transforms or []:
+        generated = t(generated)
+    for t in reverse_transforms or []:
+        expected = t(expected)
+
+    assert_equal(generated, expected)
+    # this is more a less a sanity check as checked-in schemas should be valid anyhow
+    validate_schema(schema)
+
+
+def assert_equal(actual, expected):
+    if not isinstance(actual, str):
+        actual = json.dumps(actual, indent=4)
+    if not isinstance(expected, str):
+        expected = json.dumps(expected, indent=4)
+    diff = difflib.unified_diff(
+        expected.splitlines(True),
+        actual.splitlines(True),
+    )
+    diff = ''.join(diff)
+    assert actual == expected and not diff, diff
+
+
+def generate_schema(route, viewset=None, view=None, view_function=None, patterns=None):
+    from django.urls import path
+    from drf_spectacular.generators import SchemaGenerator
+    from rest_framework import routers
+    from rest_framework.viewsets import ViewSetMixin
+
+    if viewset:
+        assert issubclass(viewset, ViewSetMixin)
+        router = routers.SimpleRouter()
+        router.register(route, viewset, basename=route)
+        patterns = router.urls
+    elif view:
+        patterns = [path(route, view.as_view())]
+    elif view_function:
+        patterns = [path(route, view_function)]
+    else:
+        assert route is None and isinstance(patterns, list)
+
+    generator = SchemaGenerator(patterns=patterns)
+    schema = generator.get_schema(request=None, public=True)
+    validate_schema(schema)  # make sure generated schemas are always valid
+    return schema
+
+
+def get_response_schema(operation, status=None, content_type='application/json'):
+    if (
+        not status
+        and operation['operationId'].endswith('_create')
+        and '201' in operation['responses']
+        and '200' not in operation['responses']
+    ):
+        status = '201'
+    elif not status:
+        status = '200'
+    return operation['responses'][status]['content'][content_type]['schema']
+
+
+def get_request_schema(operation, content_type='application/json'):
+    return operation['requestBody']['content'][content_type]['schema']

--- a/enterprise_access/apps/core/tests/test_osa.py
+++ b/enterprise_access/apps/core/tests/test_osa.py
@@ -1,0 +1,215 @@
+# pylint: skip-file
+from enum import Enum
+from unittest import mock
+
+from rest_framework import generics, mixins, serializers, viewsets
+from rest_framework.decorators import action
+
+try:
+    from django.db.models.enums import TextChoices
+except ImportError:
+    TextChoices = object  # type: ignore  # django < 3.0 handling
+
+from drf_spectacular.plumbing import list_hash, load_enum_name_overrides
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+from rest_framework.views import APIView
+
+from enterprise_access.apps.core.tests import assert_schema, generate_schema
+
+language_choices = (
+    ('en', 'en'),
+    ('es', 'es'),
+    ('ru', 'ru'),
+    ('cn', 'cn'),
+)
+
+blank_null_language_choices = (
+    ('en', 'en'),
+    ('es', 'es'),
+    ('ru', 'ru'),
+    ('cn', 'cn'),
+    ('', 'not provided'),
+    (None, 'unknown'),
+)
+
+vote_choices = (
+    (1, 'Positive'),
+    (0, 'Neutral'),
+    (-1, 'Negative'),
+)
+
+language_list = ['en']
+
+
+class LanguageEnum(Enum):
+    EN = 'en'
+
+
+class LanguageStrEnum(str, Enum):
+    EN = 'en'
+
+
+class LanguageChoices(TextChoices):
+    EN = 'en'
+
+
+blank_null_language_list = ['en', '', None]
+
+
+class BlankNullLanguageEnum(Enum):
+    EN = 'en'
+    BLANK = ''
+    NULL = None
+
+
+class BlankNullLanguageStrEnum(str, Enum):
+    EN = 'en'
+    BLANK = ''
+    # These will still be included since the values get cast to strings so 'None' != None
+    NULL = None
+
+
+class BlankNullLanguageChoices(TextChoices):
+    EN = 'en'
+    BLANK = ''
+    # These will still be included since the values get cast to strings so 'None' != None
+    NULL = None
+
+
+class ASerializer(serializers.Serializer):
+    language = serializers.ChoiceField(choices=language_choices)
+    vote = serializers.ChoiceField(choices=vote_choices)
+
+
+class BSerializer(serializers.Serializer):
+    language = serializers.ChoiceField(choices=language_choices, allow_blank=True, allow_null=True)
+
+
+class AViewset(mixins.ListModelMixin, viewsets.GenericViewSet):
+    serializer_class = ASerializer
+
+    @extend_schema(responses=BSerializer)
+    @action(detail=False, serializer_class=BSerializer)
+    def selection(self, request):
+        pass  # pragma: no cover
+
+
+def test_postprocessing():
+    schema = generate_schema('a', AViewset)
+    assert_schema(schema, 'tests/test_postprocessing.yml')
+
+
+def test_no_blank_and_null_in_enum_choices():
+    schema = generate_schema('a', AViewset)
+    assert 'NullEnum' not in schema['components']['schemas']
+    assert 'BlankEnum' not in schema['components']['schemas']
+
+
+def test_global_enum_naming_override():
+    # the override will prevent the warning for multiple names
+    class XSerializer(serializers.Serializer):
+        foo = serializers.ChoiceField(choices=language_choices)
+        bar = serializers.ChoiceField(choices=language_choices)
+
+    class XView(generics.RetrieveAPIView):
+        serializer_class = XSerializer
+
+    schema = generate_schema('/x', view=XView)
+    assert 'FooEnum' in schema['components']['schemas']['X']['properties']['foo']['$ref']
+    assert 'BarEnum' in schema['components']['schemas']['X']['properties']['bar']['$ref']
+
+
+def test_global_enum_naming_override_with_empty_string_and_nullable():
+    """Test that choices with blank values can still have their name overridden."""
+    class XSerializer(serializers.Serializer):
+        foo = serializers.ChoiceField(choices=blank_null_language_choices)
+
+    class XView(generics.RetrieveAPIView):
+        serializer_class = XSerializer
+
+    schema = generate_schema('/x', view=XView)
+    enum_data = schema['components']['schemas']['FooEnum']
+
+    assert '' in enum_data['enum']
+    assert enum_data['nullable'] is True
+
+
+def test_enum_name_reuse_warning(capsys):
+    class XSerializer(serializers.Serializer):
+        foo = serializers.ChoiceField(choices=language_choices)
+        bar = serializers.ChoiceField(choices=language_choices)
+
+    class XView(generics.RetrieveAPIView):
+        serializer_class = XSerializer
+
+    generate_schema('/x', view=XView)
+    assert 'encountered multiple names for the same choice set' in capsys.readouterr().err
+
+
+def test_enum_collision_without_override(capsys):
+    class XSerializer(serializers.Serializer):
+        foo = serializers.ChoiceField(choices=[('A', 'A')])
+
+    class YSerializer(serializers.Serializer):
+        foo = serializers.ChoiceField(choices=[('A', 'A'), ('B', 'B')])
+
+    class ZSerializer(serializers.Serializer):
+        foo = serializers.ChoiceField(choices=[('A', 'A'), ('B', 'B')])
+
+    class XAPIView(APIView):
+        @extend_schema(responses=ZSerializer)
+        def get(self, request):
+            pass  # pragma: no cover
+
+        @extend_schema(request=XSerializer, responses=YSerializer)
+        def post(self, request):
+            pass  # pragma: no cover
+
+    generate_schema('x', view=XAPIView)
+    assert 'enum naming encountered a non-optimally resolvable' in capsys.readouterr().err
+
+
+def test_resolvable_enum_collision():
+    class XSerializer(serializers.Serializer):
+        foo = serializers.ChoiceField(choices=[('A', 'A')])
+
+    class YSerializer(serializers.Serializer):
+        foo = serializers.ChoiceField(choices=[('A', 'A'), ('B', 'B')])
+
+    class XAPIView(APIView):
+        @extend_schema(request=XSerializer, responses=YSerializer)
+        def post(self, request):
+            pass  # pragma: no cover
+
+    schema = generate_schema('x', view=XAPIView)
+    assert 'XFooEnum' in schema['components']['schemas']
+    assert 'YFooEnum' in schema['components']['schemas']
+
+
+@mock.patch('drf_spectacular.settings.spectacular_settings.COMPONENT_SPLIT_PATCH', True)
+@mock.patch('drf_spectacular.settings.spectacular_settings.COMPONENT_SPLIT_REQUEST', True)
+def test_enum_resolvable_collision_with_patched_and_request_splits():
+    class XSerializer(serializers.Serializer):
+        foo = serializers.ChoiceField(choices=[('A', 'A')])
+
+    class YSerializer(serializers.Serializer):
+        foo = serializers.ChoiceField(choices=[('A', 'A'), ('B', 'B')])
+
+    class XViewset(viewsets.GenericViewSet):
+        @extend_schema(request=XSerializer, responses=YSerializer)
+        def create(self, request):
+            pass  # pragma: no cover
+
+        @extend_schema(
+            request=XSerializer,
+            responses=YSerializer,
+            parameters=[OpenApiParameter('id', int, OpenApiParameter.PATH)]
+        )
+        def partial_update(self, request):
+            pass  # pragma: no cover
+
+    schema = generate_schema('/x', XViewset)
+    components = schema['components']['schemas']
+    assert 'XFooEnum' in components and 'YFooEnum' in components
+    assert '/XFooEnum' in components['XRequest']['properties']['foo']['$ref']
+    assert '/XFooEnum' in components['PatchedXRequest']['properties']['foo']['$ref']

--- a/enterprise_access/apps/core/tests/test_postprocessing.yml
+++ b/enterprise_access/apps/core/tests/test_postprocessing.yml
@@ -1,0 +1,100 @@
+openapi: 3.0.3
+info:
+  title: Enterprise Access API
+  version: 1.0.0
+  description: API for controlling request-based access to enterprise subsidized enrollments.
+paths:
+  /a/:
+    get:
+      operationId: a_list
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      tags:
+      - a
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedAList'
+          description: ''
+  /a/selection/:
+    get:
+      operationId: a_selection_retrieve
+      tags:
+      - a
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/B'
+          description: ''
+components:
+  schemas:
+    A:
+      type: object
+      properties:
+        language:
+          $ref: '#/components/schemas/LanguageEnum'
+        vote:
+          $ref: '#/components/schemas/VoteEnum'
+      required:
+      - language
+      - vote
+    B:
+      type: object
+      properties:
+        language:
+          allOf:
+          - $ref: '#/components/schemas/LanguageEnum'
+          nullable: true
+      required:
+      - language
+    LanguageEnum:
+      enum:
+      - en
+      - es
+      - ru
+      - cn
+      type: string
+    PaginatedAList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/A'
+    VoteEnum:
+      enum:
+      - 1
+      - 0
+      - -1
+      type: integer
+  securitySchemes:
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: enterprise_access_sessionid

--- a/enterprise_access/apps/core/tests/test_postprocessing_out.yml
+++ b/enterprise_access/apps/core/tests/test_postprocessing_out.yml
@@ -1,0 +1,100 @@
+openapi: 3.0.3
+info:
+  title: Enterprise Access API
+  version: 1.0.0
+  description: API for controlling request-based access to enterprise subsidized enrollments.
+paths:
+  /a/:
+    get:
+      operationId: a_list
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      tags:
+      - a
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedAList'
+          description: ''
+  /a/selection/:
+    get:
+      operationId: a_selection_retrieve
+      tags:
+      - a
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/B'
+          description: ''
+components:
+  schemas:
+    A:
+      type: object
+      properties:
+        language:
+          $ref: '#/components/schemas/LanguageEnum'
+        vote:
+          $ref: '#/components/schemas/VoteEnum'
+      required:
+      - language
+      - vote
+    B:
+      type: object
+      properties:
+        language:
+          allOf:
+          - $ref: '#/components/schemas/LanguageEnum'
+          nullable: true
+      required:
+      - language
+    LanguageEnum:
+      enum:
+      - en
+      - es
+      - ru
+      - cn
+      type: string
+    PaginatedAList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/A'
+    VoteEnum:
+      enum:
+      - 1
+      - 0
+      - -1
+      type: integer
+  securitySchemes:
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: enterprise_access_sessionid

--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -148,6 +148,7 @@ SPECTACULAR_SETTINGS = {
      'DESCRIPTION': 'API for controlling request-based access to enterprise subsidized enrollments.',
      'VERSION': '1.0.0',
      'SERVE_INCLUDE_SCHEMA': False,
+     'POSTPROCESSING_HOOKS': ['enterprise_access.apps.core.oas.postprocess_schema_enums']
  }
 
 # Internationalization


### PR DESCRIPTION
__Jira Ticket:__ [ENT-6697](https://2u-internal.atlassian.net/browse/ENT-6697)

__Description:__
We need to handle the null and empty string values in the Enum field for the Open API schema [enterprise-access](https://github.com/edx/enterprise-access) service. A sample implementation is available at the PR [prototype: drf-spectacular by iloveagent57 · Pull Request #89 · openedx/enterprise-access](https://github.com/openedx/enterprise-access/pull/89/commits). 
The file oas.py is taken from https://github.com/openedx/enterprise-access/pull/89/files.

**Acceptance Criteria:**
1. A valid Enterprise Access API.yaml file is created to handle nullable enums and generate GraphQL schema.