### PR TITLE
fix: update Dockerfile and docker-compose.yml, add api spec for MFEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ dmypy.json
 
 # emacs
 *~
+
+# VSCode
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,9 @@ RUN pip install --upgrade pip setuptools
 RUN rm -rf /var/lib/apt/lists/*
 
 WORKDIR /tmp
-RUN wget https://packages.confluent.io/clients/deb/pool/main/libr/librdkafka/librdkafka_1.8.2.orig.tar.gz
-RUN tar -xf librdkafka_1.8.2.orig.tar.gz
-WORKDIR /tmp/librdkafka-1.8.2
+RUN wget https://packages.confluent.io/clients/deb/pool/main/libr/librdkafka/librdkafka_2.0.2.orig.tar.gz
+RUN tar -xf librdkafka_2.0.2.orig.tar.gz
+WORKDIR /tmp/librdkafka-2.0.2
 RUN ./configure && make && make install && ldconfig
 
 RUN ln -s /usr/bin/python3 /usr/bin/python

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,3 +10,6 @@ coverage:
         target: 100%
 
 comment: false
+
+ignore:
+  - "docs/decisions"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.1"
 services:
   db:
-    image: mysql:8.0.28-oracle
+    image: edxops/mysql:5.7
     container_name: enterprise_access.db
     environment:
       MYSQL_ROOT_PASSWORD: ""
@@ -9,7 +9,7 @@ services:
     networks:
       - devstack_default
     volumes:
-      - enterprise_access_mysql8:/var/lib/mysql
+      - enterprise_access_mysql57:/var/lib/mysql
 
   memcache:
     image: memcached:1.4.24
@@ -23,8 +23,6 @@ services:
     volumes:
       - .:/edx/app/enterprise-access/
     command: bash -c 'while true; do python /edx/app/enterprise-access/manage.py runserver 0.0.0.0:18270; sleep 2; done'
-    environment:
-      DJANGO_SETTINGS_MODULE: enterprise_access.settings.devstack
     ports:
       - "18270:18270" # TODO: change this to your port
     depends_on:
@@ -77,4 +75,4 @@ networks:
     external: true
 
 volumes:
-  enterprise_access_mysql8:
+  enterprise_access_mysql57:

--- a/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
+++ b/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
@@ -21,6 +21,8 @@ GET Retrieve single, redeemable access policy for a course
 
 **/api/v1/enterprise-customer/<enterprise_customer_uuid>/policy/can_redeem/**
 
+/api/v1/enterprise-customer/2c87511c-34bd-41e8-9ada-def7c79bd321/policy/can_redeem/?lms_user_id=3&content_id=course-v1:ImperialX+dacc003+3T2019
+
 This API endpoint will be called by the enterprise learner portal to understand whether
 the learner is already enrolled in the course (i.e., a prior redemption has been successfully
 fulfilled) and/or which subsidy access policy should be used to redeem the course when a learner
@@ -45,148 +47,195 @@ which returns an individual transaction and its current state (i.e., ``created``
 *Inputs (query parameters):*
 
 * ``lms_user_id``
-* ``content_id`` (i.e., course id)
+* ``content_key`` (i.e., course key or course run key)
 
 *Outputs:*
 
+For each course run associated with the specified ``content_key``:
+
 * A single, redeemable subsidy access policy (if any).
 * Redemption status of the single, redeemable subsidy access policy (if any).
-* List of error(s) around why there is no redeemable subsidy access policy.
+* List of error(s) for why there is no redeemable subsidy access policy.
 
 Sample API responses
 ^^^^^^^^^^^^^^^^^^^^
+
+::
+
+  [
+    {
+      "course_run_key": "course-v1:ImperialX+dacc003+3T2019",
+      "redemption": {
+        "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
+        "status": "fulfilled",
+        "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:ImperialX+dacc003+3T2019/courseware/",
+        "errors": []
+      },
+      "subsidy_access_policy": {
+        "uuid": "56744a36-93ac-4e6c-b998-a2a1899f2ae4",
+        "policy_redemption_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
+        "policy_type": "LearnerCreditAccessPolicy",
+        "description": "Learner credit access policy",
+        "active": true,
+        "catalog_uuid": "14f701ea-7e0b-4a4e-bbda-f295e40c7bf1",
+        "subsidy_uuid": "7801b0ef-b1c2-4f3a-97fa-121f0bce48be",
+        "access_method": "direct",
+        "spent_limit": 10000,
+        "per_learner_spend_limit": 200,
+        "remaining_balance": 9500,
+        "remaining_balance_for_learner": 200
+      },
+      "errors": []
+    }
+  ]
 
 *No redeemable subsidy access policies available to the learner:*
 
 ::
 
-  {
-    "redemption": null,
-    "subsidy_access_policy": null,
-    "errors": [
-      {
-        "code": 400,
-        "message": "Insufficient balance remaining",
-      }
-    ]
-  }
+  [
+    {
+      "course_run_key": "course-v1:ImperialX+dacc003+3T2019",
+      "redemption": null,
+      "subsidy_access_policy": null,
+      "errors": [
+        {
+          "code": 400,
+          "message": "Insufficient balance remaining",
+        }
+      ]
+    }
+  ]
 
 *Redeemable subsidy access policy that has not yet been redeemed and/or fulfilled:*
 
 ::
 
-  {
-    "redemption": null,
-    "subsidy_access_policy": {
-      "uuid": "56744a36-93ac-4e6c-b998-a2a1899f2ae4",
-      "policy_redemption_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
-      "policy_type": "LearnerCreditAccessPolicy",
-      "description": "Learner credit access policy",
-      "active": true,
-      "catalog_uuid": "14f701ea-7e0b-4a4e-bbda-f295e40c7bf1",
-      "subsidy_uuid": "7801b0ef-b1c2-4f3a-97fa-121f0bce48be",
-      "access_method": "direct",
-      "spent_limit": 10000,
-      "per_learner_spend_limit": 200,
-      "remaining_balance": 9500,
-      "remaining_balance_for_learner": 200
-    },
-    "errors": []
-  }
+  [
+    {
+      "course_run_key": "course-v1:ImperialX+dacc003+3T2019",
+      "redemption": null,
+      "subsidy_access_policy": {
+        "uuid": "56744a36-93ac-4e6c-b998-a2a1899f2ae4",
+        "policy_redemption_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
+        "policy_type": "LearnerCreditAccessPolicy",
+        "description": "Learner credit access policy",
+        "active": true,
+        "catalog_uuid": "14f701ea-7e0b-4a4e-bbda-f295e40c7bf1",
+        "subsidy_uuid": "7801b0ef-b1c2-4f3a-97fa-121f0bce48be",
+        "access_method": "direct",
+        "spent_limit": 10000,
+        "per_learner_spend_limit": 200,
+        "remaining_balance": 9500,
+        "remaining_balance_for_learner": 200
+      },
+      "errors": []
+    }
+  ]
 
 *Redeemable subsidy access policy that has been redeemed but is pending fulfillment:*
 
 ::
 
-  {
-    "redemption": {
-      "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
-      "status": "pending",
-      "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
-      "redirect_url": null,
+  [
+    {
+      "course_run_key": "course-v1:ImperialX+dacc003+3T2019",
+      "redemption": {
+        "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
+        "status": "pending",
+        "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
+        "courseware_url": null,
+        "errors": []
+      },
+      "subsidy_access_policy": {
+        "uuid": "56744a36-93ac-4e6c-b998-a2a1899f2ae4",
+        "policy_redemption_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
+        "policy_type": "LearnerCreditAccessPolicy",
+        "description": "Learner credit access policy",
+        "active": true,
+        "catalog_uuid": "14f701ea-7e0b-4a4e-bbda-f295e40c7bf1",
+        "subsidy_uuid": "7801b0ef-b1c2-4f3a-97fa-121f0bce48be",
+        "access_method": "direct",
+        "spent_limit": 10000,
+        "per_learner_spend_limit": 200,
+        "remaining_balance": 9500,
+        "remaining_balance_for_learner": 200
+      },
       "errors": []
-    },
-    "subsidy_access_policy": {
-      "uuid": "56744a36-93ac-4e6c-b998-a2a1899f2ae4",
-      "policy_redemption_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
-      "policy_type": "LearnerCreditAccessPolicy",
-      "description": "Learner credit access policy",
-      "active": true,
-      "catalog_uuid": "14f701ea-7e0b-4a4e-bbda-f295e40c7bf1",
-      "subsidy_uuid": "7801b0ef-b1c2-4f3a-97fa-121f0bce48be",
-      "access_method": "direct",
-      "spent_limit": 10000,
-      "per_learner_spend_limit": 200,
-      "remaining_balance": 9500,
-      "remaining_balance_for_learner": 200
-    },
-    "errors": []
-  }
+    }
+  ]
 
 *Redeemable subsidy access policy that has been successfully redeemed and fulfilled:*
 
 ::
 
-  {
-    "redemption": {
-      "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
-      "status": "fulfilled",
-      "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
-      "redirect_url": "https://learning.edx.org/course/course-v1:ImperialX+dacc003+3T2019/home",
+  [
+    {
+      "course_run_key": "course-v1:ImperialX+dacc003+3T2019",
+      "redemption": {
+        "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
+        "status": "fulfilled",
+        "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:ImperialX+dacc003+3T2019/courseware/",
+        "errors": []
+      },
+      "subsidy_access_policy": {
+        "uuid": "56744a36-93ac-4e6c-b998-a2a1899f2ae4",
+        "policy_redemption_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
+        "policy_type": "LearnerCreditAccessPolicy",
+        "description": "Learner credit access policy",
+        "active": true,
+        "catalog_uuid": "14f701ea-7e0b-4a4e-bbda-f295e40c7bf1",
+        "subsidy_uuid": "7801b0ef-b1c2-4f3a-97fa-121f0bce48be",
+        "access_method": "direct",
+        "spent_limit": 10000,
+        "per_learner_spend_limit": 200,
+        "remaining_balance": 9500,
+        "remaining_balance_for_learner": 200
+      },
       "errors": []
-    },
-    "subsidy_access_policy": {
-      "uuid": "56744a36-93ac-4e6c-b998-a2a1899f2ae4",
-      "policy_redemption_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
-      "policy_type": "LearnerCreditAccessPolicy",
-      "description": "Learner credit access policy",
-      "active": true,
-      "catalog_uuid": "14f701ea-7e0b-4a4e-bbda-f295e40c7bf1",
-      "subsidy_uuid": "7801b0ef-b1c2-4f3a-97fa-121f0bce48be",
-      "access_method": "direct",
-      "spent_limit": 10000,
-      "per_learner_spend_limit": 200,
-      "remaining_balance": 9500,
-      "remaining_balance_for_learner": 200
-    },
-    "errors": []
-  }
+    }
+  ]
 
 *Redeemable subsidy access policy that has been redeemed, but failed during fulfillment:*
 
 ::
 
-  {
-    "redemption": {
-      "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
-      "status": "error",
-      "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
-      "redirect_url": null,
-      "errors": [
-        {
-          "code": 500,
-          "message": "Something went wrong. Please try again.",
-        }
-      ]
-    },
-    "subsidy_access_policy": {
-      "uuid": "56744a36-93ac-4e6c-b998-a2a1899f2ae4",
-      "policy_redemption_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
-      "policy_type": "LearnerCreditAccessPolicy",
-      "description": "Learner credit access policy",
-      "active": true,
-      "catalog_uuid": "14f701ea-7e0b-4a4e-bbda-f295e40c7bf1",
-      "subsidy_uuid": "7801b0ef-b1c2-4f3a-97fa-121f0bce48be",
-      "access_method": "direct",
-      "spent_limit": 10000,
-      "per_learner_spend_limit": 200,
-      "remaining_balance": 9500,
-      "remaining_balance_for_learner": 200
-    },
-    "errors": []
-  }
+  [
+    {
+      "course_run_key": "course-v1:ImperialX+dacc003+3T2019",
+      "redemption": {
+        "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
+        "status": "error",
+        "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
+        "courseware_url": null,
+        "errors": [
+          {
+            "code": 500,
+            "message": "Something went wrong. Please try again.",
+          }
+        ]
+      },
+      "subsidy_access_policy": {
+        "uuid": "56744a36-93ac-4e6c-b998-a2a1899f2ae4",
+        "policy_redemption_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
+        "policy_type": "LearnerCreditAccessPolicy",
+        "description": "Learner credit access policy",
+        "active": true,
+        "catalog_uuid": "14f701ea-7e0b-4a4e-bbda-f295e40c7bf1",
+        "subsidy_uuid": "7801b0ef-b1c2-4f3a-97fa-121f0bce48be",
+        "access_method": "direct",
+        "spent_limit": 10000,
+        "per_learner_spend_limit": 200,
+        "remaining_balance": 9500,
+        "remaining_balance_for_learner": 200
+      },
+      "errors": []
+    }
+  ]
 
-GETRetrieve the fulfillment status for a policy redemption
+GET Retrieve the fulfillment status for a policy redemption
 --------------------------------------------------------
 
 **/api/v1/enterprise-customer/<enterprise_customer_uuid>/policy/<policy_uuid>/redemptions/<redemption_uuid>/**
@@ -221,7 +270,7 @@ Sample API responses
     "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
     "status": "fulfilled",
     "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
-    "redirect_url": "https://learning.edx.org/course/course-v1:ImperialX+dacc003+3T2019/home",
+    "courseware_url": "https://courses.edx.org/courses/course-v1:ImperialX+dacc003+3T2019/courseware/",
     "errors": []
   }
 
@@ -233,7 +282,7 @@ Sample API responses
     "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
     "status": "pending",
     "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
-    "redirect_url": null,
+    "courseware_url": null,
     "errors": []
   }
 
@@ -245,7 +294,7 @@ Sample API responses
     "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
     "status": "error",
     "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
-    "redirect_url": null,
+    "courseware_url": null,
     "errors": [
       {
         "code": 500,

--- a/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
+++ b/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
@@ -39,6 +39,9 @@ list of redeemable policies, which would mean the client  (e.g., enterprise lear
 logic to make a choice of which redeemable policy to attempt a redemption. This new API endpoint would thus remove the
 need for such business logic in the client given the subsidy access policy choice is abstracted into the API layer instead.
 
+The redemption fulfillment status is retrieved from the ``/api/v1/transactions/<transaction_uuid>/`` API endpoint in ``enterprise-subsidy``,
+which returns an individual transaction and its current state (i.e., ``created``, ``pending``, ``committed``).
+
 *Inputs (query parameters):*
 
 * ``lms_user_id``

--- a/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
+++ b/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
@@ -19,27 +19,25 @@ API Endpoints
 GET Retrieve single, redeemable access policy for a course
 ------------------------------------------------------
 
-**/api/v1/enterprise-customer/<enterprise_customer_uuid>/policy/can_redeem/**
-
-/api/v1/enterprise-customer/2c87511c-34bd-41e8-9ada-def7c79bd321/policy/can_redeem/?lms_user_id=3&content_id=course-v1:ImperialX+dacc003+3T2019
+**/api/v1/enterprise-customer/<enterprise_customer_uuid>/course/<course_key>/can_redeem/**
 
 This API endpoint will be called by the enterprise learner portal to understand whether
 the learner is already enrolled in the course (i.e., a prior redemption has been successfully
 fulfilled) and/or which subsidy access policy should be used to redeem the course when a learner
 clicks the "Enroll" button. 
 
-The course page in the enterprise learner portal displays a "Enroll" or "View course" for each course run for the course being viewed. Given
+The course page in the enterprise learner portal displays an "Enroll" or "View course" for each course run for the course being viewed. Given
 that we're now using the redemption fulfillment status as a proxy for whether the learner is already enrolled, we will need to know the fulfillment
 status for each course run. To avoid the frontend needing to make N API requests to ``can_redeem`` (i.e., one per course run), this API endpoint will
 return the fulfillment status and a redeemable policy for each course run.
 
-At a high level, this API endpoint works by iterating over all subsidy access policies associated with
+This API endpoint works by iterating over all subsidy access policies associated with
 the enterprise customer for the specified learner to understand which subsidy access policies are indeed
 redeemable. It does this by calling the ``can_redeem`` API endpoint in ``enterprise-subsidy`` for each active
 subsidy access policy. In the event multiple subsidy access policies are found, this API endpoint chooses
-the preferred subsidy basked on our business rules.
+the preferred subsidy based on defined business rules.
 
-This API endpoint differs from the one spec'd in the 0003 Initial API Specification in that
+This API endpoint differs from the one spec'd in the `0003 Initial API Specification`_ in that
 it makes a decision of which single subsidy access policy should be redeemed for a given course in the event
 a learner has multiple redeemable subsidy access policies. The API endpoint that's already spec'd returns a
 list of redeemable policies, which would mean the client  (e.g., enterprise learner portal) still requires business
@@ -52,7 +50,6 @@ which returns an individual transaction and its current state (i.e., ``created``
 *Inputs (query parameters):*
 
 * ``lms_user_id``
-* ``content_key`` (i.e., course key or course run key)
 
 *Outputs:*
 
@@ -307,3 +304,5 @@ Sample API responses
       }
     ]
   }
+
+.. _0003 Initial API Specification: 0003-initial-api-specification.rst

--- a/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
+++ b/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
@@ -9,31 +9,35 @@ Accepted (March 2023)
 Context
 =======
 
-This document intends to outline which API endpoints exist or will exist in support of the
+This document intends to outline which API endpoint(s) exist or will exist in support of the
 Enterprise MFEs (e.g., frontend-app-learner-portal-enterprise) as well as other consumers,
 or service-to-service communication.
 
 API Endpoints
 =============
 
-GET Retrieve single, redeemable access policy for a course
-------------------------------------------------------
+GET Retrieve single, redeemable access policy for a set of content keys
+-----------------------------------------------------------------------
 
-**/api/v1/enterprise-customer/<enterprise_customer_uuid>/course/<course_key>/can_redeem/**
+**/api/v1/policy/enterprise-customer/<enterprise_customer_uuid>/can_redeem/?content_key=...&content_key=...**
 
 This API endpoint will be called by the enterprise learner portal to understand whether
