### PR TITLE
feat: Added enterprise access events firing logic.

### DIFF
--- a/enterprise_access/apps/events/apps.py
+++ b/enterprise_access/apps/events/apps.py
@@ -11,6 +11,7 @@ from enterprise_access.apps.events.utils import create_topics
 
 logger = logging.getLogger(__name__)
 
+
 class EventsConfig(AppConfig):
     """
     Application Configuration for the events app.

--- a/enterprise_access/apps/events/data.py
+++ b/enterprise_access/apps/events/data.py
@@ -212,3 +212,80 @@ class AccessPolicyEventSerializer:
             )
 
         return cls.SERIALIZER
+
+
+@attr.s(frozen=True)
+class SubsidyRedemption:
+    """
+    Attributes defined for a Subsidy Redemption object.
+    """
+
+    enterprise_uuid = attr.ib(type=str)
+    content_key = attr.ib(type=str)
+    lms_user_id = attr.ib(type=int)
+
+
+class SubsidyRedemptionEvent:
+    """
+    subsidy redemption and reversal events to be put on event bus.
+    """
+
+    AVRO_SCHEMA = """
+        {
+            "namespace": "enterprise_access.apps.subsidy_access_policy",
+            "name": "SubsidyRedemptionEvent",
+            "type": "record",
+            "fields": [
+                {"name": "enterprise_uuid", "type": "string"},
+                {"name": "content_key", "type": "string"},
+                {"name": "lms_user_id", "type": "int"}
+            ]
+        }
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.enterprise_uuid = kwargs['enterprise_uuid']
+        self.content_key = kwargs['content_key']
+        self.lms_user_id = kwargs['lms_user_id']
+
+    @staticmethod
+    def from_dict(dict_instance, ctx):  # pylint: disable=unused-argument
+        return SubsidyRedemptionEvent(**dict_instance)
+
+    @staticmethod
+    def to_dict(obj, ctx):  # pylint: disable=unused-argument
+        return {
+            'enterprise_uuid': obj.enterprise_uuid,
+            'content_key': obj.content_key,
+            'lms_user_id': obj.lms_user_id,
+        }
+
+
+class SubsidyRedemptionSerializer:
+    """
+    Wrapper class used to ensure a single instance of the SubsidyRedemptionSerializer.
+    This avoids errors on startup.
+    """
+    KAFKA_SCHEMA_REGISTRY_CONFIG = {
+        'url': getattr(settings, 'SCHEMA_REGISTRY_URL', ''),
+        'basic.auth.user.info': f"{getattr(settings, 'SCHEMA_REGISTRY_API_KEY', '')}"
+                                f":{getattr(settings, 'SCHEMA_REGISTRY_API_SECRET', '')}",
+    }
+    SERIALIZER = None
+
+    @classmethod
+    def get_serializer(cls):
+        """
+        Get or create a single instance of the SubsidyRedemptionSerializer serializer
+        to be used throughout the life of the app.
+
+        :return: AvroSerializer
+        """
+        if cls.SERIALIZER is None:
+            cls.SERIALIZER = AvroSerializer(
+                schema_str=SubsidyRedemptionEvent.AVRO_SCHEMA,
+                schema_registry_client=SchemaRegistryClient(cls.KAFKA_SCHEMA_REGISTRY_CONFIG),
+                to_dict=SubsidyRedemptionEvent.to_dict
+            )
+
+        return cls.SERIALIZER

--- a/enterprise_access/apps/events/data.py
+++ b/enterprise_access/apps/events/data.py
@@ -126,3 +126,89 @@ class LicenseRequestData:
     subscription_plan_uuid = attr.ib(type=str)
     decline_reason = attr.ib(type=str, default=None)
     license_uuid = attr.ib(type=str, default=None)
