### PR TITLE
feat: define a discrete permission for policy redemption, add auth unit tests

### DIFF
--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -29,7 +29,11 @@ from rest_framework.response import Response
 from enterprise_access.apps.api import filters, serializers, utils
 from enterprise_access.apps.api.mixins import UserDetailsFromJwtMixin
 from enterprise_access.apps.api_client.lms_client import LmsApiClient
-from enterprise_access.apps.core.constants import POLICY_READ_PERMISSION
+from enterprise_access.apps.core.constants import (
+    POLICY_READ_PERMISSION,
+    POLICY_REDEMPTION_PERMISSION,
+    REQUESTS_ADMIN_LEARNER_ACCESS_PERMISSION
+)
 from enterprise_access.apps.events.signals import ACCESS_POLICY_CREATED, ACCESS_POLICY_UPDATED, SUBSIDY_REDEEMED
 from enterprise_access.apps.events.utils import (
     send_access_policy_event_to_event_bus,
@@ -135,7 +139,7 @@ class SubsidyAccessPolicyCRUDViewset(PermissionRequiredMixin, viewsets.ModelView
     pagination_class = PaginationWithPageCount
     http_method_names = ['get', 'post', 'patch', 'delete']
     lookup_field = 'uuid'
-    permission_required = 'requests.has_admin_access'
+    permission_required = REQUESTS_ADMIN_LEARNER_ACCESS_PERMISSION
 
     @property
     def requested_enterprise_customer_uuid(self):
@@ -255,7 +259,7 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
     authentication_classes = [JwtAuthentication]
     permission_classes = [permissions.IsAuthenticated]
     lookup_url_kwarg = 'policy_uuid'
-    permission_required = 'requests.has_learner_or_admin_access'
+    permission_required = POLICY_REDEMPTION_PERMISSION
     http_method_names = ['get', 'post']
 
     @classmethod

--- a/enterprise_access/apps/core/constants.py
+++ b/enterprise_access/apps/core/constants.py
@@ -14,6 +14,7 @@ REQUESTS_ADMIN_LEARNER_ACCESS_PERMISSION = 'requests.has_learner_or_admin_access
 POLICY_ADMIN_ROLE = 'enterprise_access_subsidy_access_policy_admin'
 POLICY_LEARNER_ROLE = 'enterprise_access_subsidy_access_policy_learner'
 POLICY_READ_PERMISSION = 'policy.has_read_access'
+POLICY_REDEMPTION_PERMISSION = 'policy.has_redemption_access'
 
 ALL_ACCESS_CONTEXT = '*'
 

--- a/enterprise_access/apps/core/rules.py
+++ b/enterprise_access/apps/core/rules.py
@@ -174,3 +174,9 @@ rules.add_perm(
     constants.POLICY_READ_PERMISSION,
     has_subsidy_access_policy_admin_access | has_subsidy_access_policy_learner_access
 )
+
+# Grants policy redemption permission if the user is a policy learner or admin
+rules.add_perm(
+    constants.POLICY_REDEMPTION_PERMISSION,
+    has_subsidy_access_policy_admin_access | has_subsidy_access_policy_learner_access
+)


### PR DESCRIPTION
Will make a separate PR for unit testing auth on the CRUD views.

https://2u-internal.atlassian.net/browse/ENT-6994