### PR TITLE
feat: use reason slugs and add `user_message` field in `can-redeem` response

### DIFF
--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -556,7 +556,7 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
             REASON_LEARNER_MAX_ENROLLMENTS_REACHED: MissingSubsidyAccessReasonUserMessages.LEARNER_LIMITS_REACHED,
         }
 
-        if not MISSING_SUBSIDY_ACCESS_POLICY_REASONS[reason_slug]:
+        if not reason_slug in MISSING_SUBSIDY_ACCESS_POLICY_REASONS:
             return None
 
         return MISSING_SUBSIDY_ACCESS_POLICY_REASONS[reason_slug]

--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -556,7 +556,7 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
             REASON_LEARNER_MAX_ENROLLMENTS_REACHED: MissingSubsidyAccessReasonUserMessages.LEARNER_LIMITS_REACHED,
         }
 
-        if not reason_slug in MISSING_SUBSIDY_ACCESS_POLICY_REASONS:
+        if reason_slug not in MISSING_SUBSIDY_ACCESS_POLICY_REASONS:
             return None
 
         return MISSING_SUBSIDY_ACCESS_POLICY_REASONS[reason_slug]

--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -35,12 +35,12 @@ from enterprise_access.apps.events.utils import (
 )
 from enterprise_access.apps.subsidy_access_policy.constants import (
     POLICY_TYPES_WITH_CREDIT_LIMIT,
-    REASON_POLICY_NOT_ACTIVE,
     REASON_CONTENT_NOT_IN_CATALOG,
+    REASON_LEARNER_MAX_ENROLLMENTS_REACHED,
+    REASON_LEARNER_MAX_SPEND_REACHED,
     REASON_LEARNER_NOT_IN_ENTERPRISE,
     REASON_NOT_ENOUGH_VALUE_IN_SUBSIDY,
-    REASON_LEARNER_MAX_SPEND_REACHED,
-    REASON_LEARNER_MAX_ENROLLMENTS_REACHED,
+    REASON_POLICY_NOT_ACTIVE,
     MissingSubsidyAccessReasonUserMessages,
     TransactionStateChoices
 )

--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -26,6 +26,7 @@ from rest_framework.response import Response
 
 from enterprise_access.apps.api import filters, serializers, utils
 from enterprise_access.apps.api.mixins import UserDetailsFromJwtMixin
+from enterprise_access.apps.api_client.lms_client import LmsApiClient
 from enterprise_access.apps.core.constants import POLICY_READ_PERMISSION
 from enterprise_access.apps.events.signals import ACCESS_POLICY_CREATED, ACCESS_POLICY_UPDATED, SUBSIDY_REDEEMED
 from enterprise_access.apps.events.utils import (
@@ -33,8 +34,14 @@ from enterprise_access.apps.events.utils import (
     send_subsidy_redemption_event_to_event_bus
 )
 from enterprise_access.apps.subsidy_access_policy.constants import (
-    MISSING_SUBSIDY_ACCESS_POLICY_REASONS,
     POLICY_TYPES_WITH_CREDIT_LIMIT,
+    REASON_POLICY_NOT_ACTIVE,
+    REASON_CONTENT_NOT_IN_CATALOG,
+    REASON_LEARNER_NOT_IN_ENTERPRISE,
+    REASON_NOT_ENOUGH_VALUE_IN_SUBSIDY,
+    REASON_LEARNER_MAX_SPEND_REACHED,
+    REASON_LEARNER_MAX_ENROLLMENTS_REACHED,
+    MissingSubsidyAccessReasonUserMessages,
     TransactionStateChoices
 )
 from enterprise_access.apps.subsidy_access_policy.models import (
@@ -525,11 +532,31 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
             status=status.HTTP_200_OK,
         )
 
-    def _get_user_message_for_reason(self, reason_slug):
+    def _get_user_message_for_reason(self, reason_slug, enterprise_admin_users):
         """
         Return the user-facing message for a given reason slug.
         """
-        if not reason_slug or not MISSING_SUBSIDY_ACCESS_POLICY_REASONS[reason_slug]:
+        if not reason_slug:
+            return None
+
+        has_enterprise_admin_users = len(enterprise_admin_users) > 0
+
+        user_message_organization_no_funds = (
+            MissingSubsidyAccessReasonUserMessages.ORGANIZATION_NO_FUNDS
+            if has_enterprise_admin_users
+            else MissingSubsidyAccessReasonUserMessages.ORGANIZATION_NO_FUNDS_NO_ADMINS
+        )
+
+        MISSING_SUBSIDY_ACCESS_POLICY_REASONS = {
+            REASON_POLICY_NOT_ACTIVE: user_message_organization_no_funds,
+            REASON_CONTENT_NOT_IN_CATALOG: user_message_organization_no_funds,
+            REASON_LEARNER_NOT_IN_ENTERPRISE: user_message_organization_no_funds,
+            REASON_NOT_ENOUGH_VALUE_IN_SUBSIDY: user_message_organization_no_funds,
+            REASON_LEARNER_MAX_SPEND_REACHED: MissingSubsidyAccessReasonUserMessages.LEARNER_LIMITS_REACHED,
+            REASON_LEARNER_MAX_ENROLLMENTS_REACHED: MissingSubsidyAccessReasonUserMessages.LEARNER_LIMITS_REACHED,
+        }
+
+        if not MISSING_SUBSIDY_ACCESS_POLICY_REASONS[reason_slug]:
             return None
 
         return MISSING_SUBSIDY_ACCESS_POLICY_REASONS[reason_slug]
@@ -631,10 +658,16 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
                 enterprise_customer_uuid, lms_user_id, content_key
             )
             if not redemptions and not redeemable_policies:
+                lms_client = LmsApiClient()
+                enterprise_customer_data = lms_client.get_enterprise_customer_data(enterprise_customer_uuid)
+                enterprise_admin_users = enterprise_customer_data.get('admin_users')
                 for reason, policies in non_redeemable_policies.items():
                     reasons.append({
                         "reason": reason,
-                        "user_message": self._get_user_message_for_reason(reason),
+                        "user_message": self._get_user_message_for_reason(reason, enterprise_admin_users),
+                        "metadata": {
+                            "enterprise_administrators": enterprise_admin_users,
+                        },
                         "policy_uuids": [policy.uuid for policy in policies],
                     })
             if redeemable_policies:

--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -33,6 +33,7 @@ from enterprise_access.apps.events.utils import (
     send_subsidy_redemption_event_to_event_bus
 )
 from enterprise_access.apps.subsidy_access_policy.constants import (
+    MISSING_SUBSIDY_ACCESS_POLICY_REASONS,
     POLICY_TYPES_WITH_CREDIT_LIMIT,
     TransactionStateChoices
 )
@@ -524,6 +525,15 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
             status=status.HTTP_200_OK,
         )
 
+    def _get_user_message_for_reason(self, reason_slug):
+        """
+        Return the user-facing message for a given reason slug.
+        """
+        if not reason_slug or not MISSING_SUBSIDY_ACCESS_POLICY_REASONS[reason_slug]:
+            return None
+
+        return MISSING_SUBSIDY_ACCESS_POLICY_REASONS[reason_slug]
+
     @extend_schema(
         tags=['Subsidy Access Policy Redemption'],
         summary='Can redeem.',
@@ -624,6 +634,7 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
                 for reason, policies in non_redeemable_policies.items():
                     reasons.append({
                         "reason": reason,
+                        "user_message": self._get_user_message_for_reason(reason),
                         "policy_uuids": [policy.uuid for policy in policies],
                     })
             if redeemable_policies:

--- a/enterprise_access/apps/subsidy_access_policy/constants.py
+++ b/enterprise_access/apps/subsidy_access_policy/constants.py
@@ -79,3 +79,31 @@ class TransactionStateChoices:
     PENDING = 'pending'
     COMMITTED = 'committed'
     FAILED = 'failed'
+
+
+class MissingSubsidyAccessReasonUserMessages:
+    """
+    User-friendly display messages explaining why the learner does not have subsidized access.
+    """
+    ORGANIZATION_NO_FUNDS = "You can't enroll right now because your organization doesn't have enough funds."
+    ORGANIZATION_NO_FUNDS_NO_ADMIN_CONTACT = \
+        "You can't enroll right now because your organization doesn't have enough funds. " \
+        "Contact your administrator to request more."
+    LEARNER_LIMITS_REACHED = "You can't enroll right now because of limits set by your organization."
+
+
+REASON_POLICY_NOT_ACTIVE = "policy_not_active"
+REASON_CONTENT_NOT_IN_CATALOG = "content_not_in_catalog"
+REASON_LEARNER_NOT_IN_ENTERPRISE = "learner_not_in_enterprise"
+REASON_NOT_ENOUGH_VALUE_IN_SUBSIDY = "not_enough_value_in_subsidy"
+REASON_LEARNER_MAX_SPEND_REACHED = "learner_max_spend_reached"
+REASON_LEARNER_MAX_ENROLLMENTS_REACHED = "learner_max_enrollments_reached"
+
+MISSING_SUBSIDY_ACCESS_POLICY_REASONS = {
+    REASON_POLICY_NOT_ACTIVE: MissingSubsidyAccessReasonUserMessages.ORGANIZATION_NO_FUNDS,
+    REASON_CONTENT_NOT_IN_CATALOG: MissingSubsidyAccessReasonUserMessages.ORGANIZATION_NO_FUNDS,
+    REASON_LEARNER_NOT_IN_ENTERPRISE: MissingSubsidyAccessReasonUserMessages.ORGANIZATION_NO_FUNDS,
+    REASON_NOT_ENOUGH_VALUE_IN_SUBSIDY: MissingSubsidyAccessReasonUserMessages.ORGANIZATION_NO_FUNDS,
+    REASON_LEARNER_MAX_SPEND_REACHED: MissingSubsidyAccessReasonUserMessages.LEARNER_LIMITS_REACHED,
+    REASON_LEARNER_MAX_ENROLLMENTS_REACHED: MissingSubsidyAccessReasonUserMessages.LEARNER_LIMITS_REACHED,
+}

--- a/enterprise_access/apps/subsidy_access_policy/constants.py
+++ b/enterprise_access/apps/subsidy_access_policy/constants.py
@@ -86,7 +86,7 @@ class MissingSubsidyAccessReasonUserMessages:
     User-friendly display messages explaining why the learner does not have subsidized access.
     """
     ORGANIZATION_NO_FUNDS = "You can't enroll right now because your organization doesn't have enough funds."
-    ORGANIZATION_NO_FUNDS_NO_ADMIN_CONTACT = \
+    ORGANIZATION_NO_FUNDS_NO_ADMINS = \
         "You can't enroll right now because your organization doesn't have enough funds. " \
         "Contact your administrator to request more."
     LEARNER_LIMITS_REACHED = "You can't enroll right now because of limits set by your organization."
@@ -98,12 +98,3 @@ REASON_LEARNER_NOT_IN_ENTERPRISE = "learner_not_in_enterprise"
 REASON_NOT_ENOUGH_VALUE_IN_SUBSIDY = "not_enough_value_in_subsidy"
 REASON_LEARNER_MAX_SPEND_REACHED = "learner_max_spend_reached"
 REASON_LEARNER_MAX_ENROLLMENTS_REACHED = "learner_max_enrollments_reached"
-
-MISSING_SUBSIDY_ACCESS_POLICY_REASONS = {
-    REASON_POLICY_NOT_ACTIVE: MissingSubsidyAccessReasonUserMessages.ORGANIZATION_NO_FUNDS,
-    REASON_CONTENT_NOT_IN_CATALOG: MissingSubsidyAccessReasonUserMessages.ORGANIZATION_NO_FUNDS,
-    REASON_LEARNER_NOT_IN_ENTERPRISE: MissingSubsidyAccessReasonUserMessages.ORGANIZATION_NO_FUNDS,
-    REASON_NOT_ENOUGH_VALUE_IN_SUBSIDY: MissingSubsidyAccessReasonUserMessages.ORGANIZATION_NO_FUNDS,
-    REASON_LEARNER_MAX_SPEND_REACHED: MissingSubsidyAccessReasonUserMessages.LEARNER_LIMITS_REACHED,
-    REASON_LEARNER_MAX_ENROLLMENTS_REACHED: MissingSubsidyAccessReasonUserMessages.LEARNER_LIMITS_REACHED,
-}

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -17,17 +17,18 @@ from simple_history.models import HistoricalRecords
 
 from enterprise_access.apps.api_client.enterprise_catalog_client import EnterpriseCatalogApiClient
 from enterprise_access.apps.api_client.lms_client import LmsApiClient
-from enterprise_access.apps.subsidy_access_policy.constants import CREDIT_POLICY_TYPE_PRIORITY, AccessMethods
+from enterprise_access.apps.subsidy_access_policy.constants import (
+    CREDIT_POLICY_TYPE_PRIORITY,
+    REASON_CONTENT_NOT_IN_CATALOG,
+    REASON_LEARNER_MAX_ENROLLMENTS_REACHED,
+    REASON_LEARNER_MAX_SPEND_REACHED,
+    REASON_LEARNER_NOT_IN_ENTERPRISE,
+    REASON_NOT_ENOUGH_VALUE_IN_SUBSIDY,
+    REASON_POLICY_NOT_ACTIVE,
+    AccessMethods
+)
 
 POLICY_LOCK_RESOURCE_NAME = "subsidy_access_policy"
-
-REASON_POLICY_NOT_ACTIVE = "Subsidy access policy is not active."
-REASON_CONTENT_NOT_IN_CATALOG = "Requested content_key not contained in policy's catalog."
-REASON_LEARNER_NOT_IN_ENTERPRISE = "Learner not part of enterprise associated with the access policy."
-REASON_NOT_ENOUGH_VALUE_IN_SUBSIDY = "Not enough remaining value in subsidy to redeem requested content."
-REASON_LEARNER_MAX_SPEND_REACHED = "The learner's maximum spend in this subsidy access policy has been reached."
-REASON_LEARNER_MAX_ENROLLMENTS_REACHED = \
-    "The learner's maximum number of enrollments given by this subsidy access policy has been reached."
 
 
 class SubsidyAccessPolicyLockAttemptFailed(Exception):

--- a/enterprise_access/apps/subsidy_access_policy/tests/test_models.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/test_models.py
@@ -11,6 +11,14 @@ from django.core.cache import cache as django_cache
 from django.test import TestCase
 
 from enterprise_access.apps.core.tests.factories import UserFactory
+from enterprise_access.apps.subsidy_access_policy.constants import (
+    REASON_CONTENT_NOT_IN_CATALOG,
+    REASON_LEARNER_MAX_ENROLLMENTS_REACHED,
+    REASON_LEARNER_MAX_SPEND_REACHED,
+    REASON_LEARNER_NOT_IN_ENTERPRISE,
+    REASON_NOT_ENOUGH_VALUE_IN_SUBSIDY,
+    REASON_POLICY_NOT_ACTIVE
+)
 from enterprise_access.apps.subsidy_access_policy.models import (
     PerLearnerEnrollmentCreditAccessPolicy,
     PerLearnerSpendCreditAccessPolicy,
@@ -152,7 +160,7 @@ class SubsidyAccessPolicyTests(TestCase):
             'enterprise_contains_learner': True,
             'subsidy_is_redeemable': True,
             'transactions_for_learner': {'results': [], 'aggregates': {}},
-            'expected_policy_can_redeem': (False, "Requested content_key not contained in policy's catalog."),
+            'expected_policy_can_redeem': (False, REASON_CONTENT_NOT_IN_CATALOG),
         },
         {
             # Learner is not in the enterprise, every other check would succeed.
@@ -162,7 +170,7 @@ class SubsidyAccessPolicyTests(TestCase):
             'enterprise_contains_learner': False,
             'subsidy_is_redeemable': True,
             'transactions_for_learner': {'results': [], 'aggregates': {}},
-            'expected_policy_can_redeem': (False, 'Learner not part of enterprise associated with the access policy.'),
+            'expected_policy_can_redeem': (False, REASON_LEARNER_NOT_IN_ENTERPRISE),
         },
         {
             # The subsidy is not redeemable, every other check would succeed.
@@ -172,7 +180,7 @@ class SubsidyAccessPolicyTests(TestCase):
             'enterprise_contains_learner': True,
             'subsidy_is_redeemable': False,
             'transactions_for_learner': {'results': [], 'aggregates': {}},
-            'expected_policy_can_redeem': (False, 'Not enough remaining value in subsidy to redeem requested content.'),
+            'expected_policy_can_redeem': (False, REASON_NOT_ENOUGH_VALUE_IN_SUBSIDY),
         },
         {
             # The subsidy is redeemable, but the learner has already enrolled more than the limit.
@@ -186,10 +194,7 @@ class SubsidyAccessPolicyTests(TestCase):
                 'results': [{'foo': 'bar'} for _ in range(10)],
                 'aggregates': {'total_quantity': 100}
             },
-            'expected_policy_can_redeem': (
-                False,
-                "The learner's maximum number of enrollments given by this subsidy access policy has been reached."
-            ),
+            'expected_policy_can_redeem': (False, REASON_LEARNER_MAX_ENROLLMENTS_REACHED),
         },
         {
             # The subsidy access policy is not active, every other check would succeed.
@@ -199,10 +204,7 @@ class SubsidyAccessPolicyTests(TestCase):
             'enterprise_contains_learner': True,
             'subsidy_is_redeemable': True,
             'transactions_for_learner': {'results': [], 'aggregates': {}},
-            'expected_policy_can_redeem': (
-                False,
-                "Subsidy access policy is not active."
-            ),
+            'expected_policy_can_redeem': (False, REASON_POLICY_NOT_ACTIVE),
         },
     )
     @ddt.unpack
@@ -253,7 +255,7 @@ class SubsidyAccessPolicyTests(TestCase):
             'enterprise_contains_learner': True,
             'subsidy_is_redeemable': True,
             'transactions_for_learner': {'results': [], 'aggregates': {}},
-            'expected_policy_can_redeem': (False, "Requested content_key not contained in policy's catalog."),
+            'expected_policy_can_redeem': (False, REASON_CONTENT_NOT_IN_CATALOG),
         },
         {
             # Learner is not in the enterprise, every other check would succeed.
@@ -263,7 +265,7 @@ class SubsidyAccessPolicyTests(TestCase):
             'enterprise_contains_learner': False,
             'subsidy_is_redeemable': True,
             'transactions_for_learner': {'results': [], 'aggregates': {}},
-            'expected_policy_can_redeem': (False, 'Learner not part of enterprise associated with the access policy.'),
+            'expected_policy_can_redeem': (False, REASON_LEARNER_NOT_IN_ENTERPRISE),
         },
         {
             # The subsidy is not redeemable, every other check would succeed.
@@ -273,7 +275,7 @@ class SubsidyAccessPolicyTests(TestCase):
             'enterprise_contains_learner': True,
             'subsidy_is_redeemable': False,
             'transactions_for_learner': {'results': [], 'aggregates': {}},
-            'expected_policy_can_redeem': (False, 'Not enough remaining value in subsidy to redeem requested content.'),
+            'expected_policy_can_redeem': (False, REASON_NOT_ENOUGH_VALUE_IN_SUBSIDY),
         },
         {
             # The subsidy is redeemable, but the learner has already enrolled more than the limit.
@@ -287,10 +289,7 @@ class SubsidyAccessPolicyTests(TestCase):
                 'results': [{'foo': 'bar'}],
                 'aggregates': {'total_quantity': 50000}
             },
-            'expected_policy_can_redeem': (
-                False,
-                "The learner's maximum spend in this subsidy access policy has been reached."
-            ),
+            'expected_policy_can_redeem': (False, REASON_LEARNER_MAX_SPEND_REACHED),
         },
         {
             # The subsidy access policy is not active, every other check would succeed.
@@ -300,10 +299,7 @@ class SubsidyAccessPolicyTests(TestCase):
             'enterprise_contains_learner': True,
             'subsidy_is_redeemable': True,
             'transactions_for_learner': {'results': [], 'aggregates': {}},
-            'expected_policy_can_redeem': (
-                False,
-                "Subsidy access policy is not active."
-            ),
+            'expected_policy_can_redeem': (False, REASON_POLICY_NOT_ACTIVE),
         },
     )
     @ddt.unpack


### PR DESCRIPTION
* Uses a unique reason slug as the `reason` attribute.
* Generates a `user_message` for each reason based on the reason slug.
  * The UI (learner portal MFE course page) will use the `user_message` for display in the below screenshots.

Related PRs:
* https://github.com/openedx/frontend-app-learner-portal-enterprise/pull/732

<img width="275" alt="image" src="https://github.com/openedx/enterprise-access/assets/2828721/100ff88f-db05-4a5c-84d7-8f0e8dbc0745">

<img width="272" alt="image" src="https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/2828721/f23dd21f-0290-4a5e-b823-a0323a31c770">

<img width="268" alt="image" src="https://github.com/openedx/enterprise-access/assets/2828721/66f2239d-87cd-4b56-858b-1d2505049ed7">

Sample response payload:

```json
[{
	"content_key": "course-v1:edX+CTL.SC2x+1T2023a",
	"redemptions": [],
	"has_successful_redemption": false,
	"redeemable_subsidy_access_policy": null,
	"can_redeem": false,
	"reasons": [{
		"reason": "learner_max_spend_reached",
		"user_message": "You can't enroll right now because of limits set by your organization.",
		"metadata": {
			"enterprise_administrators": [{
				"email": "edx@example.com",
				"lms_user_id": 3
			}]
		},
		"policy_uuids": [
			"c6fa5898-9a51-4425-8198-263378762a20"
		]
	}]
}]
```