+
+
+@attr.s(frozen=True)
+class AccessPolicyData:
+    """
+    Attributes defined for a AccessPolicy object.
+    """
+
+    uuid = attr.ib(type=str)
+    active = attr.ib(type=bool)
+    group_uuid = attr.ib(type=str)
+    catalog_uuid = attr.ib(type=str)
+    subsidy_uuid = attr.ib(type=str)
+    access_method = attr.ib(type=str)
+
+
+class AccessPolicyEvent:
+    """
+    Access policy creation and update events to be put on event bus.
+    """
+
+    AVRO_SCHEMA = """
+        {
+            "namespace": "enterprise_access.apps.subsidy_access_policy",
+            "name": "AccessPolicyEvent",
+            "type": "record",
+            "fields": [
+                {"name": "uuid", "type": "string"},
+                {"name": "active", "type": "boolean"},
+                {"name": "group_uuid", "type": "string"},
+                {"name": "subsidy_uuid", "type": "string"},
+                {"name": "access_method", "type": "string"}
+            ]
+        }
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.uuid = kwargs['uuid']
+        self.active = kwargs['active']
+        self.group_uuid = kwargs['group_uuid']
+        self.subsidy_uuid = kwargs['subsidy_uuid']
+        self.access_method = kwargs['access_method']
+
+    @staticmethod
+    def from_dict(dict_instance, ctx):  # pylint: disable=unused-argument
+        return AccessPolicyEvent(**dict_instance)
+
+    @staticmethod
+    def to_dict(obj, ctx):  # pylint: disable=unused-argument
+        return {
+            'uuid': obj.uuid,
+            'active': obj.active,
+            'group_uuid': obj.group_uuid,
+            'subsidy_uuid': obj.subsidy_uuid,
+            'access_method': obj.access_method,
+        }
+
+
+class AccessPolicyEventSerializer:
+    """
+    Wrapper class used to ensure a single instance of the AccessPolicyEventSerializer.
+    This avoids errors on startup.
+    """
+    KAFKA_SCHEMA_REGISTRY_CONFIG = {
+        'url': getattr(settings, 'SCHEMA_REGISTRY_URL', ''),
+        'basic.auth.user.info': f"{getattr(settings, 'SCHEMA_REGISTRY_API_KEY', '')}"
+                                f":{getattr(settings, 'SCHEMA_REGISTRY_API_SECRET', '')}",
+    }
+    SERIALIZER = None
+
+    @classmethod
+    def get_serializer(cls):
+        """
+        Get or create a single instance of the AccessPolicyEventSerializer serializer
+        to be used throughout the life of the app.
+
+        :return: AvroSerializer
+        """
+        if cls.SERIALIZER is None:
+            cls.SERIALIZER = AvroSerializer(
+                schema_str=AccessPolicyEvent.AVRO_SCHEMA,
+                schema_registry_client=SchemaRegistryClient(cls.KAFKA_SCHEMA_REGISTRY_CONFIG),
+                to_dict=AccessPolicyEvent.to_dict
+            )
+
+        return cls.SERIALIZER

--- a/enterprise_access/apps/events/signals.py
+++ b/enterprise_access/apps/events/signals.py
@@ -4,7 +4,7 @@ Custom signals definitions that represent enterprise-access events.
 
 from openedx_events.tooling import OpenEdxPublicSignal
 
-from .data import AccessPolicyData, CouponCodeRequestData, LicenseRequestData
+from .data import AccessPolicyData, CouponCodeRequestData, LicenseRequestData, SubsidyRedemption
 
 # TODO: Move the signals to openedx_events
 
@@ -40,5 +40,20 @@ ACCESS_POLICY_DELETED = OpenEdxPublicSignal(
     event_type="org.openedx.enterprise.access.access-policy.deleted.v1",
     data={
         "access-policy": AccessPolicyData,
+    }
+)
+
+
+SUBSIDY_REDEEMED = OpenEdxPublicSignal(
+    event_type="org.openedx.enterprise.access.subsidy.redeemed.v1",
+    data={
+        "redemption": SubsidyRedemption,
+    }
+)
+
+SUBSIDY_REDEMPTION_REVERSED = OpenEdxPublicSignal(
+    event_type="org.openedx.enterprise.access.subsidy.redemption-reversed.v1",
+    data={
+        "redemption": SubsidyRedemption,
     }
 )

--- a/enterprise_access/apps/events/signals.py
+++ b/enterprise_access/apps/events/signals.py
@@ -4,7 +4,7 @@ Custom signals definitions that represent enterprise-access events.
 
 from openedx_events.tooling import OpenEdxPublicSignal
 
-from .data import CouponCodeRequestData, LicenseRequestData
+from .data import AccessPolicyData, CouponCodeRequestData, LicenseRequestData
 
 # TODO: Move the signals to openedx_events
 
@@ -19,5 +19,26 @@ LICENSE_REQUEST_APPROVED = OpenEdxPublicSignal(
     event_type="org.openedx.enterprise.access.license-request.approved.v1",
     data={
         "request": LicenseRequestData,
+    }
+)
+
+ACCESS_POLICY_CREATED = OpenEdxPublicSignal(
+    event_type="org.openedx.enterprise.access.access-policy.created.v1",
+    data={
+        "access-policy": AccessPolicyData,
+    }
+)
+
+ACCESS_POLICY_UPDATED = OpenEdxPublicSignal(
+    event_type="org.openedx.enterprise.access.access-policy.updated.v1",
+    data={
+        "access-policy": AccessPolicyData,
+    }
+)
+
+ACCESS_POLICY_DELETED = OpenEdxPublicSignal(
+    event_type="org.openedx.enterprise.access.access-policy.deleted.v1",
+    data={
+        "access-policy": AccessPolicyData,
     }
 )

--- a/enterprise_access/apps/events/tests/test_data.py
+++ b/enterprise_access/apps/events/tests/test_data.py
@@ -5,9 +5,17 @@ from uuid import uuid4
 
 import mock
 from django.test import TestCase
+from faker import Faker
 
-from enterprise_access.apps.events.data import AccessPolicyEvent, AccessPolicyEventSerializer
+from enterprise_access.apps.events.data import (
+    AccessPolicyEvent,
+    AccessPolicyEventSerializer,
+    SubsidyRedemptionEvent,
+    SubsidyRedemptionSerializer
+)
 from enterprise_access.apps.subsidy_access_policy.models import AccessMethods
+
+FAKER = Faker()
 
 
 class DataTests(TestCase):
@@ -41,4 +49,31 @@ class DataTests(TestCase):
 
         # Verify subsequent calls return the same serializer.
         assert AccessPolicyEventSerializer.get_serializer() == serializer
+        assert mock_avro_serializer.call_count == 1
+
+    def test_subsidy_redemption_event(self):
+        """
+        Validate the behavior of SubsidyRedemptionEvent class.
+        """
+        subsidy_redemption_event_data = {
+            'enterprise_uuid': uuid4(),
+            'content_key': 'test-course',
+            'lms_user_id': FAKER.pyint(),
+        }
+
+        subsidy_redemption_event = SubsidyRedemptionEvent.from_dict(subsidy_redemption_event_data, mock.MagicMock())
+
+        assert SubsidyRedemptionEvent.to_dict(subsidy_redemption_event, mock.MagicMock()) == \
+               subsidy_redemption_event_data
+
+    @mock.patch('enterprise_access.apps.events.data.AvroSerializer', return_value=mock.MagicMock())
+    def test_subsidy_event_serializer(self, mock_avro_serializer):
+        """
+        Validate the behavior of SubsidyRedemptionSerializer.
+        """
+        serializer = SubsidyRedemptionSerializer.get_serializer()
+        assert mock_avro_serializer.call_count == 1
+
+        # Verify subsequent calls return the same serializer.
+        assert SubsidyRedemptionSerializer.get_serializer() == serializer
         assert mock_avro_serializer.call_count == 1

--- a/enterprise_access/apps/events/tests/test_data.py
+++ b/enterprise_access/apps/events/tests/test_data.py
@@ -1,0 +1,44 @@
+"""
+Tests for data module in events django application.
+"""
+from uuid import uuid4
+
+import mock
+from django.test import TestCase
+
+from enterprise_access.apps.events.data import AccessPolicyEvent, AccessPolicyEventSerializer
+from enterprise_access.apps.subsidy_access_policy.models import AccessMethods
+
+
+class DataTests(TestCase):
+    """
+    Unit tests for data module in events django application..
+    """
+
+    def test_access_policy_event(self):
+        """
+        Validate the behavior of AccessPolicyEvent class.
+        """
+        access_policy_event_data = {
+            'uuid': uuid4(),
+            'active': True,
+            'group_uuid': uuid4(),
+            'subsidy_uuid': uuid4(),
+            'access_method': AccessMethods.DIRECT,
+        }
+
+        access_policy_event = AccessPolicyEvent.from_dict(access_policy_event_data, mock.MagicMock())
+
+        assert AccessPolicyEvent.to_dict(access_policy_event, mock.MagicMock()) == access_policy_event_data
+
+    @mock.patch('enterprise_access.apps.events.data.AvroSerializer', return_value=mock.MagicMock())
+    def test_access_policy_event_serializer(self, mock_avro_serializer):
+        """
+        Validate the behavior of AccessPolicyEventSerializer.
+        """
+        serializer = AccessPolicyEventSerializer.get_serializer()
+        assert mock_avro_serializer.call_count == 1
+
+        # Verify subsequent calls return the same serializer.
+        assert AccessPolicyEventSerializer.get_serializer() == serializer
+        assert mock_avro_serializer.call_count == 1

--- a/enterprise_access/apps/events/tests/test_utils.py
+++ b/enterprise_access/apps/events/tests/test_utils.py
@@ -1,0 +1,57 @@
+"""
+Unit tests for the utility functions.
+"""
+from unittest.mock import ANY
+from uuid import uuid4
+
+import mock
+from confluent_kafka.error import ValueSerializationError
+from django.conf import settings
+from django.test import TestCase
+
+from enterprise_access.apps.events.signals import ACCESS_POLICY_CREATED
+from enterprise_access.apps.events.utils import send_access_policy_event_to_event_bus, verify_event
+from enterprise_access.apps.subsidy_access_policy.models import AccessMethods
+
+
+class UtilsTests(TestCase):
+    """
+    Unit tests for the utility functions.
+    """
+
+    @mock.patch('enterprise_access.apps.events.utils.logger', return_value=mock.MagicMock())
+    @mock.patch('enterprise_access.apps.events.utils.SerializingProducer', return_value=mock.MagicMock())
+    def test_send_access_policy_event_to_event_bus(self, mock_serializing_producer, mock_logger):
+        """
+        Validate the behavior of send_access_policy_event_to_event_bus utility method.
+        """
+        access_policy_event_data = {
+            'uuid': uuid4(),
+            'active': True,
+            'group_uuid': uuid4(),
+            'subsidy_uuid': uuid4(),
+            'access_method': AccessMethods.DIRECT,
+        }
+
+        send_access_policy_event_to_event_bus(ACCESS_POLICY_CREATED.event_type, access_policy_event_data)
+
+        mock_serializing_producer().produce.assert_any_call(
+            settings.ACCESS_POLICY_TOPIC_NAME,
+            key=str(ACCESS_POLICY_CREATED.event_type),
+            value=ANY,
+            on_delivery=verify_event
+        )
+
+        assert mock_serializing_producer().poll.call_count == 1
+
+        mock_serializing_producer().poll.side_effect = ValueSerializationError
+
+        send_access_policy_event_to_event_bus(ACCESS_POLICY_CREATED.event_type, access_policy_event_data)
+
+        mock_serializing_producer().produce.assert_any_call(
+            settings.ACCESS_POLICY_TOPIC_NAME,
+            key=str(ACCESS_POLICY_CREATED.event_type),
+            value=ANY,
+            on_delivery=verify_event
+        )
+        assert mock_logger.exception.call_count == 1

--- a/enterprise_access/apps/events/tests/test_utils.py
+++ b/enterprise_access/apps/events/tests/test_utils.py
@@ -8,10 +8,17 @@ import mock
 from confluent_kafka.error import ValueSerializationError
 from django.conf import settings
 from django.test import TestCase
+from faker import Faker
 
-from enterprise_access.apps.events.signals import ACCESS_POLICY_CREATED
-from enterprise_access.apps.events.utils import send_access_policy_event_to_event_bus, verify_event
+from enterprise_access.apps.events.signals import ACCESS_POLICY_CREATED, SUBSIDY_REDEEMED
+from enterprise_access.apps.events.utils import (
+    send_access_policy_event_to_event_bus,
+    send_subsidy_redemption_event_to_event_bus,
+    verify_event
+)
 from enterprise_access.apps.subsidy_access_policy.models import AccessMethods
+
+FAKER = Faker()
 
 
 class UtilsTests(TestCase):
@@ -51,6 +58,41 @@ class UtilsTests(TestCase):
         mock_serializing_producer().produce.assert_any_call(
             settings.ACCESS_POLICY_TOPIC_NAME,
             key=str(ACCESS_POLICY_CREATED.event_type),
+            value=ANY,
+            on_delivery=verify_event
+        )
+        assert mock_logger.exception.call_count == 1
+
+    @mock.patch('enterprise_access.apps.events.utils.logger', return_value=mock.MagicMock())
+    @mock.patch('enterprise_access.apps.events.utils.SerializingProducer', return_value=mock.MagicMock())
+    def test_send_subsidy_redemption_event_to_event_bus(self, mock_serializing_producer, mock_logger):
+        """
+        Validate the behavior of send_access_policy_event_to_event_bus utility method.
+        """
+        subsidy_redemption_event_data = {
+            'enterprise_uuid': uuid4(),
+            'content_key': 'test-course',
+            'lms_user_id': FAKER.pyint(),
+        }
+
+        send_subsidy_redemption_event_to_event_bus(SUBSIDY_REDEEMED.event_type, subsidy_redemption_event_data)
+
+        mock_serializing_producer().produce.assert_any_call(
+            settings.SUBSIDY_REDEMPTION_TOPIC_NAME,
+            key=str(SUBSIDY_REDEEMED.event_type),
+            value=ANY,
+            on_delivery=verify_event
+        )
+
+        assert mock_serializing_producer().poll.call_count == 1
+
+        mock_serializing_producer().poll.side_effect = ValueSerializationError
+
+        send_subsidy_redemption_event_to_event_bus(SUBSIDY_REDEEMED.event_type, subsidy_redemption_event_data)
+
+        mock_serializing_producer().produce.assert_any_call(
+            settings.SUBSIDY_REDEMPTION_TOPIC_NAME,
+            key=str(SUBSIDY_REDEEMED.event_type),
             value=ANY,
             on_delivery=verify_event
         )

--- a/enterprise_access/apps/events/utils.py
+++ b/enterprise_access/apps/events/utils.py
@@ -11,7 +11,12 @@ from confluent_kafka.error import ValueSerializationError
 from confluent_kafka.serialization import StringSerializer
 from django.conf import settings
 
-from enterprise_access.apps.events.data import CouponCodeRequestEvent, CouponCodeRequestEventSerializer
+from enterprise_access.apps.events.data import (
+    AccessPolicyEvent,
+    AccessPolicyEventSerializer,
+    CouponCodeRequestEvent,
+    CouponCodeRequestEventSerializer
+)
 
 logger = logging.getLogger(__name__)
 
@@ -113,6 +118,27 @@ def send_coupon_code_request_event_to_event_bus(event_name, event_properties):
             settings.COUPON_CODE_REQUEST_TOPIC_NAME,
             key=str(event_name),
             value=CouponCodeRequestEvent(**event_properties),
+            on_delivery=verify_event
+        )
+        event_producer.poll()
+    except ValueSerializationError as vse:
+        logger.exception(vse)
+
+
+def send_access_policy_event_to_event_bus(event_name, event_properties):
+    """
+    Sends access policy event to the event bus.
+    """
+    try:
+        event_producer = ProducerFactory.get_or_create_event_producer(
+            settings.ACCESS_POLICY_TOPIC_NAME,
+            StringSerializer('utf-8'),
+            AccessPolicyEventSerializer.get_serializer()
+        )
+        event_producer.produce(
+            settings.ACCESS_POLICY_TOPIC_NAME,
+            key=str(event_name),
+            value=AccessPolicyEvent(**event_properties),
             on_delivery=verify_event
         )
         event_producer.poll()

--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -390,7 +390,20 @@ SCHEMA_REGISTRY_URL = ''
 KAFKA_PARTITIONS_PER_TOPIC = 1
 # This number is dictated by the cluster setup
 KAFKA_REPLICATION_FACTOR_PER_TOPIC = 3
-KAFKA_TOPICS = []
+
+COUPON_CODE_REQUEST_TOPIC_NAME = "coupon-code-request"
+LICENSE_REQUEST_TOPIC_NAME = "license-request"
+ACCESS_POLICY_TOPIC_NAME = "access-policy"
+SUBSIDY_REDEMPTION_TOPIC_NAME = "subsidy-redemption"
+KAFKA_TOPICS = [
+    COUPON_CODE_REQUEST_TOPIC_NAME,
+    LICENSE_REQUEST_TOPIC_NAME,
+
+    # Access policy events
+    ACCESS_POLICY_TOPIC_NAME,
+    SUBSIDY_REDEMPTION_TOPIC_NAME,
+]
+
 
 ################### End Kafka Related Settings ##############################
 

--- a/enterprise_access/settings/devstack.py
+++ b/enterprise_access/settings/devstack.py
@@ -81,14 +81,21 @@ SHELL_PLUS_IMPORTS = [
 
 
 ################### Kafka Related Settings ##############################
-KAFKA_ENABLED=False
+KAFKA_ENABLED = False
 
 KAFKA_BOOTSTRAP_SERVER = 'edx.devstack.kafka:29092'
 SCHEMA_REGISTRY_URL = 'http://edx.devstack.schema-registry:8081'
-KAFKA_REPLICATION_FACTOR_PER_TOPIC=1
+KAFKA_REPLICATION_FACTOR_PER_TOPIC = 1
 
-COUPON_CODE_REQUEST_TOPIC_NAME="coupon-code-request-dev"
-LICENSE_REQUEST_TOPIC_NAME="license-request-dev"
-KAFKA_TOPICS = [COUPON_CODE_REQUEST_TOPIC_NAME, LICENSE_REQUEST_TOPIC_NAME]
+COUPON_CODE_REQUEST_TOPIC_NAME = "coupon-code-request-dev"
+LICENSE_REQUEST_TOPIC_NAME = "license-request-dev"
+ACCESS_POLICY_TOPIC_NAME = "access-policy-dev"
+KAFKA_TOPICS = [
+    COUPON_CODE_REQUEST_TOPIC_NAME,
+    LICENSE_REQUEST_TOPIC_NAME,
+
+    # Access policy events
+    ACCESS_POLICY_TOPIC_NAME,
+]
 
 ################### End Kafka Related Settings ##############################

--- a/enterprise_access/settings/devstack.py
+++ b/enterprise_access/settings/devstack.py
@@ -90,12 +90,14 @@ KAFKA_REPLICATION_FACTOR_PER_TOPIC = 1
 COUPON_CODE_REQUEST_TOPIC_NAME = "coupon-code-request-dev"
 LICENSE_REQUEST_TOPIC_NAME = "license-request-dev"
 ACCESS_POLICY_TOPIC_NAME = "access-policy-dev"
+SUBSIDY_REDEMPTION_TOPIC_NAME = "subsidy-redemption-dev"
 KAFKA_TOPICS = [
     COUPON_CODE_REQUEST_TOPIC_NAME,
     LICENSE_REQUEST_TOPIC_NAME,
 
     # Access policy events
     ACCESS_POLICY_TOPIC_NAME,
+    SUBSIDY_REDEMPTION_TOPIC_NAME,
 ]
 
 ################### End Kafka Related Settings ##############################

--- a/enterprise_access/settings/test.py
+++ b/enterprise_access/settings/test.py
@@ -37,3 +37,22 @@ BRAZE_NEW_REQUESTS_NOTIFICATION_CAMPAIGN = 'test-new-subsidy-campaign'
 
 # SEGMENT CONFIGURATION
 SEGMENT_KEY = 'test-key'
+
+################### Kafka Related Settings ##############################
+KAFKA_ENABLED = False
+
+KAFKA_BOOTSTRAP_SERVER = 'edx.devstack.kafka:29092'
+SCHEMA_REGISTRY_URL = 'http://edx.devstack.schema-registry:8081'
+KAFKA_REPLICATION_FACTOR_PER_TOPIC = 1
+
+COUPON_CODE_REQUEST_TOPIC_NAME = "coupon-code-request-dev"
+LICENSE_REQUEST_TOPIC_NAME = "license-request-dev"
+ACCESS_POLICY_TOPIC_NAME = "access-policy-dev"
+KAFKA_TOPICS = [
+    COUPON_CODE_REQUEST_TOPIC_NAME,
+    LICENSE_REQUEST_TOPIC_NAME,
+
+    # Access policy events
+    ACCESS_POLICY_TOPIC_NAME,
+]
+################### End Kafka Related Settings ##############################

--- a/enterprise_access/settings/test.py
+++ b/enterprise_access/settings/test.py
@@ -45,14 +45,16 @@ KAFKA_BOOTSTRAP_SERVER = 'edx.devstack.kafka:29092'
 SCHEMA_REGISTRY_URL = 'http://edx.devstack.schema-registry:8081'
 KAFKA_REPLICATION_FACTOR_PER_TOPIC = 1
 
-COUPON_CODE_REQUEST_TOPIC_NAME = "coupon-code-request-dev"
-LICENSE_REQUEST_TOPIC_NAME = "license-request-dev"
-ACCESS_POLICY_TOPIC_NAME = "access-policy-dev"
+COUPON_CODE_REQUEST_TOPIC_NAME = "coupon-code-request-test"
+LICENSE_REQUEST_TOPIC_NAME = "license-request-test"
+ACCESS_POLICY_TOPIC_NAME = "access-policy-test"
+SUBSIDY_REDEMPTION_TOPIC_NAME = "subsidy-redemption-test"
 KAFKA_TOPICS = [
     COUPON_CODE_REQUEST_TOPIC_NAME,
     LICENSE_REQUEST_TOPIC_NAME,
 
     # Access policy events
     ACCESS_POLICY_TOPIC_NAME,
+    SUBSIDY_REDEMPTION_TOPIC_NAME,
 ]
 ################### End Kafka Related Settings ##############################


### PR DESCRIPTION
__Jira Ticket:__ [ENT-6754](https://2u-internal.atlassian.net/browse/ENT-6754)

__Description:__
This PR adds mechanism for sending policy related events to event bus for anyone who wants to subscribe to these events and perform some operation.

 
**Acceptance Criteria:**

1. Kafka topics are created for policy created, policy updated and policy deleted events.
2. Avro Serializers are created for policy created, policy updated and policy deleted events.
3. Utility methods are created for policy created, policy updated and policy deleted events
4. Events are fired on when policy is created, updated or deleted.