### PR TITLE
refactor: rename `learner_id` -> `lms_user_id`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,10 @@ lint: ## run Python code linting
 	pylint --rcfile=pylintrc enterprise_access *.py
 
 quality: style isort_check lint ## check code style and import sorting, then lint
+	@echo "\e[32mQuality tests passed!\e[0m"
 
 quality_fix: style isort lint ## Check code style, FIX any imports, then lint
+	@echo "\e[32mQuality tests passed!\e[0m"
 
 pii_check: ## check for PII annotations on all Django models
 	DJANGO_SETTINGS_MODULE=enterprise_access.settings.test \

--- a/enterprise_access/apps/api/v1/tests/test_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_views.py
@@ -1599,7 +1599,7 @@ class TestSubsidyAccessPolicyRedeemViewset(TestSubsidyRequestViewSet):
         """
         query_params = {
             'enterprise_customer_uuid': self.enterprise_uuid,
-            'learner_id': '1234',
+            'lms_user_id': '1234',
             'content_key': 'course-v1:edX+edXPrivacy101+3T2020',
         }
         response = self.client.get(SUBSIDY_ACCESS_POLICY_LIST_ENDPOINT, query_params)
@@ -1633,20 +1633,20 @@ class TestSubsidyAccessPolicyRedeemViewset(TestSubsidyRequestViewSet):
             },
             {
                 'content_key': ['This field is required.'],
-                'learner_id': ['This field is required.']
+                'lms_user_id': ['This field is required.']
             }
         ),
         (
             {
                 'enterprise_customer_uuid': '12aacfee-8ffa-4cb3-bed1-059565a57f06',
-                'learner_id': '1234',
-                'content_key': 'content_key',
+                'lms_user_id': '1234',
+                'content_key': 'invalid_content_key',
             },
-            {'content_key': ['Invalid course key: content_key']}
+            {'content_key': ['Invalid content_key: invalid_content_key']}
         ),
         (
             {
-                'learner_id': '1234',
+                'lms_user_id': '1234',
                 'content_key': 'content_key',
             },
             {'detail': 'MISSING: requests.has_learner_or_admin_access'}
@@ -1677,7 +1677,7 @@ class TestSubsidyAccessPolicyRedeemViewset(TestSubsidyRequestViewSet):
         self.redeemable_policy.get_subsidy_client.return_value.create_subsidy_transaction.return_value = \
             mock_transaction_record
         payload = {
-            'learner_id': '1234',
+            'lms_user_id': '1234',
             'content_key': 'course-v1:edX+edXPrivacy101+3T2020',
         }
         response = self.client.post(self.subsidy_access_policy_redeem_endpoint, payload)
@@ -1699,7 +1699,7 @@ class TestSubsidyAccessPolicyRedeemViewset(TestSubsidyRequestViewSet):
         self.redeemable_policy.get_subsidy_client.return_value.create_subsidy_transaction.return_value = \
             mock_transaction_record
         payload = {
-            'learner_id': '1234',
+            'lms_user_id': '1234',
             'content_key': 'course-v1:edX+edXPrivacy101+3T2020',
             'metadata': {
                 'geag_first_name': 'John'
@@ -1729,7 +1729,7 @@ class TestSubsidyAccessPolicyRedeemViewset(TestSubsidyRequestViewSet):
         }
         query_params = {
             'enterprise_customer_uuid': str(self.enterprise_uuid),
-            'learner_id': '1234',
+            'lms_user_id': '1234',
             'content_key': 'course-v1:edX+edXPrivacy101+3T2020',
         }
         response = self.client.get(self.subsidy_access_policy_redemption_endpoint, query_params)
@@ -1815,6 +1815,21 @@ class TestSubsidyAccessPolicyRedeemViewset(TestSubsidyRequestViewSet):
         # only returns 1 policy created in the setup
         assert len(response_json) == 1
 
+    def test_can_redeem_policy_missing_params(self):
+        """
+        Test that the can_redeem endpoint returns an access policy when one is redeemable.
+        """
+        self.redeemable_policy.subsidy_client.list_subsidy_transactions.return_value = {
+            'results': [],
+            'aggregates': {
+                'total_quantity': 0,
+            },
+        }
+        query_params = {}  # Test what happens when we fail to supply a list of content_keys.
+        response = self.client.get(self.subsidy_access_policy_can_redeem_endpoint, query_params)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {"content_key": ["This field is required."]}
+
     def test_can_redeem_policy(self):
         """
         Test that the can_redeem endpoint returns an access policy when one is redeemable.
@@ -1829,6 +1844,7 @@ class TestSubsidyAccessPolicyRedeemViewset(TestSubsidyRequestViewSet):
             'content_key': ['course-v1:edX+edXPrivacy101+3T2020', 'course-v1:edX+edXPrivacy101+3T2020_2'],
         }
         response = self.client.get(self.subsidy_access_policy_can_redeem_endpoint, query_params)
