### PR TITLE
refactor: stop caching oauth clients, cleanup test code, use mock from std lib

### DIFF
--- a/enterprise_access/apps/api/tests/test_tasks.py
+++ b/enterprise_access/apps/api/tests/test_tasks.py
@@ -2,10 +2,10 @@
 Tests for Enterprise Access API tasks.
 """
 
+from unittest import mock
 from uuid import uuid4
 
 import ddt
-import mock
 
 from enterprise_access.apps.api.serializers import CouponCodeRequestSerializer, LicenseRequestSerializer
 from enterprise_access.apps.api.tasks import (

--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -1,7 +1,6 @@
 """
 REST API views for the subsidy_access_policy app.
 """
-import functools
 import logging
 import os
 from collections import defaultdict
@@ -262,20 +261,15 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
     permission_required = POLICY_REDEMPTION_PERMISSION
     http_method_names = ['get', 'post']
 
-    @classmethod
-    @functools.lru_cache(maxsize=None)
-    def get_subsidy_client(cls):
+    @property
+    def subsidy_client(self):
         """
-        A process-cached EnterpriseSubsidyAPIClient instance.
+        An EnterpriseSubsidyAPIClient instance.
         """
         kwargs = {}
         if getattr(settings, 'ENTERPRISE_SUBSIDY_API_CLIENT_VERSION', None):
             kwargs['version'] = int(settings.ENTERPRISE_SUBSIDY_API_CLIENT_VERSION)
         return get_enterprise_subsidy_api_client(**kwargs)
-
-    @property
-    def subsidy_client(self):
-        return self.get_subsidy_client()
 
     @property
     def enterprise_customer_uuid(self):

--- a/enterprise_access/apps/api_client/tests/test_discovery_client.py
+++ b/enterprise_access/apps/api_client/tests/test_discovery_client.py
@@ -2,7 +2,8 @@
 Tests for Discovery client.
 """
 
-import mock
+from unittest import mock
+
 from django.conf import settings
 from django.test import TestCase
 from requests import Response

--- a/enterprise_access/apps/api_client/tests/test_ecommerce_client.py
+++ b/enterprise_access/apps/api_client/tests/test_ecommerce_client.py
@@ -2,7 +2,8 @@
 Tests for Ecommerce client.
 """
 
-import mock
+from unittest import mock
+
 from django.conf import settings
 from django.test import TestCase
 from requests import Response

--- a/enterprise_access/apps/api_client/tests/test_enterprise_catalog_client.py
+++ b/enterprise_access/apps/api_client/tests/test_enterprise_catalog_client.py
@@ -2,7 +2,8 @@
 Tests for Discovery client.
 """
 
-import mock
+from unittest import mock
+
 from django.test import TestCase
 from requests import Response
 

--- a/enterprise_access/apps/api_client/tests/test_license_manager_client.py
+++ b/enterprise_access/apps/api_client/tests/test_license_manager_client.py
@@ -2,7 +2,8 @@
 Tests for License Manager client.
 """
 
-import mock
+from unittest import mock
+
 from django.conf import settings
 from django.test import TestCase
 from requests import Response

--- a/enterprise_access/apps/api_client/tests/test_lms_client.py
+++ b/enterprise_access/apps/api_client/tests/test_lms_client.py
@@ -2,9 +2,9 @@
 Tests for License Manager client.
 """
 
+from unittest import mock
 from uuid import uuid4
 
-import mock
 from django.conf import settings
 from django.test import TestCase
 from requests import Response

--- a/enterprise_access/apps/core/tests/test_views.py
+++ b/enterprise_access/apps/core/tests/test_views.py
@@ -1,6 +1,7 @@
 """Test core.views."""
 
-import mock
+from unittest import mock
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import DatabaseError

--- a/enterprise_access/apps/events/tests/test_data.py
+++ b/enterprise_access/apps/events/tests/test_data.py
@@ -1,9 +1,9 @@
 """
 Tests for data module in events django application.
 """
+from unittest import mock
 from uuid import uuid4
 
-import mock
 from django.test import TestCase
 from faker import Faker
 

