### PR TITLE
feat: lay down some drf-spec basics. ENT-6948

### DIFF
--- a/enterprise_access/apps/api/serializers.py
+++ b/enterprise_access/apps/api/serializers.py
@@ -266,8 +266,15 @@ class SubsidyAccessPolicyCanRedeemRequestSerializer(ValidateContentKeyMixin, ser
 
     For view: SubsidyAccessPolicyRedeemViewset.can_redeem
     """
-    enterprise_customer_uuid = serializers.UUIDField(required=True)
-    content_key = serializers.ListField(child=serializers.CharField(required=True), allow_empty=False)
+    # enterprise_customer_uuid = serializers.UUIDField(
+    #     required=False,
+    #     help_text='The enterprise customer UUID under which policies will be queried for redeemability.',
+    # )
+    content_key = serializers.ListField(
+        child=serializers.CharField(required=True),
+        allow_empty=False,
+        help_text='Content keys about which redeemability will be queried.',
+    )
 
 
 class SubsidyAccessPolicyRedeemableResponseSerializer(serializers.ModelSerializer):

--- a/enterprise_access/apps/api/v1/views/browse_and_request.py
+++ b/enterprise_access/apps/api/v1/views/browse_and_request.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.db.models import Count
 from django_filters.rest_framework import DjangoFilterBackend
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from edx_rbac.decorators import permission_required
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from requests.exceptions import ConnectionError as RequestConnectionError
@@ -189,6 +190,24 @@ class SubsidyRequestViewSet(UserDetailsFromJwtMixin, viewsets.ModelViewSet):
         return Response(requests_overview, status=status.HTTP_200_OK)
 
 
+@extend_schema_view(
+    retrieve=extend_schema(
+        tags=['License Requests'],
+        summary='License request retrieve.',
+    ),
+    list=extend_schema(
+        tags=['License Requests'],
+        summary='License request list.',
+    ),
+    create=extend_schema(
+        tags=['License Requests'],
+        summary='License request create.',
+    ),
+    overview=extend_schema(
+        tags=['License Requests'],
+        summary='License request overview.',
+    ),
+)
 class LicenseRequestViewSet(SubsidyRequestViewSet):
     """
     Viewset for license requests
@@ -269,6 +288,10 @@ class LicenseRequestViewSet(SubsidyRequestViewSet):
             )
             raise SubsidyRequestError(error_msg, status.HTTP_422_UNPROCESSABLE_ENTITY)
 
+    @extend_schema(
+        tags=['License Requests'],
+        summary='License request approve.',
+    )
     @permission_required(
         constants.REQUESTS_ADMIN_ACCESS_PERMISSION,
         fn=get_enterprise_uuid_from_request_data,
@@ -343,6 +366,10 @@ class LicenseRequestViewSet(SubsidyRequestViewSet):
             status=status.HTTP_200_OK,
         )
 
+    @extend_schema(
+        tags=['License Requests'],
+        summary='License request deny.',
+    )
     @permission_required(
         constants.REQUESTS_ADMIN_ACCESS_PERMISSION,
         fn=get_enterprise_uuid_from_request_data,
@@ -426,6 +453,24 @@ class LicenseRequestViewSet(SubsidyRequestViewSet):
         )
 
 
+@extend_schema_view(
+    retrieve=extend_schema(
+        tags=['Coupon Code Requests'],
+        summary='Coupon Code request retrieve.',
+    ),
+    list=extend_schema(
+        tags=['Coupon Code Requests'],
+        summary='Coupon Code request list.',
+    ),
+    create=extend_schema(
+        tags=['Coupon Code Requests'],
+        summary='Coupon Code request create.',
+    ),
+    overview=extend_schema(
+        tags=['Coupon Code Requests'],
+        summary='Coupon Code request overview.',
+    ),
+)
 class CouponCodeRequestViewSet(SubsidyRequestViewSet):
     """
     Viewset for coupon code requests
@@ -479,6 +524,10 @@ class CouponCodeRequestViewSet(SubsidyRequestViewSet):
             error_msg = 'Not enough codes available for coupon {coupon_id} to approve the requests'
             raise SubsidyRequestError(error_msg, status.HTTP_422_UNPROCESSABLE_ENTITY)
 
+    @extend_schema(
+        tags=['Coupon Code Requests'],
+        summary='Coupon Code request approve.',
+    )
     @permission_required(
         constants.REQUESTS_ADMIN_ACCESS_PERMISSION,
         fn=get_enterprise_uuid_from_request_data,
@@ -556,6 +605,10 @@ class CouponCodeRequestViewSet(SubsidyRequestViewSet):
             status=status.HTTP_200_OK,
         )
 
+    @extend_schema(
+        tags=['Coupon Code Requests'],
+        summary='Coupon Code request deny.',
+    )
     @action(detail=False, url_path='decline', methods=['post'])
     def decline(self, *args, **kwargs):
         """