-the learner is already enrolled in the course (i.e., a prior redemption has been successfully
-fulfilled) and/or which subsidy access policy should be used to redeem the course when a learner
+the learner is already enrolled in any of the available course runs (i.e., a prior redemption has been successfully
+fulfilled) and/or which subsidy access policy should be used to redeem each course run when a learner
 clicks the "Enroll" button. 
 
-The course page in the enterprise learner portal displays an "Enroll" or "View course" for each course run for the course being viewed. Given
-that we're now using the redemption fulfillment status as a proxy for whether the learner is already enrolled, we will need to know the fulfillment
-status for each course run. To avoid the frontend needing to make N API requests to ``can_redeem`` (i.e., one per course run), this API endpoint will
-return the fulfillment status and a redeemable policy for each course run.
+The redemption fulfillment status is retrieved from the ``/api/v1/transactions/<transaction_uuid>/`` API endpoint in ``enterprise-subsidy``,
+which returns an individual transaction and its current state (i.e., ``created``, ``pending``, ``committed``, ``failed``).
+
+The course page in the enterprise learner portal displays an "Enroll" or "View course" CTA for each course run of the
+course being viewed. Given that we're now using the redemption fulfillment status as a proxy for whether the learner
+is already enrolled, we will need to know the fulfillment status for each course run. To avoid the frontend needing to
+make N API requests to ``can_redeem`` (i.e., one per course run), this API endpoint will return the redemption's fulfillment
+status and a redeemable policy for each course run.
 
 This API endpoint works by iterating over all subsidy access policies associated with
 the enterprise customer for the specified learner to understand which subsidy access policies are indeed