+        assert response.status_code == status.HTTP_200_OK
         response_list = response.json()
 
         # Make sure we got responses for all two content_keys requested.
@@ -1865,6 +1881,7 @@ class TestSubsidyAccessPolicyRedeemViewset(TestSubsidyRequestViewSet):
             'content_key': ['course-v1:edX+edXPrivacy101+3T2020', 'course-v1:edX+edXPrivacy101+3T2020_2'],
         }
         response = self.client.get(self.subsidy_access_policy_can_redeem_endpoint, query_params)
+        assert response.status_code == status.HTTP_200_OK
         response_list = response.json()
 
         # Make sure we got responses for all two content_keys requested.
@@ -1906,7 +1923,7 @@ class TestSubsidyAccessPolicyRedeemViewset(TestSubsidyRequestViewSet):
                 "uuid": test_transaction_uuid,
                 "state": TransactionStateChoices.COMMITTED,
                 "idempotency_key": "the-idempotency-key",
-                "learner_id": self.user.lms_user_id,
+                "lms_user_id": self.user.lms_user_id,
                 "content_key": "course-v1:demox+1234+2T2023",
                 "quantity": -19900,
                 "unit": "USD_CENTS",
@@ -1921,6 +1938,7 @@ class TestSubsidyAccessPolicyRedeemViewset(TestSubsidyRequestViewSet):
         }
         query_params = {'content_key': 'course-v1:demox+1234+2T2023'}
         response = self.client.get(self.subsidy_access_policy_can_redeem_endpoint, query_params)
+        assert response.status_code == status.HTTP_200_OK
         response_list = response.json()
 
         # Make sure we got responses containing existing redemptions.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -155,7 +155,7 @@ edx-drf-extensions==8.7.0
     # via
     #   -r requirements/base.in
     #   edx-rbac
-edx-enterprise-subsidy-client==0.2.5
+edx-enterprise-subsidy-client==0.2.6
     # via -r requirements/base.in
 edx-opaque-keys[django]==2.3.0
     # via
@@ -259,7 +259,7 @@ pyyaml==6.0
     #   edx-django-release-util
 redis==4.5.4
     # via -r requirements/base.in
-requests==2.28.2
+requests==2.29.0
     # via
     #   analytics-python
     #   coreapi

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -238,7 +238,7 @@ edx-drf-extensions==8.7.0
     # via
     #   -r requirements/validation.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.2.5
+edx-enterprise-subsidy-client==0.2.6
     # via -r requirements/validation.txt
 edx-i18n-tools==0.9.2
     # via -r requirements/dev.in
@@ -261,7 +261,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/validation.txt
-faker==18.5.1
+faker==18.6.0
     # via
     #   -r requirements/validation.txt
     #   factory-boy
@@ -413,7 +413,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/validation.txt
     #   jsonschema
-platformdirs==3.2.0
+platformdirs==3.5.0
     # via
     #   -r requirements/validation.txt
     #   pylint
@@ -472,7 +472,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.17.2
+pylint==2.17.3
     # via
     #   -r requirements/validation.txt
     #   edx-lint
@@ -551,7 +551,7 @@ readme-renderer==37.3
     #   twine
 redis==4.5.4
     # via -r requirements/validation.txt
-requests==2.28.2
+requests==2.29.0
     # via
     #   -r requirements/validation.txt
     #   analytics-python
@@ -576,7 +576,7 @@ rfc3986==2.0.0
     # via
     #   -r requirements/validation.txt
     #   twine
-rich==13.3.4
+rich==13.3.5
     # via
     #   -r requirements/validation.txt
     #   twine
@@ -659,7 +659,7 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via
     #   -r requirements/validation.txt
     #   pylint

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -40,7 +40,7 @@ backoff==1.10.0
     # via
     #   -r requirements/test.txt
     #   analytics-python
-beautifulsoup4==4.12.0
+beautifulsoup4==4.12.2
     # via pydata-sphinx-theme
 billiard==3.6.4.0
     # via
@@ -241,7 +241,7 @@ edx-drf-extensions==8.7.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.2.5
+edx-enterprise-subsidy-client==0.2.6
     # via -r requirements/test.txt
 edx-lint==5.3.4
     # via -r requirements/test.txt
@@ -262,7 +262,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==18.5.1
+faker==18.6.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -381,7 +381,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/test.txt
     #   jsonschema
-platformdirs==3.2.0
+platformdirs==3.5.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -436,7 +436,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.17.2
+pylint==2.17.3
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -509,7 +509,7 @@ readme-renderer==37.3
     # via -r requirements/doc.in
 redis==4.5.4
     # via -r requirements/test.txt