@@ -637,6 +690,16 @@ class CouponCodeRequestViewSet(SubsidyRequestViewSet):
         )
 
 
+@extend_schema_view(
+    retrieve=extend_schema(
+        tags=['Subsidy Request Configuration'],
+        summary='Retrieve customer config.',
+    ),
+    list=extend_schema(
+        tags=['Subsidy Request Configuration'],
+        summary='List customer config.',
+    ),
+)
 class SubsidyRequestCustomerConfigurationViewSet(UserDetailsFromJwtMixin, viewsets.ModelViewSet):
     """ Viewset for customer configurations."""
 
@@ -653,6 +716,10 @@ class SubsidyRequestCustomerConfigurationViewSet(UserDetailsFromJwtMixin, viewse
 
     http_method_names = ['get', 'post', 'patch']
 
+    @extend_schema(
+        tags=['Subsidy Request Configuration'],
+        summary='Create customer config.',
+    )
     @permission_required(
         constants.REQUESTS_ADMIN_ACCESS_PERMISSION,
         fn=get_enterprise_uuid_from_request_data,
@@ -666,6 +733,10 @@ class SubsidyRequestCustomerConfigurationViewSet(UserDetailsFromJwtMixin, viewse
         )
         return response
 
+    @extend_schema(
+        tags=['Subsidy Request Configuration'],
+        summary='Update customer config.',
+    )
     @permission_required(
         constants.REQUESTS_ADMIN_ACCESS_PERMISSION,
         fn=lambda request, pk: pk

--- a/enterprise_access/urls.py
+++ b/enterprise_access/urls.py
@@ -22,9 +22,8 @@ from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
 from django.urls import path
-from drf_spectacular.views import SpectacularAPIView
+from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 from edx_api_doc_tools import make_api_info, make_docs_urls
-from rest_framework_swagger.views import get_swagger_view
 
 from enterprise_access.apps.api import urls as api_urls
 from enterprise_access.apps.core import views as core_views
@@ -32,14 +31,27 @@ from enterprise_access.apps.core import views as core_views
 api_info = make_api_info(title="Enterprise Access API", version="v1")
 admin.autodiscover()
 
+spectacular_view = SpectacularAPIView(
+    api_version='v1',
+    title='enterprise-access spectacular view',
+)
+
+spec_swagger_view = SpectacularSwaggerView()
+
+spec_redoc_view = SpectacularRedocView(
+    title='Redoc view for the enterprise-access API.',
+    url_name='schema',
+)
+
 urlpatterns = oauth2_urlpatterns + make_docs_urls(api_info) + [
     url(r'^admin/', admin.site.urls),
     url(r'^api/', include(api_urls)),
-    url(r'^api-docs/', get_swagger_view(title='enterprise-access API')),
+    url(r'^api-docs/', spec_swagger_view.as_view(), name='swagger-ui'),
     url(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
     url(r'', include('csrf.urls')),  # Include csrf urls from edx-drf-extensions
     url(r'^health/$', core_views.health, name='health'),
-    path('api/schema/', SpectacularAPIView.as_view(), name='openapi_schema'),
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('api/schema/redoc/', spec_redoc_view.as_view(url_name='schema'), name='redoc'),
 ]
 
 if settings.DEBUG and os.environ.get('ENABLE_DJANGO_TOOLBAR', False):  # pragma: no cover


### PR DESCRIPTION
It's spec-tac-u-lahhh!

To test:
- checkout this branch
- make sure devserver reloads
- Visit http://localhost:18270/api-docs/ (swagger docs at existing route, but powered by drf-spec now, so some things work a little nicer)
- Visit http://localhost:18270/api/schema/redoc/, observe the glory

![image](https://user-images.githubusercontent.com/2307986/235760915-dde2ef31-f03f-47d3-9782-7bea437cfa14.png)

I've tidy-d up the `can_redeem` docstring for now to render a little cleaner - it'll need some follow-up work to get its complicated/nested response serialization represented with a serializer class.
