### PR TITLE
feat: redemption metadata

### DIFF
--- a/docs/decisions/0008-additional-redemption-metadata.rst
+++ b/docs/decisions/0008-additional-redemption-metadata.rst
@@ -9,12 +9,12 @@ Proposed
 Context
 =======
 
-This document intends to outline modifications to existing API endpoint(s) such that MFEs can pass additional metadata into the redemption flow. This extention was devised to support required GEAG meatadata such as DOB and terms acceptance dates.
+This document intends to outline modifications to existing API endpoint(s) such that MFEs can pass additional metadata into the redemption flow. This extension was devised to support required GEAG meatadata such as DOB and terms acceptance dates.
 
 Decision
 =======
 
-The GEAG system requires additional metadata about a learner in order to process an allocation. This additional metadata (name, dob, etc) are collected during the enrollment flow on the edX side before enrollment. This additional metadata is not persisted anywhere on the edX side. Because of the lack of persistence and the placement of this information collection on the edX side of the process we decided to create a faicility for the frontend to pass along additional metadata into the redemption flow.
+The GEAG system requires additional metadata about a learner in order to process an allocation. This additional metadata (name, dob, etc) are collected during the enrollment flow on the edX side before enrollment. This additional metadata is not persisted anywhere on the edX side. Because of the lack of persistence and the placement of this information collection on the edX side of the process we decided to create a facility for the frontend to pass along additional metadata into the redemption flow.
 
 
 POST access policy redeem transaction

--- a/docs/decisions/0008-additional-redemption-metadata.rst
+++ b/docs/decisions/0008-additional-redemption-metadata.rst
@@ -11,6 +11,12 @@ Context
 
 This document intends to outline modifications to existing API endpoint(s) such that MFEs can pass additional metadata into the redemption flow. This extention was devised to support required GEAG meatadata such as DOB and terms acceptance dates.
 