-redeemable. It does this by calling the ``can_redeem`` API endpoint in ``enterprise-subsidy`` for each active
+redeemable for each course run. It does this by calling the ``can_redeem`` API endpoint in ``enterprise-subsidy`` for each active
 subsidy access policy. In the event multiple subsidy access policies are found, this API endpoint chooses
 the preferred subsidy based on defined business rules.
 
@@ -44,20 +48,19 @@ list of redeemable policies, which would mean the client  (e.g., enterprise lear
 logic to make a choice of which redeemable policy to attempt a redemption. This new API endpoint would thus remove the
 need for such business logic in the client given the subsidy access policy choice is abstracted into the API layer instead.
 
-The redemption fulfillment status is retrieved from the ``/api/v1/transactions/<transaction_uuid>/`` API endpoint in ``enterprise-subsidy``,
-which returns an individual transaction and its current state (i.e., ``created``, ``pending``, ``committed``).
-
 *Inputs (query parameters):*
 
 * ``lms_user_id``
+* ``content_key`` (i.e., one or more course run keys)
+* ``enterprise_customer_uuid`` might actually make more sense as a query parameter, too. TBD at implementation time.
 
 *Outputs:*
 
-For each course run associated with the specified ``content_key``:
+For each specified ``content_key`` (i.e., course run key), returns the following:
 
 * A single, redeemable subsidy access policy (if any).
-* Redemption status of the single, redeemable subsidy access policy (if any).
-* List of error(s) for why there is no redeemable subsidy access policy.
+* Redemption status of the single, redeemable subsidy access policy (if any). This is largely a serialized ``Transaction`` from ``enterprise-subsidy``, where the redemption UUID is a ``Transaction`` UUID.
+* List of reasons for why there is no redeemable subsidy access policy.
 
 Sample API responses
 ^^^^^^^^^^^^^^^^^^^^
@@ -69,14 +72,14 @@ Sample API responses
       "course_run_key": "course-v1:ImperialX+dacc003+3T2019",
       "redemption": {
         "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
-        "status": "fulfilled",
-        "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
+        "state": "committed",
+        "policy_redemption_status_url": "https://enterprise-subsidy.edx.org/api/v1/transactions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
         "courseware_url": "https://courses.edx.org/courses/course-v1:ImperialX+dacc003+3T2019/courseware/",
         "errors": []
       },
       "subsidy_access_policy": {
         "uuid": "56744a36-93ac-4e6c-b998-a2a1899f2ae4",
-        "policy_redemption_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
+        "policy_redemption_url": "https://enterprise-access.edx.org/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
         "policy_type": "LearnerCreditAccessPolicy",
         "description": "Learner credit access policy",
         "active": true,
@@ -88,7 +91,7 @@ Sample API responses
         "remaining_balance": 9500,
         "remaining_balance_for_learner": 200
       },
-      "errors": []
+      "reasons": []
     }
   ]
 
