### PR TITLE
fix: update response for can-redeem API endpoint to remove business logic on client

### DIFF
--- a/enterprise_access/apps/api/v1/views.py
+++ b/enterprise_access/apps/api/v1/views.py
@@ -1238,10 +1238,13 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
                 resolved_policy = SubsidyAccessPolicy.resolve_policy(redeemable_policies)
                 serialized_policy = serializers.SubsidyAccessPolicyRedeemableSerializer(resolved_policy).data
 
+            has_successful_redemption = any(redemption['state'] == 'committed' for redemption in redemptions)
             can_redeem_for_content_response = {
                 "content_key": content_key,
                 "redemptions": redemptions,
-                "subsidy_access_policy": serialized_policy,
+                "has_redeemed": has_successful_redemption,
+                "redeemable_subsidy_access_policy": serialized_policy,
+                "can_redeem": bool(serialized_policy),
                 "reasons": reasons,
             }
             response.append(can_redeem_for_content_response)


### PR DESCRIPTION
# Description

In the `/api/v1/polic/enterprise-customer/<enterprise_customer_uuid>/can-redeem/` API endpoint:

* Adds missing migrations about removed models.
* Updated the model fields around per-learner enrollment and spend limits to default to `None` instead of `0` and, related, updated the `can_redeem` validation logic to account for `None`. This allows policies to be created with no limits enforced on a policy.
* Renames `subsidy_access_policy` to `redeemable_subsidy_access_policy` in the response to more clearly communicate that it is indeed redeemable to consumers.
* Adds a `can_redeem` helper boolean property in the response when `redeemable_subsidy_access_policy` is returned so that the frontend doesn't need to compute its own boolean.
* Adds a `has_successful_redemption` helper boolean property in the response so the frontend doesn't necessarily need to iterate through all redemptions in the returned list to find if one of them has `state: "committed"`. May eventually be used to determine whether learner is already enrolled. Not currently used given course page in the learner portal needs to support existing enrollments from other non-EMET (legacy) subsidies.