### PR TITLE
fix: account for active flag on redeemable policies

### DIFF
--- a/enterprise_access/apps/api/v1/views.py
+++ b/enterprise_access/apps/api/v1/views.py
@@ -934,7 +934,8 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
         redeemable_policies = []
         non_redeemable_policies = defaultdict(list)
         all_policies_for_enterprise = SubsidyAccessPolicy.objects.filter(
-            enterprise_customer_uuid=enterprise_customer_uuid
+            enterprise_customer_uuid=enterprise_customer_uuid,
+            active=True,
         )
         for policy in all_policies_for_enterprise:
             redeemable, reason = policy.can_redeem(learner_id, content_key)

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -20,6 +20,7 @@ from enterprise_access.apps.subsidy_access_policy.constants import CREDIT_POLICY
 
 POLICY_LOCK_RESOURCE_NAME = "subsidy_access_policy"
 
+REASON_POLICY_NOT_ACTIVE = "Subsidy access policy is not active."
 REASON_CONTENT_NOT_IN_CATALOG = "Requested content_key not contained in policy's catalog."
 REASON_LEARNER_NOT_IN_ENTERPRISE = "Learner not part of enterprise associated with the access policy."
 REASON_NOT_ENOUGH_VALUE_IN_SUBSIDY = "Not enough remaining value in subsidy to redeem requested content."
@@ -207,6 +208,8 @@ class SubsidyAccessPolicy(TimeStampedModel):
         """
         Check that a given learner can redeem the given content.
         """
+        if not self.active:
+            return (False, REASON_POLICY_NOT_ACTIVE)
         if not self.catalog_client.contains_content_items(self.catalog_uuid, [content_key]):
             return (False, REASON_CONTENT_NOT_IN_CATALOG)
         # TODO: can we rely on JWT roles to check this?
@@ -375,8 +378,12 @@ class PerLearnerEnrollmentCreditAccessPolicy(SubsidyAccessPolicy, CreditPolicyMi
         Checks if the given learner_id has a number of existing subsidy transactions
         LTE to the learner enrollment cap declared by this policy.
         """
-        has_per_learner_enrollment_limit = self.per_learner_enrollment_limit is not None
+        # perform generic access checks
+        should_attempt_redemption, reason = super().can_redeem(learner_id, content_key)
+        if not should_attempt_redemption:
+            return (False, reason)
 
+        has_per_learner_enrollment_limit = self.per_learner_enrollment_limit is not None
         if has_per_learner_enrollment_limit:
             # only retrieve transactions if there is a per-learner enrollment limit
             learner_transactions_count = len(self.transactions_for_learner(learner_id)['transactions'])
@@ -384,8 +391,8 @@ class PerLearnerEnrollmentCreditAccessPolicy(SubsidyAccessPolicy, CreditPolicyMi
             if learner_transactions_count >= self.per_learner_enrollment_limit:
                 return (False, REASON_LEARNER_MAX_ENROLLMENTS_REACHED)
 
-        # learner can redeem the subsidy access policy, so perform the generic access checks
-        return super().can_redeem(learner_id, content_key)
+        # learner can redeem the subsidy access policy
+        return (True, None)
 
     def credit_available(self, learner_id=None):
         if self.remaining_balance_per_user(learner_id) > 0:
@@ -420,6 +427,11 @@ class PerLearnerSpendCreditAccessPolicy(SubsidyAccessPolicy, CreditPolicyMixin):
         Determines whether learner can redeem a subsidy access policy given the
         limits specified on the policy.
         """
+        # perform generic access checks
+        should_attempt_redemption, reason = super().can_redeem(learner_id, content_key)
+        if not should_attempt_redemption:
+            return (False, reason)
+
         has_per_learner_spend_limit = self.per_learner_spend_limit is not None
         if has_per_learner_spend_limit:
             # only retrieve transactions if there is a per-learner spend limit
@@ -433,8 +445,8 @@ class PerLearnerSpendCreditAccessPolicy(SubsidyAccessPolicy, CreditPolicyMixin):
             if (spent_amount + course_price) >= self.per_learner_spend_limit:
                 return (False, REASON_LEARNER_MAX_SPEND_REACHED)
 
-        # learner can redeem the subsidy access policy, so perform the generic access checks
-        return super().can_redeem(learner_id, content_key)
+        # learner can redeem the subsidy access policy
+        return (True, None)
 
     def credit_available(self, learner_id=None):
         return self.remaining_balance_per_user(learner_id) > 0

--- a/enterprise_access/apps/subsidy_access_policy/tests/factories.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/factories.py
@@ -27,6 +27,7 @@ class SubsidyAccessPolicyFactory(factory.django.DjangoModelFactory):
     catalog_uuid = factory.LazyFunction(uuid4)
     subsidy_uuid = factory.LazyFunction(uuid4)
     access_method = AccessMethods.DIRECT
+    active = True
 
 
 class PerLearnerEnrollmentCapLearnerCreditAccessPolicyFactory(SubsidyAccessPolicyFactory):


### PR DESCRIPTION
The `subsidy-access-policy` app considers inactive (i.e., `active=False`) policies as redeemable. For example, calling the `http://localhost:18270/api/v1/policy/enterprise-customer/a067aacd-667d-4bd6-81e2-e332ef5ca1cd/can-redeem/?content_key=course-v1%3AedX%2BS2023%2B1T2023` endpoint, which has a policy marked as `active=False` that is otherwise redeemable, returns the inactive policy, which is not correct given `active=False`.

To fix this, we first check the generic `can_redeem` defined in the extended `SubsidyAccessPolicy` model before checking the policy-specific `can_redeem` business rules.

This ensures policies with `active=False` don't attempt to validate their own business (i.e., having to make API calls to `enterprise-subsidy`, etc.) if the policy isn't active to begin with.