--- a/enterprise_access/apps/events/tests/test_utils.py
+++ b/enterprise_access/apps/events/tests/test_utils.py
@@ -1,10 +1,10 @@
 """
 Unit tests for the utility functions.
 """
+from unittest import mock
 from unittest.mock import ANY
 from uuid import uuid4
 
-import mock
 from confluent_kafka.error import ValueSerializationError
 from django.conf import settings
 from django.test import TestCase

--- a/enterprise_access/apps/subsidy_access_policy/mocks.py
+++ b/enterprise_access/apps/subsidy_access_policy/mocks.py
@@ -1,6 +1,6 @@
 """ Mock clients for subsidy_access_policy models. """
 
-import mock
+from unittest import mock
 
 
 class group_client():

--- a/enterprise_access/apps/subsidy_request/management/commands/tests/test_send_admins_email_with_new_requests.py
+++ b/enterprise_access/apps/subsidy_request/management/commands/tests/test_send_admins_email_with_new_requests.py
@@ -2,9 +2,9 @@
 Tests for Subsidy Request Management commands.
 """
 from datetime import datetime
+from unittest import mock
 from uuid import uuid4
 
-import mock
 from django.conf import settings
 from django.core.management import call_command
 from pytest import mark

--- a/enterprise_access/apps/subsidy_request/tests/test_admin.py
+++ b/enterprise_access/apps/subsidy_request/tests/test_admin.py
@@ -1,6 +1,7 @@
 """Test subsidy_requests.admin"""
 
-import mock
+from unittest import mock
+
 from django.contrib.admin.sites import AdminSite
 from django.http import HttpRequest
 

--- a/enterprise_access/apps/subsidy_request/tests/test_utils.py
+++ b/enterprise_access/apps/subsidy_request/tests/test_utils.py
@@ -1,6 +1,7 @@
 """Test subsidy_requests.utils"""
 
-import mock
+from unittest import mock
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sessions.middleware import SessionMiddleware

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -90,9 +90,9 @@ django==3.2.19
     #   jsonfield2
     #   openedx-events
     #   social-auth-app-django
-django-celery-results==2.5.0
+django-celery-results==2.5.1
     # via -r requirements/base.in
-django-cors-headers==3.14.0
+django-cors-headers==4.0.0
     # via -r requirements/base.in
 django-crum==0.7.9
     # via
@@ -206,7 +206,7 @@ oauthlib==3.2.2
     #   social-auth-core
 openapi-codec==1.3.2
     # via django-rest-swagger
-openedx-events==7.1.0
+openedx-events==7.2.0
     # via -r requirements/base.in
 packaging==23.1
     # via drf-yasg
@@ -226,7 +226,7 @@ pycryptodomex==3.17
     # via pyjwkest
 pyjwkest==1.4.2
     # via edx-drf-extensions
-pyjwt[crypto]==2.6.0
+pyjwt[crypto]==2.7.0
     # via
     #   drf-jwt
     #   edx-auth-backends
@@ -270,7 +270,7 @@ requests==2.30.0
     #   social-auth-core
 requests-oauthlib==1.3.1
     # via social-auth-core
-ruamel-yaml==0.17.24
+ruamel-yaml==0.17.26
     # via drf-yasg
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -163,9 +163,9 @@ django==3.2.19
     #   jsonfield2
     #   openedx-events
     #   social-auth-app-django
-django-celery-results==2.5.0
+django-celery-results==2.5.1
     # via -r requirements/validation.txt
-django-cors-headers==3.14.0
+django-cors-headers==4.0.0
     # via -r requirements/validation.txt
 django-crum==0.7.9
     # via
@@ -205,7 +205,7 @@ djangorestframework==3.14.0
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-drf-extensions
-docutils==0.19
+docutils==0.20
     # via
     #   -r requirements/validation.txt
     #   readme-renderer
@@ -261,7 +261,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/validation.txt
-faker==18.6.2
+faker==18.7.0
     # via
     #   -r requirements/validation.txt
     #   factory-boy
@@ -362,8 +362,6 @@ mdurl==0.1.2
     # via
     #   -r requirements/validation.txt
     #   markdown-it-py
-mock==5.0.2
-    # via -r requirements/validation.txt
 monotonic==1.6
     # via
     #   -r requirements/validation.txt
@@ -387,7 +385,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/validation.txt
     #   django-rest-swagger
-openedx-events==7.1.0
+openedx-events==7.2.0
     # via -r requirements/validation.txt
 packaging==23.1
     # via
@@ -413,7 +411,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/validation.txt
     #   jsonschema
-platformdirs==3.5.0
+platformdirs==3.5.1
     # via
     #   -r requirements/validation.txt
     #   pylint
@@ -464,7 +462,7 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.6.0
+pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/validation.txt
     #   drf-jwt
@@ -580,7 +578,7 @@ rich==13.3.5
     # via
     #   -r requirements/validation.txt
     #   twine
-ruamel-yaml==0.17.24
+ruamel-yaml==0.17.26
     # via
     #   -r requirements/validation.txt
     #   drf-yasg

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -159,9 +159,9 @@ django==3.2.19
     #   jsonfield2
     #   openedx-events
     #   social-auth-app-django
-django-celery-results==2.5.0
+django-celery-results==2.5.1
     # via -r requirements/test.txt
-django-cors-headers==3.14.0
+django-cors-headers==4.0.0
     # via -r requirements/test.txt
 django-crum==0.7.9
     # via
@@ -260,7 +260,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==18.6.2
+faker==18.7.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -338,8 +338,6 @@ mccabe==0.7.0
     # via
     #   -r requirements/test.txt
     #   pylint
-mock==5.0.2
-    # via -r requirements/test.txt
 monotonic==1.6
     # via
     #   -r requirements/test.txt
@@ -359,7 +357,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
-openedx-events==7.1.0
+openedx-events==7.2.0
     # via -r requirements/test.txt
 packaging==23.1
     # via
@@ -377,7 +375,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/test.txt
     #   jsonschema
-platformdirs==3.5.0
+platformdirs==3.5.1
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -424,7 +422,7 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.6.0
+pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/test.txt
     #   drf-jwt
@@ -523,7 +521,7 @@ requests-oauthlib==1.3.1
     #   social-auth-core
 restructuredtext-lint==1.4.0
     # via doc8
-ruamel-yaml==0.17.24
+ruamel-yaml==0.17.26
     # via
     #   -r requirements/test.txt
     #   drf-yasg

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -116,9 +116,9 @@ django==3.2.19
     #   jsonfield2
     #   openedx-events
     #   social-auth-app-django
-django-celery-results==2.5.0
+django-celery-results==2.5.1
     # via -r requirements/base.txt
-django-cors-headers==3.14.0
+django-cors-headers==4.0.0
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -270,7 +270,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-openedx-events==7.1.0
+openedx-events==7.2.0
     # via -r requirements/base.txt
 packaging==23.1
     # via
@@ -308,7 +308,7 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.6.0
+pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/base.txt
     #   drf-jwt
@@ -369,7 +369,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-ruamel-yaml==0.17.24
+ruamel-yaml==0.17.26
     # via
     #   -r requirements/base.txt
     #   drf-yasg

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -150,9 +150,9 @@ django==3.2.19
     #   jsonfield2
     #   openedx-events
     #   social-auth-app-django
-django-celery-results==2.5.0
+django-celery-results==2.5.1
     # via -r requirements/test.txt
-django-cors-headers==3.14.0
+django-cors-headers==4.0.0
     # via -r requirements/test.txt
 django-crum==0.7.9
     # via
@@ -192,7 +192,7 @@ djangorestframework==3.14.0
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-drf-extensions
-docutils==0.19
+docutils==0.20
     # via readme-renderer
 drf-jwt==1.19.2
     # via
@@ -246,7 +246,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==18.6.2
+faker==18.7.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -337,8 +337,6 @@ mccabe==0.7.0
     #   pylint
 mdurl==0.1.2
     # via markdown-it-py
-mock==5.0.2
-    # via -r requirements/test.txt
 monotonic==1.6
     # via
     #   -r requirements/test.txt
@@ -360,7 +358,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
-openedx-events==7.1.0
+openedx-events==7.2.0
     # via -r requirements/test.txt
 packaging==23.1
     # via
@@ -378,7 +376,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/test.txt
     #   jsonschema
-platformdirs==3.5.0
+platformdirs==3.5.1
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -424,7 +422,7 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.6.0
+pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/test.txt
     #   drf-jwt
@@ -527,7 +525,7 @@ rfc3986==2.0.0
     # via twine
 rich==13.3.5
     # via twine
-ruamel-yaml==0.17.24
+ruamel-yaml==0.17.26
     # via
     #   -r requirements/test.txt
     #   drf-yasg

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -9,7 +9,6 @@ ddt
 django-dynamic-fixture    # library to create dynamic model instances for testing purposes
 edx-lint
 factory-boy
-mock
 pytest-cov
 pytest-django
 tox

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -139,9 +139,9 @@ distlib==0.3.6
     #   jsonfield2
     #   openedx-events
     #   social-auth-app-django
-django-celery-results==2.5.0
+django-celery-results==2.5.1
     # via -r requirements/base.txt
-django-cors-headers==3.14.0
+django-cors-headers==4.0.0
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -229,7 +229,7 @@ exceptiongroup==1.1.1
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==18.6.2
+faker==18.7.0
     # via factory-boy
 fastavro==1.7.4
     # via
@@ -291,8 +291,6 @@ markupsafe==2.1.2
     #   jinja2
 mccabe==0.7.0
     # via pylint
-mock==5.0.2
-    # via -r requirements/test.in
 monotonic==1.6
     # via
     #   -r requirements/base.txt
@@ -312,7 +310,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-openedx-events==7.1.0
+openedx-events==7.2.0
     # via -r requirements/base.txt
 packaging==23.1
     # via
@@ -328,7 +326,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/base.txt
     #   jsonschema
-platformdirs==3.5.0
+platformdirs==3.5.1
     # via
     #   pylint
     #   virtualenv
@@ -362,7 +360,7 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.6.0
+pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/base.txt
     #   drf-jwt
@@ -446,7 +444,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-ruamel-yaml==0.17.24
+ruamel-yaml==0.17.26
     # via
     #   -r requirements/base.txt
     #   drf-yasg

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -182,11 +182,11 @@ django==3.2.19
     #   jsonfield2
     #   openedx-events
     #   social-auth-app-django
-django-celery-results==2.5.0
+django-celery-results==2.5.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-django-cors-headers==3.14.0
+django-cors-headers==4.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -242,7 +242,7 @@ djangorestframework==3.14.0
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-drf-extensions
-docutils==0.19
+docutils==0.20
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
@@ -323,7 +323,7 @@ factory-boy==3.2.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-faker==18.6.2
+faker==18.7.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -442,10 +442,6 @@ mdurl==0.1.2
     # via
     #   -r requirements/quality.txt
     #   markdown-it-py
-mock==5.0.2
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
 monotonic==1.6
     # via
     #   -r requirements/quality.txt
@@ -475,7 +471,7 @@ openapi-codec==1.3.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django-rest-swagger
-openedx-events==7.1.0
+openedx-events==7.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -500,7 +496,7 @@ pkgutil-resolve-name==1.3.10
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   jsonschema
-platformdirs==3.5.0
+platformdirs==3.5.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -556,7 +552,7 @@ pyjwkest==1.4.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.6.0
+pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -689,7 +685,7 @@ rich==13.3.5
     # via
     #   -r requirements/quality.txt
     #   twine
-ruamel-yaml==0.17.24
+ruamel-yaml==0.17.26
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -9,8 +9,8 @@ in multiple test modules (i.e. factoryboy factories, base test classes).
 So this package is the place to put them.
 """
 import json
+from unittest import mock
 
-import mock
 from django.test import TestCase
 from django.test.client import RequestFactory
 from edx_rest_framework_extensions.auth.jwt.cookies import jwt_cookie_name


### PR DESCRIPTION
caching the clients does little in terms of performance and creates lots of testing headaches.

Furthermore, `unittest.mock` is the correct mock to use.  Stop installing it from pip.