@@ -101,10 +104,10 @@ Sample API responses
       "course_run_key": "course-v1:ImperialX+dacc003+3T2019",
       "redemption": null,
       "subsidy_access_policy": null,
-      "errors": [
+      "reasons": [
         {
-          "code": 400,
-          "message": "Insufficient balance remaining",
+          "reason": "Insufficient balance remaining",
+          "detail": "Not enough funds available for the course."
         }
       ]
     }
@@ -120,7 +123,7 @@ Sample API responses
       "redemption": null,
       "subsidy_access_policy": {
         "uuid": "56744a36-93ac-4e6c-b998-a2a1899f2ae4",
-        "policy_redemption_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
+        "policy_redemption_url": "https://enterprise-access.edx.org/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
         "policy_type": "LearnerCreditAccessPolicy",
         "description": "Learner credit access policy",
         "active": true,
@@ -132,7 +135,7 @@ Sample API responses
         "remaining_balance": 9500,
         "remaining_balance_for_learner": 200
       },
-      "errors": []
+      "reasons": []
     }
   ]
 
@@ -145,14 +148,14 @@ Sample API responses
       "course_run_key": "course-v1:ImperialX+dacc003+3T2019",
       "redemption": {
         "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
-        "status": "pending",
-        "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
+        "state": "pending",
+        "policy_redemption_status_url": "https://enterprise-subsidy.edx.org/api/v1/transactions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
         "courseware_url": null,
         "errors": []
       },
       "subsidy_access_policy": {
         "uuid": "56744a36-93ac-4e6c-b998-a2a1899f2ae4",
-        "policy_redemption_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
+        "policy_redemption_url": "https://enterprise-access.edx.org/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
         "policy_type": "LearnerCreditAccessPolicy",
         "description": "Learner credit access policy",
         "active": true,
@@ -164,7 +167,7 @@ Sample API responses
         "remaining_balance": 9500,
         "remaining_balance_for_learner": 200
       },