+Decision
+=======
+
+The GEAG system requires additional metadata about a learner in order to process an allocation. This additional metadata (name, dob, etc) are collected during the enrollment flow on the edX side before enrollment. This additional metadata is not persisted anywhere on the edX side. Because of the lack of persistence and the placement of this information collection on the edX side of the process we decided to create a faicility for the frontend to pass along additional metadata into the redemption flow.
+
+
 POST access policy redeem transaction
 ======================================
 **/api/v1/policy/<policy_uuid>/redeem/**
@@ -34,12 +40,15 @@ Inputs
       "metadata": {
         "geag_first_name": "Mona",
         "geag_last_name": "Lisa",
-        "geag_dob": "1503-01-01"
+        "geag_date_of_birth": "1503-01-01",
+        "geag_terms_accepted_at": "2021-05-21T17:32:28Z"
     }
   ]
 
+Consequences
+************
 
-
+The subsidy service will need to accept metadata in a similar way so that the policy service can pass the metadata along.
 
 
 .. _0003 Initial API Specification: 0003-initial-api-specification.rst

--- a/docs/decisions/0008-additional-redemption-metadata.rst
+++ b/docs/decisions/0008-additional-redemption-metadata.rst
@@ -14,7 +14,7 @@ This document intends to outline modifications to existing API endpoint(s) such 
 Decision
 =======
 
-The GetSmarter Enteprise Api Gateway (GEAG) system requires additional metadata about a learner in order to process an allocation. This additional metadata (name, dob, etc) are collected during the enrollment flow on the edX side before enrollment. This additional metadata is not persisted anywhere on the edX side. Because of the lack of persistence and the placement of this information collection on the edX side of the process we decided to create a facility for the frontend to pass along additional metadata into the redemption flow.
+The GetSmarter Enteprise Api Gateway (GEAG) system requires additional metadata about a learner in order to process an allocation. The additional metadata (name, dob, etc) is collected during the enrollment flow on the edX side before enrollment. This additional metadata is not persisted anywhere on the edX side - such as the user profile. Given these factors we have decided to create a facility for the frontend to pass along additional metadata into the redemption flow. It will pass this information onto the subsidy redemption call, returning any response. Subsidy service will be responsible for any validation or data persistence as it relates to this metadata.
 
 
 POST access policy redeem transaction

--- a/docs/decisions/0008-additional-redemption-metadata.rst
+++ b/docs/decisions/0008-additional-redemption-metadata.rst
@@ -21,7 +21,7 @@ POST access policy redeem transaction
 ======================================
 **/api/v1/policy/<policy_uuid>/redeem/**
 
-This is the existing API endpoint to eedeem subsidy value by making a request to enterprise-subsidy service.
+This is the existing API endpoint to redeem subsidy value by making a request to enterprise-subsidy service.
 
 Inputs
 ------

--- a/docs/decisions/0008-additional-redemption-metadata.rst
+++ b/docs/decisions/0008-additional-redemption-metadata.rst
@@ -9,12 +9,12 @@ Proposed
 Context
 =======
 
-This document intends to outline modifications to existing API endpoint(s) such that MFEs can pass additional metadata into the redemption flow. This extension was devised to support required GetSmarter Enteprise Api Gateway (GEAG) meatadata such as DOB and terms acceptance dates.
+This document intends to outline modifications to existing API endpoint(s) such that MFEs can pass additional metadata into the redemption flow. This extension was devised to support required GetSmarter Enterprise Api Gateway (GEAG) meatadata such as DOB and terms acceptance dates.
 
 Decision
 =======
 
-The GetSmarter Enteprise Api Gateway (GEAG) system requires additional metadata about a learner in order to process an allocation. The additional metadata (name, dob, etc) is collected during the enrollment flow on the edX side before enrollment. This additional metadata is not persisted anywhere on the edX side - such as the user profile. Given these factors we have decided to create a facility for the frontend to pass along additional metadata into the redemption flow. It will pass this information onto the subsidy redemption call, returning any response. Subsidy service will be responsible for any validation or data persistence as it relates to this metadata.
+The GetSmarter Enterprise Api Gateway (GEAG) system requires additional metadata about a learner in order to process an allocation. The additional metadata (name, dob, etc) is collected during the enrollment flow on the edX side before enrollment. This additional metadata is not persisted anywhere on the edX side - such as the user profile. Given these factors we have decided to create a facility for the frontend to pass along additional metadata into the redemption flow. It will pass this information onto the subsidy redemption call, returning any response. Subsidy service will be responsible for any validation or data persistence as it relates to this metadata.
 
 
 POST access policy redeem transaction

--- a/docs/decisions/0008-additional-redemption-metadata.rst
+++ b/docs/decisions/0008-additional-redemption-metadata.rst
@@ -9,12 +9,12 @@ Proposed
 Context
 =======
 
-This document intends to outline modifications to existing API endpoint(s) such that MFEs can pass additional metadata into the redemption flow. This extension was devised to support required GEAG meatadata such as DOB and terms acceptance dates.
+This document intends to outline modifications to existing API endpoint(s) such that MFEs can pass additional metadata into the redemption flow. This extension was devised to support required GetSmarter Enteprise Api Gateway (GEAG) meatadata such as DOB and terms acceptance dates.
 
 Decision
 =======
 
-The GEAG system requires additional metadata about a learner in order to process an allocation. This additional metadata (name, dob, etc) are collected during the enrollment flow on the edX side before enrollment. This additional metadata is not persisted anywhere on the edX side. Because of the lack of persistence and the placement of this information collection on the edX side of the process we decided to create a facility for the frontend to pass along additional metadata into the redemption flow.
+The GetSmarter Enteprise Api Gateway (GEAG) system requires additional metadata about a learner in order to process an allocation. This additional metadata (name, dob, etc) are collected during the enrollment flow on the edX side before enrollment. This additional metadata is not persisted anywhere on the edX side. Because of the lack of persistence and the placement of this information collection on the edX side of the process we decided to create a facility for the frontend to pass along additional metadata into the redemption flow.
 
 
 POST access policy redeem transaction

--- a/docs/decisions/0008-additional-redemption-metadata.rst
+++ b/docs/decisions/0008-additional-redemption-metadata.rst
@@ -1,0 +1,46 @@
+0008 Additional Metadata for Policy Redemption
+************************************************************
+
+Status
+======
+
+Proposed
+
+Context
+=======
+
+This document intends to outline modifications to existing API endpoint(s) such that MFEs can pass additional metadata into the redemption flow. This extention was devised to support required GEAG meatadata such as DOB and terms acceptance dates.
+
+POST access policy redeem transaction
+======================================
+**/api/v1/policy/<policy_uuid>/redeem/**
+
+This is the existing API endpoint to eedeem subsidy value by making a request to enterprise-subsidy service.
+
+Inputs
+------
+
+- ``enterprise_customer_uuid`` (POST data, required): The uuid of the enterprise customer.
+- ``lms_user_id`` (POST data, required): The user for whom the transaction is written and for which a enrollment should occur.
+- ``content_key`` (POST data, required): The content for which a enrollment is created.
+- ``metadata`` (POST data, optional): The new metadata dict
+::
+
+  [
+    {
+      "content_key": "course-v1:ImperialX+dacc003+3T2019",
+      "enterprise_customer_uuid": "65653029-35ec-4907-855f-85b148cdfcf7",
+      "lms_user_id": 12345,
+      "metadata": {
+        "geag_first_name": "Mona",
+        "geag_last_name": "Lisa",
+        "geag_dob": "1503-01-01"
+    }
+  ]
+
+
+
+
+
+.. _0003 Initial API Specification: 0003-initial-api-specification.rst
+.. _0006 API Specification for Enterprise Micro-frontends (MFEs): 0006-api-specification-for-enterprise-mfes.rst

--- a/enterprise_access/apps/api/serializers.py
+++ b/enterprise_access/apps/api/serializers.py
@@ -141,7 +141,7 @@ class SubsidyAccessPolicyRedeemSerializer(serializers.Serializer):  # pylint: di
     """
     learner_id = serializers.IntegerField(required=True)
     content_key = serializers.CharField(required=True)
-    metadata = serializers.JSONField(required=False)
+    metadata = serializers.JSONField(required=False, allow_null=True)
 
     def validate_content_key(self, value):
         """

--- a/enterprise_access/apps/api/serializers.py
+++ b/enterprise_access/apps/api/serializers.py
@@ -141,6 +141,7 @@ class SubsidyAccessPolicyRedeemSerializer(serializers.Serializer):  # pylint: di
     """
     learner_id = serializers.IntegerField(required=True)
     content_key = serializers.CharField(required=True)
+    metadata = serializers.JSONField(required=False)
 
     def validate_content_key(self, value):
         """

--- a/enterprise_access/apps/api/v1/tests/test_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_views.py
@@ -1671,6 +1671,31 @@ class TestSubsidyAccessPolicyRedeemViewset(TestSubsidyRequestViewSet):
         response_json = self.load_json(response.content)
         assert response_json == mock_transaction_record
 
+    def test_redeem_policy_with_metadata(self):
+        """
+        Verify that SubsidyAccessPolicyRedeemViewset redeem endpoint works as expected
+        """
+        mock_transaction_record = {
+            'uuid': str(uuid4()),
+            'status': 'committed',
+            'other': True,
+        }
+        # HTTPError would be caused by a 404, indicating that a transaction does not already exist for this policy.
+        self.redeemable_policy.get_subsidy_client.return_value.retrieve_subsidy_transaction.side_effect = HTTPError()
+        self.redeemable_policy.get_subsidy_client.return_value.create_subsidy_transaction.side_effect = None
+        self.redeemable_policy.get_subsidy_client.return_value.create_subsidy_transaction.return_value = \
+            mock_transaction_record
+        payload = {
+            'learner_id': '1234',
+            'content_key': 'course-v1:edX+edXPrivacy101+3T2020',
+            'metadata': {
+                'geag_first_name': 'John'
+            }
+        }
+        response = self.client.post(self.subsidy_access_policy_redeem_endpoint, payload)
+        response_json = self.load_json(response.content)
+        assert response_json == mock_transaction_record
+
     def test_redemption_endpoint(self):
         """
         Verify that SubsidyAccessPolicyViewset redemption endpoint works as expected

--- a/enterprise_access/apps/api/v1/views.py
+++ b/enterprise_access/apps/api/v1/views.py
@@ -1040,7 +1040,7 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
 
         learner_id = serializer.data['learner_id']
         content_key = serializer.data['content_key']
-        metadata = serializer.data.get('metadata', {})
+        metadata = serializer.data.get('metadata')
         try:
             # For now, we should lock the whole policy (i.e. pass nothing to policy.lock()).  In some cases this is more
             # aggressive than necessary, but we can optimize for performance at a later phase of this project.  At that

--- a/enterprise_access/apps/api/v1/views.py
+++ b/enterprise_access/apps/api/v1/views.py
@@ -1040,7 +1040,7 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
 
         learner_id = serializer.data['learner_id']
         content_key = serializer.data['content_key']
-        metadata = serializer.data['metadata']
+        metadata = serializer.data.get('metadata', {})
         try:
             # For now, we should lock the whole policy (i.e. pass nothing to policy.lock()).  In some cases this is more
             # aggressive than necessary, but we can optimize for performance at a later phase of this project.  At that

--- a/enterprise_access/apps/api/v1/views.py
+++ b/enterprise_access/apps/api/v1/views.py
@@ -1040,6 +1040,7 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
 
         learner_id = serializer.data['learner_id']
         content_key = serializer.data['content_key']
+        metadata = serializer.data['metadata']
         try:
             # For now, we should lock the whole policy (i.e. pass nothing to policy.lock()).  In some cases this is more
             # aggressive than necessary, but we can optimize for performance at a later phase of this project.  At that
@@ -1047,7 +1048,7 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
             # that have different locking needs can supply different lock kwargs.
             with policy.lock():
                 if policy.can_redeem(learner_id, content_key):
-                    redemption_result = policy.redeem(learner_id, content_key)
+                    redemption_result = policy.redeem(learner_id, content_key, metadata)
                     send_subsidy_redemption_event_to_event_bus(
                         SUBSIDY_REDEEMED.event_type,
                         serializer.data

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -229,6 +229,7 @@ class SubsidyAccessPolicy(TimeStampedModel):
                 lms_user_id=learner_id,
                 content_key=content_key,
                 subsidy_access_policy_uuid=self.uuid,
+                metadata=metadata,
             )
         else:
             raise ValueError(f"unknown access method {self.access_method}")

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -217,7 +217,7 @@ class SubsidyAccessPolicy(TimeStampedModel):
 
         return (True, None)
 
-    def redeem(self, learner_id, content_key, metadata={}):
+    def redeem(self, learner_id, content_key, metadata=None):
         """
         Redeem a subsidy for the given learner and content.
         Returns:

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -217,7 +217,7 @@ class SubsidyAccessPolicy(TimeStampedModel):
 
         return (True, None)
 
-    def redeem(self, learner_id, content_key):
+    def redeem(self, learner_id, content_key, metadata={}):
         """
         Redeem a subsidy for the given learner and content.
         Returns:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -154,7 +154,7 @@ edx-drf-extensions==8.4.1
     # via
     #   -r requirements/base.in
     #   edx-rbac
-edx-enterprise-subsidy-client==0.2.4
+edx-enterprise-subsidy-client==0.2.5
     # via -r requirements/base.in
 edx-opaque-keys[django]==2.3.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -239,7 +239,7 @@ edx-drf-extensions==8.4.1
     # via
     #   -r requirements/validation.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.2.4
+edx-enterprise-subsidy-client==0.2.5
     # via -r requirements/validation.txt
 edx-i18n-tools==0.9.2
     # via -r requirements/dev.in

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -235,7 +235,7 @@ edx-drf-extensions==8.4.1
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.2.4
+edx-enterprise-subsidy-client==0.2.5
     # via -r requirements/test.txt
 edx-lint==5.3.4
     # via -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -183,7 +183,7 @@ edx-drf-extensions==8.4.1
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.2.4
+edx-enterprise-subsidy-client==0.2.5
     # via -r requirements/base.txt
 edx-opaque-keys[django]==2.3.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -226,7 +226,7 @@ edx-drf-extensions==8.4.1
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.2.4
+edx-enterprise-subsidy-client==0.2.5
     # via -r requirements/test.txt
 edx-lint==5.3.4
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -213,7 +213,7 @@ edx-drf-extensions==8.4.1
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.2.4
+edx-enterprise-subsidy-client==0.2.5
     # via -r requirements/base.txt
 edx-lint==5.3.4
     # via -r requirements/test.in

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -292,7 +292,7 @@ edx-drf-extensions==8.4.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.2.4
+edx-enterprise-subsidy-client==0.2.5
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
# Description

- This PR contains an ADR and the start of what modifications would be required to enact it.
- This ADR intends to outline modifications to existing API endpoint(s) such that MFEs can pass additional metadata into the redemption flow. This extension was devised to support required GEAG meatadata such as DOB and terms acceptance dates.
- if folks generally vibe with this, I will flesh out the PR to include a full implementation

# References

- https://github.com/openedx/edx-enterprise-subsidy-client/pull/15