### PR TITLE
feat: Added URL definitions to expose OpenAPI schema.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -37,6 +37,8 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+
+    'drf_spectacular',
     'drf_yasg',
     'edx_api_doc_tools',
     'release_util',
@@ -135,10 +137,18 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAuthenticated',
         'rest_framework.permissions.IsAdminUser',
     ],
-    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     'PAGE_SIZE': 100,
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }
+
+# DRF Spectacular settings
+SPECTACULAR_SETTINGS = {
+     'TITLE': 'Enterprise Access API',
+     'DESCRIPTION': 'API for controlling request-based access to enterprise subsidized enrollments.',
+     'VERSION': '1.0.0',
+     'SERVE_INCLUDE_SCHEMA': False,
+ }
 
 # Internationalization
 # https://docs.djangoproject.com/en/dev/topics/i18n/

--- a/enterprise_access/urls.py
+++ b/enterprise_access/urls.py
@@ -21,6 +21,8 @@ from auth_backends.urls import oauth2_urlpatterns
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
+from django.urls import path
+from drf_spectacular.views import SpectacularAPIView
 from edx_api_doc_tools import make_api_info, make_docs_urls
 from rest_framework_swagger.views import get_swagger_view
 
@@ -37,6 +39,7 @@ urlpatterns = oauth2_urlpatterns + make_docs_urls(api_info) + [
     url(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
     url(r'', include('csrf.urls')),  # Include csrf urls from edx-drf-extensions
     url(r'^health/$', core_views.health, name='health'),
+    path('api/schema/', SpectacularAPIView.as_view(), name='openapi_schema'),
 ]
 
 if settings.DEBUG and os.environ.get('ENABLE_DJANGO_TOOLBAR', False):  # pragma: no cover

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -30,3 +30,4 @@ openedx-events
 pytz
 redis
 rules
+drf-spectacular

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,9 @@ asgiref==3.6.0
 async-timeout==4.0.2
     # via redis
 attrs==22.2.0
-    # via openedx-events
+    # via
+    #   jsonschema
+    #   openedx-events
 backoff==1.10.0
     # via analytics-python
 billiard==3.6.4.0
@@ -75,6 +77,7 @@ django==3.2.16
     #   django-model-utils
     #   djangorestframework
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-auth-backends
@@ -120,11 +123,14 @@ djangorestframework==3.14.0
     #   -r requirements/base.in
     #   django-rest-swagger
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-drf-extensions
 drf-jwt==1.19.2
     # via edx-drf-extensions
+drf-spectacular==0.25.1
+    # via -r requirements/base.in
 drf-yasg==1.21.4
     # via edx-api-doc-tools
 edx-api-doc-tools==1.6.0
@@ -162,8 +168,12 @@ future==0.18.3
     # via pyjwkest
 idna==3.4
     # via requests
+importlib-resources==5.10.2
+    # via jsonschema
 inflection==0.5.1
-    # via drf-yasg
+    # via
+    #   drf-spectacular
+    #   drf-yasg
 itypes==1.2.0
     # via coreapi
 jinja2==3.1.2
@@ -172,6 +182,8 @@ jsonfield==3.1.0
     # via edx-celeryutils
 jsonfield2==4.0.0.post0
     # via -r requirements/base.in
+jsonschema==4.17.3
+    # via drf-spectacular
 kombu==5.2.4
     # via celery
 markupsafe==2.1.2
@@ -188,12 +200,14 @@ oauthlib==3.2.2
     #   social-auth-core
 openapi-codec==1.3.2
     # via django-rest-swagger
-openedx-events==4.1.1
+openedx-events==4.2.0
     # via -r requirements/base.in
 packaging==23.0
     # via drf-yasg
 pbr==5.11.1
     # via stevedore
+pkgutil-resolve-name==1.3.10
+    # via jsonschema
 ply==3.11
     # via djangoql
 prompt-toolkit==3.0.36
@@ -217,6 +231,8 @@ pymongo==3.13.0
     # via edx-opaque-keys
 pynacl==1.5.0
     # via edx-django-utils
+pyrsistent==0.19.3
+    # via jsonschema
 python-dateutil==2.8.2
     # via
     #   analytics-python
@@ -231,7 +247,9 @@ pytz==2022.7.1
     #   djangorestframework
     #   drf-yasg
 pyyaml==6.0
-    # via edx-django-release-util
+    # via
+    #   drf-spectacular
+    #   edx-django-release-util
 redis==4.4.2
     # via -r requirements/base.in
 requests==2.28.2
@@ -283,6 +301,7 @@ stevedore==4.1.1
 uritemplate==4.1.1
     # via
     #   coreapi
+    #   drf-spectacular
     #   drf-yasg
 urllib3==1.26.14
     # via requests
@@ -293,3 +312,5 @@ vine==5.0.0
     #   kombu
 wcwidth==0.2.6
     # via prompt-toolkit
+zipp==3.11.0
+    # via importlib-resources

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -26,6 +26,7 @@ async-timeout==4.0.2
 attrs==22.2.0
     # via
     #   -r requirements/validation.txt
+    #   jsonschema
     #   openedx-events
     #   pytest
 backoff==1.10.0
@@ -127,7 +128,7 @@ defusedxml==0.7.1
     #   -r requirements/validation.txt
     #   python3-openid
     #   social-auth-core
-diff-cover==7.3.2
+diff-cover==7.4.0
     # via -r requirements/dev.in
 dill==0.3.6
     # via
@@ -148,6 +149,7 @@ django==3.2.16
     #   django-model-utils
     #   djangorestframework
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-auth-backends
@@ -198,6 +200,7 @@ djangorestframework==3.14.0
     #   -r requirements/validation.txt
     #   django-rest-swagger
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-drf-extensions
@@ -209,6 +212,8 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
+drf-spectacular==0.25.1
+    # via -r requirements/validation.txt
 drf-yasg==1.21.4
     # via
     #   -r requirements/validation.txt
@@ -251,7 +256,7 @@ exceptiongroup==1.1.0
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/validation.txt
-faker==16.6.0
+faker==16.6.1
     # via
     #   -r requirements/validation.txt
     #   factory-boy
@@ -280,10 +285,12 @@ importlib-metadata==6.0.0
 importlib-resources==5.10.2
     # via
     #   -r requirements/validation.txt
+    #   jsonschema
     #   keyring
 inflection==0.5.1
     # via
     #   -r requirements/validation.txt
+    #   drf-spectacular
     #   drf-yasg
 iniconfig==2.0.0
     # via
@@ -318,6 +325,10 @@ jsonfield==3.1.0
     #   edx-celeryutils
 jsonfield2==4.0.0.post0
     # via -r requirements/validation.txt
+jsonschema==4.17.3
+    # via
+    #   -r requirements/validation.txt
+    #   drf-spectacular
 keyring==23.13.1
     # via
     #   -r requirements/validation.txt
@@ -371,7 +382,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/validation.txt
     #   django-rest-swagger
-openedx-events==4.1.1
+openedx-events==4.2.0
     # via -r requirements/validation.txt
 packaging==23.0
     # via
@@ -393,6 +404,10 @@ pkginfo==1.9.6
     # via
     #   -r requirements/validation.txt
     #   twine
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r requirements/validation.txt
+    #   jsonschema
 platformdirs==2.6.2
     # via
     #   -r requirements/validation.txt
@@ -484,6 +499,10 @@ pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
+pyrsistent==0.19.3
+    # via
+    #   -r requirements/validation.txt
+    #   jsonschema
 pytest==7.2.1
     # via
     #   -r requirements/validation.txt
@@ -518,6 +537,7 @@ pyyaml==6.0
     # via
     #   -r requirements/validation.txt
     #   code-annotations
+    #   drf-spectacular
     #   edx-django-release-util
     #   edx-i18n-tools
 readme-renderer==37.3
@@ -652,6 +672,7 @@ uritemplate==4.1.1
     # via
     #   -r requirements/validation.txt
     #   coreapi
+    #   drf-spectacular
     #   drf-yasg
 urllib3==1.26.14
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -28,6 +28,7 @@ async-timeout==4.0.2
 attrs==22.2.0
     # via
     #   -r requirements/test.txt
+    #   jsonschema
     #   openedx-events
     #   pytest
 babel==2.11.0
@@ -141,6 +142,7 @@ django==3.2.16
     #   django-model-utils
     #   djangorestframework
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-auth-backends
@@ -190,6 +192,7 @@ djangorestframework==3.14.0
     #   -r requirements/test.txt
     #   django-rest-swagger
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-drf-extensions
@@ -205,6 +208,8 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
+drf-spectacular==0.25.1
+    # via -r requirements/test.txt
 drf-yasg==1.21.4
     # via
     #   -r requirements/test.txt
@@ -247,7 +252,7 @@ exceptiongroup==1.1.0
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==16.6.0
+faker==16.6.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -272,9 +277,14 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==6.0.0
     # via sphinx
+importlib-resources==5.10.2
+    # via
+    #   -r requirements/test.txt
+    #   jsonschema
 inflection==0.5.1
     # via
     #   -r requirements/test.txt
+    #   drf-spectacular
     #   drf-yasg
 iniconfig==2.0.0
     # via
@@ -300,6 +310,10 @@ jsonfield==3.1.0
     #   edx-celeryutils
 jsonfield2==4.0.0.post0
     # via -r requirements/test.txt
+jsonschema==4.17.3
+    # via
+    #   -r requirements/test.txt
+    #   drf-spectacular
 kombu==5.2.4
     # via
     #   -r requirements/test.txt
@@ -339,7 +353,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
-openedx-events==4.1.1
+openedx-events==4.2.0
     # via -r requirements/test.txt
 packaging==23.0
     # via
@@ -352,6 +366,10 @@ pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r requirements/test.txt
+    #   jsonschema
 platformdirs==2.6.2
     # via
     #   -r requirements/test.txt
@@ -431,6 +449,10 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
+pyrsistent==0.19.3
+    # via
+    #   -r requirements/test.txt
+    #   jsonschema
 pytest==7.2.1
     # via
     #   -r requirements/test.txt
@@ -466,6 +488,7 @@ pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
+    #   drf-spectacular
     #   edx-django-release-util
 readme-renderer==37.3
     # via -r requirements/doc.in
@@ -595,6 +618,7 @@ uritemplate==4.1.1
     # via
     #   -r requirements/test.txt
     #   coreapi
+    #   drf-spectacular
     #   drf-yasg
 urllib3==1.26.14
     # via
@@ -621,4 +645,7 @@ wrapt==1.14.1
     #   -r requirements/test.txt
     #   astroid
 zipp==3.11.0
-    # via importlib-metadata
+    # via
+    #   -r requirements/test.txt
+    #   importlib-metadata
+    #   importlib-resources

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -21,6 +21,7 @@ async-timeout==4.0.2
 attrs==22.2.0
     # via
     #   -r requirements/base.txt
+    #   jsonschema
     #   openedx-events
 backoff==1.10.0
     # via
@@ -101,6 +102,7 @@ django==3.2.16
     #   django-model-utils
     #   djangorestframework
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-auth-backends
@@ -146,6 +148,7 @@ djangorestframework==3.14.0
     #   -r requirements/base.txt
     #   django-rest-swagger
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-drf-extensions
@@ -153,6 +156,8 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+drf-spectacular==0.25.1
+    # via -r requirements/base.txt
 drf-yasg==1.21.4
     # via
     #   -r requirements/base.txt
@@ -203,9 +208,14 @@ idna==3.4
     # via
     #   -r requirements/base.txt
     #   requests
+importlib-resources==5.10.2
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
 inflection==0.5.1
     # via
     #   -r requirements/base.txt
+    #   drf-spectacular
     #   drf-yasg
 itypes==1.2.0
     # via
@@ -221,6 +231,10 @@ jsonfield==3.1.0
     #   edx-celeryutils
 jsonfield2==4.0.0.post0
     # via -r requirements/base.txt
+jsonschema==4.17.3
+    # via
+    #   -r requirements/base.txt
+    #   drf-spectacular
 kombu==5.2.4
     # via
     #   -r requirements/base.txt
@@ -250,7 +264,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-openedx-events==4.1.1
+openedx-events==4.2.0
     # via -r requirements/base.txt
 packaging==23.0
     # via
@@ -260,6 +274,10 @@ pbr==5.11.1
     # via
     #   -r requirements/base.txt
     #   stevedore
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
 ply==3.11
     # via
     #   -r requirements/base.txt
@@ -300,6 +318,10 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
+pyrsistent==0.19.3
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
 python-dateutil==2.8.2
     # via
     #   -r requirements/base.txt
@@ -322,6 +344,7 @@ pyyaml==6.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/production.in
+    #   drf-spectacular
     #   edx-django-release-util
 redis==4.4.2
     # via -r requirements/base.txt
@@ -396,6 +419,7 @@ uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
     #   coreapi
+    #   drf-spectacular
     #   drf-yasg
 urllib3==1.26.14
     # via
@@ -411,6 +435,10 @@ wcwidth==0.2.6
     # via
     #   -r requirements/base.txt
     #   prompt-toolkit
+zipp==3.11.0
+    # via
+    #   -r requirements/base.txt
+    #   importlib-resources
 zope-event==4.6
     # via gevent
 zope-interface==5.5.2

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -26,6 +26,7 @@ async-timeout==4.0.2
 attrs==22.2.0
     # via
     #   -r requirements/test.txt
+    #   jsonschema
     #   openedx-events
     #   pytest
 backoff==1.10.0
@@ -138,6 +139,7 @@ django==3.2.16
     #   django-model-utils
     #   djangorestframework
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-auth-backends
@@ -187,6 +189,7 @@ djangorestframework==3.14.0
     #   -r requirements/test.txt
     #   django-rest-swagger
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-drf-extensions
@@ -196,6 +199,8 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
+drf-spectacular==0.25.1
+    # via -r requirements/test.txt
 drf-yasg==1.21.4
     # via
     #   -r requirements/test.txt
@@ -238,7 +243,7 @@ exceptiongroup==1.1.0
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==16.6.0
+faker==16.6.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -264,10 +269,14 @@ importlib-metadata==6.0.0
     #   keyring
     #   twine
 importlib-resources==5.10.2
-    # via keyring
+    # via
+    #   -r requirements/test.txt
+    #   jsonschema
+    #   keyring
 inflection==0.5.1
     # via
     #   -r requirements/test.txt
+    #   drf-spectacular
     #   drf-yasg
 iniconfig==2.0.0
     # via
@@ -299,6 +308,10 @@ jsonfield==3.1.0
     #   edx-celeryutils
 jsonfield2==4.0.0.post0
     # via -r requirements/test.txt
+jsonschema==4.17.3
+    # via
+    #   -r requirements/test.txt
+    #   drf-spectacular
 keyring==23.13.1
     # via twine
 kombu==5.2.4
@@ -346,7 +359,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
-openedx-events==4.1.1
+openedx-events==4.2.0
     # via -r requirements/test.txt
 packaging==23.0
     # via
@@ -360,6 +373,10 @@ pbr==5.11.1
     #   stevedore
 pkginfo==1.9.6
     # via twine
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r requirements/test.txt
+    #   jsonschema
 platformdirs==2.6.2
     # via
     #   -r requirements/test.txt
@@ -442,6 +459,10 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
+pyrsistent==0.19.3
+    # via
+    #   -r requirements/test.txt
+    #   jsonschema
 pytest==7.2.1
     # via
     #   -r requirements/test.txt
@@ -476,6 +497,7 @@ pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
+    #   drf-spectacular
     #   edx-django-release-util
 readme-renderer==37.3
     # via twine
@@ -595,6 +617,7 @@ uritemplate==4.1.1
     # via
     #   -r requirements/test.txt
     #   coreapi
+    #   drf-spectacular
     #   drf-yasg
 urllib3==1.26.14
     # via
@@ -623,5 +646,6 @@ wrapt==1.14.1
     #   astroid
 zipp==3.11.0
     # via
+    #   -r requirements/test.txt
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -25,6 +25,7 @@ async-timeout==4.0.2
 attrs==22.2.0
     # via
     #   -r requirements/base.txt
+    #   jsonschema
     #   openedx-events
     #   pytest
 backoff==1.10.0
@@ -127,6 +128,7 @@ distlib==0.3.6
     #   django-model-utils
     #   djangorestframework
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-auth-backends
@@ -176,6 +178,7 @@ djangorestframework==3.14.0
     #   -r requirements/base.txt
     #   django-rest-swagger
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-drf-extensions
@@ -183,6 +186,8 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+drf-spectacular==0.25.1
+    # via -r requirements/base.txt
 drf-yasg==1.21.4
     # via
     #   -r requirements/base.txt
@@ -221,7 +226,7 @@ exceptiongroup==1.1.0
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==16.6.0
+faker==16.6.1
     # via factory-boy
 fastavro==1.7.0
     # via
@@ -239,9 +244,14 @@ idna==3.4
     # via
     #   -r requirements/base.txt
     #   requests
+importlib-resources==5.10.2
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
 inflection==0.5.1
     # via
     #   -r requirements/base.txt
+    #   drf-spectacular
     #   drf-yasg
 iniconfig==2.0.0
     # via pytest
@@ -262,6 +272,10 @@ jsonfield==3.1.0
     #   edx-celeryutils
 jsonfield2==4.0.0.post0
     # via -r requirements/base.txt
+jsonschema==4.17.3
+    # via
+    #   -r requirements/base.txt
+    #   drf-spectacular
 kombu==5.2.4
     # via
     #   -r requirements/base.txt
@@ -297,7 +311,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-openedx-events==4.1.1
+openedx-events==4.2.0
     # via -r requirements/base.txt
 packaging==23.0
     # via
@@ -309,6 +323,10 @@ pbr==5.11.1
     # via
     #   -r requirements/base.txt
     #   stevedore
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
 platformdirs==2.6.2
     # via
     #   pylint
@@ -373,6 +391,10 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
+pyrsistent==0.19.3
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
 pytest==7.2.1
     # via
     #   pytest-cov
@@ -404,6 +426,7 @@ pyyaml==6.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
+    #   drf-spectacular
     #   edx-django-release-util
 redis==4.4.2
     # via -r requirements/base.txt
@@ -499,6 +522,7 @@ uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
     #   coreapi
+    #   drf-spectacular
     #   drf-yasg
 urllib3==1.26.14
     # via
@@ -518,3 +542,7 @@ wcwidth==0.2.6
     #   prompt-toolkit
 wrapt==1.14.1
     # via astroid
+zipp==3.11.0
+    # via
+    #   -r requirements/base.txt
+    #   importlib-resources

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -33,6 +33,7 @@ attrs==22.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   jsonschema
     #   openedx-events
     #   pytest
 backoff==1.10.0
@@ -168,6 +169,7 @@ django==3.2.16
     #   django-model-utils
     #   djangorestframework
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-auth-backends
@@ -235,6 +237,7 @@ djangorestframework==3.14.0
     #   -r requirements/test.txt
     #   django-rest-swagger
     #   drf-jwt
+    #   drf-spectacular
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-drf-extensions
@@ -247,6 +250,10 @@ drf-jwt==1.19.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
+drf-spectacular==0.25.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 drf-yasg==1.21.4
     # via
     #   -r requirements/quality.txt
@@ -310,7 +317,7 @@ factory-boy==3.2.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-faker==16.6.0
+faker==16.6.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -344,11 +351,14 @@ importlib-metadata==6.0.0
 importlib-resources==5.10.2
     # via
     #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   jsonschema
     #   keyring
 inflection==0.5.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   drf-spectacular
     #   drf-yasg
 iniconfig==2.0.0
     # via
@@ -389,6 +399,11 @@ jsonfield2==4.0.0.post0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+jsonschema==4.17.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   drf-spectacular
 keyring==23.13.1
     # via
     #   -r requirements/quality.txt
@@ -454,7 +469,7 @@ openapi-codec==1.3.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django-rest-swagger
-openedx-events==4.1.1
+openedx-events==4.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -474,6 +489,11 @@ pkginfo==1.9.6
     # via
     #   -r requirements/quality.txt
     #   twine
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   jsonschema
 platformdirs==2.6.2
     # via
     #   -r requirements/quality.txt
@@ -573,6 +593,11 @@ pynacl==1.5.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-django-utils
+pyrsistent==0.19.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   jsonschema
 pytest==7.2.1
     # via
     #   -r requirements/quality.txt
@@ -617,6 +642,7 @@ pyyaml==6.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   code-annotations
+    #   drf-spectacular
     #   edx-django-release-util
 readme-renderer==37.3
     # via
@@ -769,6 +795,7 @@ uritemplate==4.1.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   coreapi
+    #   drf-spectacular
     #   drf-yasg
 urllib3==1.26.14
     # via
@@ -805,5 +832,6 @@ wrapt==1.14.1
 zipp==3.11.0
     # via
     #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   importlib-metadata
     #   importlib-resources


### PR DESCRIPTION
__Jira Ticket:__ [ENT-6698](https://2u-internal.atlassian.net/browse/ENT-6698)

__Description:__
We need to expose the Open API schema for [enterprise-access](https://github.com/edx/enterprise-access) service so that is is accessible publicly. Sample implementation is available at the PR [prototype: drf-spectacular by iloveagent57 · Pull Request #89 · openedx/enterprise-access](https://github.com/openedx/enterprise-access/pull/89/commits)  make sure to use the changes with commit 1711195c68ae16ba906f86ac691660e7861c7934. 

**Acceptance Criteria:**
1. A public endpoint is available to access OpenAPI V3 Schema .