-      "errors": []
+      "reasons": []
     }
   ]
 
@@ -177,14 +180,14 @@ Sample API responses
       "course_run_key": "course-v1:ImperialX+dacc003+3T2019",
       "redemption": {
         "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
-        "status": "fulfilled",
-        "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
+        "state": "committed",
+        "policy_redemption_status_url": "https://enterprise-subsidy.edx.org/api/v1/transactions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
         "courseware_url": "https://courses.edx.org/courses/course-v1:ImperialX+dacc003+3T2019/courseware/",
         "errors": []
       },
       "subsidy_access_policy": {
         "uuid": "56744a36-93ac-4e6c-b998-a2a1899f2ae4",
-        "policy_redemption_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
+        "policy_redemption_url": "https://enterprise-access.edx.org/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
         "policy_type": "LearnerCreditAccessPolicy",
         "description": "Learner credit access policy",
         "active": true,
@@ -196,7 +199,7 @@ Sample API responses
         "remaining_balance": 9500,
         "remaining_balance_for_learner": 200
       },
-      "errors": []
+      "reasons": []
     }
   ]
 
@@ -209,8 +212,8 @@ Sample API responses
       "course_run_key": "course-v1:ImperialX+dacc003+3T2019",
       "redemption": {
         "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
-        "status": "error",
-        "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
+        "state": "failed",
+        "policy_redemption_status_url": "https://enterprise-subsidy.edx.org/api/v1/transactions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
         "courseware_url": null,
         "errors": [
           {
@@ -221,7 +224,7 @@ Sample API responses
       },
       "subsidy_access_policy": {
         "uuid": "56744a36-93ac-4e6c-b998-a2a1899f2ae4",
-        "policy_redemption_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
+        "policy_redemption_url": "https://enterprise-access.edx.org/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
         "policy_type": "LearnerCreditAccessPolicy",
         "description": "Learner credit access policy",
         "active": true,
@@ -233,76 +236,8 @@ Sample API responses
         "remaining_balance": 9500,
         "remaining_balance_for_learner": 200
       },
-      "errors": []
+      "reasons": []
     }
   ]