-requests==2.28.2
+requests==2.29.0
     # via
     #   -r requirements/test.txt
     #   analytics-python
@@ -575,7 +575,7 @@ social-auth-core==4.4.2
     #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-app-django
-soupsieve==2.4
+soupsieve==2.4.1
     # via beautifulsoup4
 sphinx==5.3.0
     # via
@@ -620,7 +620,7 @@ tomli==2.0.1
     #   pylint
     #   pytest
     #   tox
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via
     #   -r requirements/test.txt
     #   pylint

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.1.1
+pip==23.1.2
     # via -r requirements/pip.in
 setuptools==67.7.2
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -183,7 +183,7 @@ edx-drf-extensions==8.7.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.2.5
+edx-enterprise-subsidy-client==0.2.6
     # via -r requirements/base.txt
 edx-opaque-keys[django]==2.3.0
     # via
@@ -354,7 +354,7 @@ pyyaml==6.0
     #   edx-django-release-util
 redis==4.5.4
     # via -r requirements/base.txt
-requests==2.28.2
+requests==2.29.0
     # via
     #   -r requirements/base.txt
     #   analytics-python

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -225,7 +225,7 @@ edx-drf-extensions==8.7.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.2.5
+edx-enterprise-subsidy-client==0.2.6
     # via -r requirements/test.txt
 edx-lint==5.3.4
     # via
@@ -248,7 +248,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==18.5.1
+faker==18.6.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -382,7 +382,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/test.txt
     #   jsonschema
-platformdirs==3.2.0
+platformdirs==3.5.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -436,7 +436,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.17.2
+pylint==2.17.3
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -508,7 +508,7 @@ readme-renderer==37.3
     # via twine
 redis==4.5.4
     # via -r requirements/test.txt
-requests==2.28.2
+requests==2.29.0
     # via
     #   -r requirements/test.txt
     #   analytics-python
@@ -529,7 +529,7 @@ requests-toolbelt==0.10.1
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.4
+rich==13.3.5
     # via twine
 ruamel-yaml==0.17.21
     # via
@@ -602,7 +602,7 @@ tomli==2.0.1
     #   pylint
     #   pytest
     #   tox
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via
     #   -r requirements/test.txt
     #   pylint

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -212,7 +212,7 @@ edx-drf-extensions==8.7.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.2.5
+edx-enterprise-subsidy-client==0.2.6
     # via -r requirements/base.txt
 edx-lint==5.3.4
     # via -r requirements/test.in
@@ -231,7 +231,7 @@ exceptiongroup==1.1.1
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==18.5.1
+faker==18.6.0
     # via factory-boy
 fastavro==1.7.3
     # via
@@ -332,7 +332,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/base.txt
     #   jsonschema
-platformdirs==3.2.0
+platformdirs==3.5.0
     # via
     #   pylint
     #   virtualenv
@@ -374,7 +374,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.17.2
+pylint==2.17.3
     # via
     #   edx-lint
     #   pylint-celery
@@ -435,7 +435,7 @@ pyyaml==6.0
     #   edx-django-release-util
 redis==4.5.4
     # via -r requirements/base.txt
-requests==2.28.2
+requests==2.29.0
     # via
     #   -r requirements/base.txt
     #   analytics-python
@@ -513,7 +513,7 @@ tomli==2.0.1
     #   pylint
     #   pytest
     #   tox
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via pylint
 tox==3.28.0
     # via

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -291,7 +291,7 @@ edx-drf-extensions==8.7.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.2.5
+edx-enterprise-subsidy-client==0.2.6
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -323,7 +323,7 @@ factory-boy==3.2.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-faker==18.5.1
+faker==18.6.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -500,7 +500,7 @@ pkgutil-resolve-name==1.3.10
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   jsonschema
-platformdirs==3.2.0
+platformdirs==3.5.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -565,7 +565,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.17.2
+pylint==2.17.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -658,7 +658,7 @@ redis==4.5.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-requests==2.28.2
+requests==2.29.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -685,7 +685,7 @@ rfc3986==2.0.0
     # via
     #   -r requirements/quality.txt
     #   twine
-rich==13.3.4
+rich==13.3.5
     # via
     #   -r requirements/quality.txt
     #   twine
@@ -778,7 +778,7 @@ tomli==2.0.1
     #   pylint
     #   pytest
     #   tox
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
The subsidy access policy APIs should accept `lms_user_id` as a request parameter instead of `learner_id`.

Also, standardize the names of the request/response serializers used in the policy views.

Note: this PR is a breaking change to the REST API.

ENT-6988

Related PRs:
* https://github.com/openedx/enterprise-subsidy/pull/62
* https://github.com/openedx/edx-enterprise-subsidy-client/pull/16