-
-GET Retrieve the fulfillment status for a policy redemption
---------------------------------------------------------
-
-**/api/v1/enterprise-customer/<enterprise_customer_uuid>/policy/<policy_uuid>/redemptions/<redemption_uuid>/**
-
-When the policy-specific `redeem` endpoint is called (e.g., when learner clicks "Enroll" button on course page), it returns
-with a redemption (transaction) UUID that may be used to query against to understand the status of the redemption's fulfillment which, by
-design, may be asynchronous. As such, this API endpoint intends to be used to check the fulfillment status of a redemption to communicate to consumers that
-any side effects from the redemption have been successfully completed.
-
-*Inputs (query parameters):*
-
-None, other than the arguments in the URL path for the endpoint.
-
-*Outputs:*
-
-Metadata around the redemption fulfillment status, including:
-
-* Redemption/transaction UUID
-* Status (fulfilled, pending, error)
-* Path to the API endpoint to re-check the redemption's fulfillment status
-* Redirect URL (optional), e.g. on successful fulfillment, this might be URL to courseware.
-* List of errors, each with status code and error message (potentially to be displayed in the UI).
-
-Sample API responses
-^^^^^^^^^^^^^^^^^^^^
-
-*Redemption with successful fulfillment*
-
-::
-
-  {
-    "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
-    "status": "fulfilled",
-    "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
-    "courseware_url": "https://courses.edx.org/courses/course-v1:ImperialX+dacc003+3T2019/courseware/",
-    "errors": []
-  }
-
-*Redemption with pending fulfillment*
-
-::
-
-  {
-    "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
-    "status": "pending",
-    "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
-    "courseware_url": null,
-    "errors": []
-  }
-
-*Redemption with error(s) during fulfillment*
-
-::
-
-  {
-    "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
-    "status": "error",
-    "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
-    "courseware_url": null,
-    "errors": [
-      {
-        "code": 500,
-        "message": "Something went wrong. Please try again.",
-      }
-    ]
-  }
 
 .. _0003 Initial API Specification: 0003-initial-api-specification.rst

--- a/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
+++ b/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
@@ -139,7 +139,11 @@ Sample API responses
         "spent_limit": 10000,
         "per_learner_spend_limit": 200,
         "remaining_balance": 9500,
-        "remaining_balance_for_learner": 200
+        "remaining_balance_for_learner": 200,
+        "content_price": {
+          "list": 199,
+          "discounted": 0
+        }
       },
       "reasons": []
     }
@@ -171,7 +175,11 @@ Sample API responses
         "spent_limit": 10000,
         "per_learner_spend_limit": 200,
         "remaining_balance": 9500,
-        "remaining_balance_for_learner": 200
+        "remaining_balance_for_learner": 200,
+        "content_price": {
+          "list": 199,
+          "discounted": 0
+        }
       },
       "reasons": []
     }
@@ -208,7 +216,11 @@ Sample API responses
         "spent_limit": 10000,
         "per_learner_spend_limit": 200,
         "remaining_balance": 9500,
-        "remaining_balance_for_learner": 200
+        "remaining_balance_for_learner": 200,
+        "content_price": {
+          "list": 199,
+          "discounted": 0
+        }
       },
       "reasons": []
     }

--- a/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
+++ b/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
@@ -104,10 +104,7 @@ Sample API responses
         "per_learner_spend_limit": 200,
         "remaining_balance": 9500,
         "remaining_balance_for_learner": 200,
-        "content_price": {
-          "list": 199,
-          "discounted": 0
-        }
+        "list_price": 199,
       },
       "reasons": []
     }
@@ -140,10 +137,7 @@ Sample API responses
         "per_learner_spend_limit": 200,
         "remaining_balance": 9500,
         "remaining_balance_for_learner": 200,
-        "content_price": {
-          "list": 199,
-          "discounted": 0
-        }
+        "list_price": 199,
       },
       "reasons": []
     }
@@ -176,10 +170,7 @@ Sample API responses
         "per_learner_spend_limit": 200,
         "remaining_balance": 9500,
         "remaining_balance_for_learner": 200,
-        "content_price": {
-          "list": 199,
-          "discounted": 0
-        }
+        "list_price": 199,
       },
       "reasons": []
     }
@@ -217,10 +208,7 @@ Sample API responses
         "per_learner_spend_limit": 200,
         "remaining_balance": 9500,
         "remaining_balance_for_learner": 200,
-        "content_price": {
-          "list": 199,
-          "discounted": 0
-        }
+        "list_price": 199,
       },
       "reasons": []
     }

--- a/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
+++ b/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
@@ -65,36 +65,6 @@ For each specified ``content_key`` (i.e., course run key), returns the following
 Sample API responses
 ^^^^^^^^^^^^^^^^^^^^
 
-::
-
-  [
-    {
-      "course_run_key": "course-v1:ImperialX+dacc003+3T2019",
-      "redemption": {
-        "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
-        "state": "committed",
-        "policy_redemption_status_url": "https://enterprise-subsidy.edx.org/api/v1/transactions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
-        "courseware_url": "https://courses.edx.org/courses/course-v1:ImperialX+dacc003+3T2019/courseware/",
-        "errors": []
-      },
-      "subsidy_access_policy": {
-        "uuid": "56744a36-93ac-4e6c-b998-a2a1899f2ae4",
-        "policy_redemption_url": "https://enterprise-access.edx.org/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
-        "policy_type": "LearnerCreditAccessPolicy",
-        "description": "Learner credit access policy",
-        "active": true,
-        "catalog_uuid": "14f701ea-7e0b-4a4e-bbda-f295e40c7bf1",
-        "subsidy_uuid": "7801b0ef-b1c2-4f3a-97fa-121f0bce48be",
-        "access_method": "direct",
-        "spent_limit": 10000,
-        "per_learner_spend_limit": 200,
-        "remaining_balance": 9500,
-        "remaining_balance_for_learner": 200
-      },
-      "reasons": []
-    }
-  ]
-
 *No redeemable subsidy access policies available to the learner:*
 
 ::
@@ -133,7 +103,11 @@ Sample API responses
         "spent_limit": 10000,
         "per_learner_spend_limit": 200,
         "remaining_balance": 9500,
-        "remaining_balance_for_learner": 200
+        "remaining_balance_for_learner": 200,
+        "content_price": {
+          "list": 199,
+          "discounted": 0
+        }
       },
       "reasons": []
     }

--- a/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
+++ b/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
@@ -26,6 +26,12 @@ the learner is already enrolled in the course (i.e., a prior redemption has been
 fulfilled) and/or which subsidy access policy should be used to redeem the course when a learner
 clicks the "Enroll" button.
 
+At a high level, this API endpoint works by iterating over all subsidy access policies associated with
+the enterprise customer for the specified learner to understand which subsidy access policies are indeed
+redeemable. It does this by calling the `can_redeem` API endpoint in `enterprise-subsidy` for each active
+subsidy access policy. In the event multiple subsidy access policies are found, this API endpoint chooses
+the preferred subsidy basked on our business rules.
+
 This API endpoint differs from the one spec'd in the 0003 Initial API Specification in that
 it makes a decision of which single subsidy access policy should be redeemed for a given course in the event
 a learner has multiple redeemable subsidy access policies. The API endpoint that's already spec'd returns a

--- a/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
+++ b/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
@@ -175,7 +175,7 @@ Sample API responses
     "errors": []
   }
 
-Retrieve the fulfillment status for a policy redemption
+GET Retrieve the fulfillment status for a policy redemption
 --------------------------------------------------------
 
 **/api/v1/enterprise-customer/<enterprise_customer_uuid>/policy/<policy_uuid>/redemptions/<redemption_uuid>/**

--- a/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
+++ b/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
@@ -1,0 +1,204 @@
+0006 API Specification for Enterprise Micro-frontends (MFEs)
+************************************************************
+
+Status
+======
+
+Accepted (March 2023)
+
+Context
+=======
+
+This document intends to outline which API endpoints exist or will exist in support of the
+Enterprise MFEs (e.g., frontend-app-learner-portal-enterprise) as well as other consumers,
+or service-to-service communication.
+
+API Endpoints
+=============
+
+Retrieve single, redeemable access policy for a course
+------------------------------------------------------
+
+**/api/v1/enterprise-customer/<enterprise_customer_uuid>/policy/can_redeem/**
+
+This API endpoint will be called by the enterprise learner portal to understand whether
+the learner is already enrolled in the course (i.e., a prior redemption has been successfully
+fulfilled) and/or which subsidy access policy should be used to redeem the course when a learner
+clicks the "Enroll" button.
+
+*Inputs:*
+
+* `lms_user_id`
+* `content_id` (i.e., course id)
+
+*Outputs:*
+
+* A single, redeemable subsidy access policy.
+* Redemption status of the single, redeemable subsidy access policy.
+
+Sample API responses
+^^^^^^^^^^^^^^^^^^^^
+
+*Redeemable subsidy access policy that has not yet been redeemed and/or fulfilled:*
+
+::
+
+  {
+    "redemption": null,
+    "subsidy_access_policy": {
+      "uuid": "56744a36-93ac-4e6c-b998-a2a1899f2ae4",
+      "policy_redemption_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
+      "policy_type": "LearnerCreditAccessPolicy",
+      "description": "Learner credit access policy",
+      "active": true,
+      "catalog_uuid": "14f701ea-7e0b-4a4e-bbda-f295e40c7bf1",
+      "subsidy_uuid": "7801b0ef-b1c2-4f3a-97fa-121f0bce48be",
+      "access_method": "direct",
+      "spent_limit": 10000,
+      "per_learner_spend_limit": 200,
+    }
+  }
+
+*Redeemable subsidy access policy that has been redeemed but is pending fulfillment:*
+
+::
+
+  {
+    "redemption": {
+      "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
+      "status": "pending",
+      "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
+      "courseware_redirect_url": null,
+      "error_status_code": null,
+      "error_message": null,
+    },
+    "subsidy_access_policy": {
+      "uuid": "56744a36-93ac-4e6c-b998-a2a1899f2ae4",
+      "policy_redemption_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
+      "policy_type": "LearnerCreditAccessPolicy",
+      "description": "Learner credit access policy",
+      "active": true,
+      "catalog_uuid": "14f701ea-7e0b-4a4e-bbda-f295e40c7bf1",
+      "subsidy_uuid": "7801b0ef-b1c2-4f3a-97fa-121f0bce48be",
+      "access_method": "direct",
+      "spent_limit": 10000,
+      "per_learner_spend_limit": 200,
+    },
+  }
+
+*Redeemable subsidy access policy that has been successfully redeemed and fulfilled:*
+
+::
+
+  {
+    "redemption": {
+      "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
+      "status": "fulfilled",
+      "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
+      "courseware_redirect_url": "https://learning.edx.org",
+      "error_status_code": null,
+      "error_message": null,
+    },
+    "subsidy_access_policy": {
+      "uuid": "56744a36-93ac-4e6c-b998-a2a1899f2ae4",
+      "policy_redemption_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
+      "policy_type": "LearnerCreditAccessPolicy",
+      "description": "Learner credit access policy",
+      "active": true,
+      "catalog_uuid": "14f701ea-7e0b-4a4e-bbda-f295e40c7bf1",
+      "subsidy_uuid": "7801b0ef-b1c2-4f3a-97fa-121f0bce48be",
+      "access_method": "direct",
+      "spent_limit": 10000,
+      "per_learner_spend_limit": 200,
+    },
+  }
+
+*Redeemable subsidy access policy that has been redeemed, but failed during fulfillment:*
+
+::
+
+  {
+    "redemption": {
+      "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
+      "status": "error",
+      "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
+      "courseware_redirect_url": null,
+      "error_status_code": 400,
+      "error_message": "Something went wrong. Please try again.",
+    },
+    "subsidy_access_policy": {
+      "uuid": "56744a36-93ac-4e6c-b998-a2a1899f2ae4",
+      "policy_redemption_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redeem/",
+      "policy_type": "LearnerCreditAccessPolicy",
+      "description": "Learner credit access policy",
+      "active": true,
+      "catalog_uuid": "14f701ea-7e0b-4a4e-bbda-f295e40c7bf1",
+      "subsidy_uuid": "7801b0ef-b1c2-4f3a-97fa-121f0bce48be",
+      "access_method": "direct",
+      "spent_limit": 10000,
+      "per_learner_spend_limit": 200,
+    },
+  }
+
+Retrieve the fulfillment status for a policy redemption
+--------------------------------------------------------
+
+**/api/v1/enterprise-customer/<enterprise_customer_uuid>/policy/<policy_uuid>/redemptions/<redemption_uuid>/**
+
+When the policy-specific `redeem` endpoint is called (e.g., when learner clicks "Enroll" button on course page), it returns
+with a redemption UUID that may be used to query against to understand the status of the redemption's fulfillment which, by
+design, may be asynchronous.
+
+As such, this API endpoint intends to be used to check the fulfillment status of a redemption to communicate to consumers that
+any side effects from the redemption have been successfully completed.
+
+*Inputs:*
+
+None other than the arguments in the URL path for the endpoint.
+
+*Outputs:*
+
+* A single, redeemable subsidy access policy.
+* Redemption status of the single, redeemable subsidy access policy.
+
+Sample API responses
+^^^^^^^^^^^^^^^^^^^^
+
+*Redemption with successful fulfillment*
+
+::
+
+  {
+    "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
+    "status": "fulfilled",
+    "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
+    "courseware_redirect_url": "https://learning.edx.org",
+    "error_status_code": null,
+    "error_message": null,
+  }
+
+*Redemption with pending fulfillment*
+
+::
+
+  {
+    "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
+    "status": "pending",
+    "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
+    "courseware_redirect_url": null,
+    "error_status_code": null,
+    "error_message": null,
+  }
+
+*Redemption with error during fulfillment*
+
+::
+
+  {
+    "uuid": "26cdce7f-b13d-46fe-a395-06d8a50932e9",
+    "status": "error",
+    "policy_redemption_status_url": "/api/v1/policy/56744a36-93ac-4e6c-b998-a2a1899f2ae4/redemptions/26cdce7f-b13d-46fe-a395-06d8a50932e9/",
+    "courseware_redirect_url": null,
+    "error_status_code": 400,
+    "error_message": "Something went wrong. Please try again.",
+  }

--- a/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
+++ b/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
@@ -26,10 +26,12 @@ the learner is already enrolled in the course (i.e., a prior redemption has been
 fulfilled) and/or which subsidy access policy should be used to redeem the course when a learner
 clicks the "Enroll" button.
 
-This API endpoint differs from the current one spec'd in the 0003 Initial API Specification in that
-it makes a decision of which subsidy access policy should be redeemed for a given course in the event
-a learner has multiple redeemable subsidy access policies. As such, less business logic is needed on
-the client (e.g., the enterprise learner portal).
+This API endpoint differs from the one spec'd in the 0003 Initial API Specification in that
+it makes a decision of which single subsidy access policy should be redeemed for a given course in the event
+a learner has multiple redeemable subsidy access policies. The API endpoint that's already spec'd returns a
+list of redeemable policies, which would mean the client  (e.g., enterprise learner portal) still requires business
+logic to make a choice of which redeemable policy to attempt a redemption. This new API endpoint would thus remove the
+need for such business logic in the client given the subsidy access policy choice is abstracted into the API layer instead.
 
 *Inputs:*
 

--- a/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
+++ b/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
@@ -85,6 +85,8 @@ Sample API responses
       "access_method": "direct",
       "spent_limit": 10000,
       "per_learner_spend_limit": 200,
+      "remaining_balance": 9500,
+      "remaining_balance_for_learner": 200
     },
     "errors": []
   }
@@ -112,6 +114,8 @@ Sample API responses
       "access_method": "direct",
       "spent_limit": 10000,
       "per_learner_spend_limit": 200,
+      "remaining_balance": 9500,
+      "remaining_balance_for_learner": 200
     },
     "errors": []
   }
@@ -139,6 +143,8 @@ Sample API responses
       "access_method": "direct",
       "spent_limit": 10000,
       "per_learner_spend_limit": 200,
+      "remaining_balance": 9500,
+      "remaining_balance_for_learner": 200
     },
     "errors": []
   }
@@ -171,11 +177,13 @@ Sample API responses
       "access_method": "direct",
       "spent_limit": 10000,
       "per_learner_spend_limit": 200,
+      "remaining_balance": 9500,
+      "remaining_balance_for_learner": 200
     },
     "errors": []
   }
 
-GET Retrieve the fulfillment status for a policy redemption
+GETRetrieve the fulfillment status for a policy redemption
 --------------------------------------------------------
 
 **/api/v1/enterprise-customer/<enterprise_customer_uuid>/policy/<policy_uuid>/redemptions/<redemption_uuid>/**

--- a/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
+++ b/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
@@ -16,7 +16,7 @@ or service-to-service communication.
 API Endpoints
 =============
 
-Retrieve single, redeemable access policy for a course
+GET Retrieve single, redeemable access policy for a course
 ------------------------------------------------------
 
 **/api/v1/enterprise-customer/<enterprise_customer_uuid>/policy/can_redeem/**
@@ -28,7 +28,7 @@ clicks the "Enroll" button.
 
 At a high level, this API endpoint works by iterating over all subsidy access policies associated with
 the enterprise customer for the specified learner to understand which subsidy access policies are indeed
-redeemable. It does this by calling the `can_redeem` API endpoint in `enterprise-subsidy` for each active
+redeemable. It does this by calling the ``can_redeem`` API endpoint in ``enterprise-subsidy`` for each active
 subsidy access policy. In the event multiple subsidy access policies are found, this API endpoint chooses
 the preferred subsidy basked on our business rules.
 
@@ -39,10 +39,10 @@ list of redeemable policies, which would mean the client  (e.g., enterprise lear
 logic to make a choice of which redeemable policy to attempt a redemption. This new API endpoint would thus remove the
 need for such business logic in the client given the subsidy access policy choice is abstracted into the API layer instead.
 
-*Inputs:*
+*Inputs (query parameters):*
 
-* `lms_user_id`
-* `content_id` (i.e., course id)
+* ``lms_user_id``
+* ``content_id`` (i.e., course id)
 
 *Outputs:*
 
@@ -185,7 +185,7 @@ with a redemption (transaction) UUID that may be used to query against to unders
 design, may be asynchronous. As such, this API endpoint intends to be used to check the fulfillment status of a redemption to communicate to consumers that
 any side effects from the redemption have been successfully completed.
 
-*Inputs:*
+*Inputs (query parameters):*
 
 None, other than the arguments in the URL path for the endpoint.
 

--- a/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
+++ b/docs/decisions/0006-api-specification-for-enterprise-mfes.rst
@@ -26,7 +26,12 @@ GET Retrieve single, redeemable access policy for a course
 This API endpoint will be called by the enterprise learner portal to understand whether
 the learner is already enrolled in the course (i.e., a prior redemption has been successfully
 fulfilled) and/or which subsidy access policy should be used to redeem the course when a learner
-clicks the "Enroll" button.
+clicks the "Enroll" button. 
+
+The course page in the enterprise learner portal displays a "Enroll" or "View course" for each course run for the course being viewed. Given
+that we're now using the redemption fulfillment status as a proxy for whether the learner is already enrolled, we will need to know the fulfillment
+status for each course run. To avoid the frontend needing to make N API requests to ``can_redeem`` (i.e., one per course run), this API endpoint will
+return the fulfillment status and a redeemable policy for each course run.
 
 At a high level, this API endpoint works by iterating over all subsidy access policies associated with
 the enterprise customer for the specified learner to understand which subsidy access policies are indeed


### PR DESCRIPTION
# Description

Adds a new ADR 0006 to describe 2 new endpoints in `enterprise-access/policy`:
1. `/api/v1/enterprise-customer/<enterprise_customer_uuid>/policy/can_redeem/`
2. `/api/v1/enterprise-customer/<enterprise_customer_uuid>/policy/<policy_uuid>/redemptions/<redemption_uuid>/`

[ADR Formatted Preview](https://github.com/openedx/enterprise-access/blob/cfcf8aa33534f17ddd84f0962390df68c6407a7f/docs/decisions/0006-api-specification-for-enterprise-mfes.rst)

**Tickets**
* [ENT-6921](https://2u-internal.atlassian.net/browse/ENT-6921)
* [ENT-6923](https://2u-internal.atlassian.net/browse/ENT-6923)