### PR TITLE
fix: list price on `can-redeem` API endpoint

### DIFF
--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -368,7 +368,7 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
         Setup mocks for different api clients.
         """
         subsidy_client_path = (
-            'enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.subsidy_client'
+            'enterprise_access.apps.subsidy_access_policy.models.get_versioned_subsidy_client'
         )
         subsidy_client_patcher = mock.patch(subsidy_client_path)
         subsidy_client = subsidy_client_patcher.start()
@@ -650,14 +650,14 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
         }
         test_content_key_1 = "course-v1:edX+edXPrivacy101+3T2020"
         test_content_key_2 = "course-v1:edX+edXPrivacy101+3T2020_2"
-        test_content_key_1_metadata_price = "12.34"
-        test_content_key_2_metadata_price = "56.78"
-        test_content_key_1_float_price = 12.34
-        test_content_key_2_float_price = 56.78
-        test_content_key_1_cents_price = 1234
-        test_content_key_2_cents_price = 5678
+        test_content_key_1_metadata_price = 29900
+        test_content_key_2_metadata_price = 81900
+        test_content_key_1_usd_price = 299
+        test_content_key_2_usd_price = 819
+        test_content_key_1_cents_price = 29900
+        test_content_key_2_cents_price = 81900
 
-        def mock_get_subsidy_content_data(*args, **kwargs):
+        def mock_get_subsidy_content_data(*args):
             if test_content_key_1 in args:
                 return {
                     "content_uuid": str(uuid4()),
@@ -691,7 +691,7 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
         # Check the response for the first content_key given.
         assert response_list[0]["content_key"] == test_content_key_1
         assert response_list[0]["list_price"] == {
-            "usd": test_content_key_1_float_price,
+            "usd": test_content_key_1_usd_price,
             "usd_cents": test_content_key_1_cents_price,
         }
         assert len(response_list[0]["redemptions"]) == 0
@@ -703,7 +703,7 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
         # Check the response for the second content_key given.
         assert response_list[1]["content_key"] == test_content_key_2
         assert response_list[1]["list_price"] == {
-            "usd": test_content_key_2_float_price,
+            "usd": test_content_key_2_usd_price,
             "usd_cents": test_content_key_2_cents_price,
         }
         assert len(response_list[1]["redemptions"]) == 0
@@ -738,12 +738,12 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
         self.redeemable_policy.subsidy_client.can_redeem.return_value = False
         test_content_key_1 = "course-v1:edX+edXPrivacy101+3T2020"
         test_content_key_2 = "course-v1:edX+edXPrivacy101+3T2020_2"
-        test_content_key_1_metadata_price = "12.34"
-        test_content_key_2_metadata_price = "56.78"
-        test_content_key_1_float_price = 12.34
-        test_content_key_2_float_price = 56.78
-        test_content_key_1_cents_price = 1234
-        test_content_key_2_cents_price = 5678
+        test_content_key_1_metadata_price = 29900
+        test_content_key_2_metadata_price = 81900
+        test_content_key_1_usd_price = 299
+        test_content_key_2_usd_price = 819
+        test_content_key_1_cents_price = 29900
+        test_content_key_2_cents_price = 81900
 
         def mock_get_subsidy_content_data(*args, **kwargs):
             if test_content_key_1 in args:
@@ -779,7 +779,7 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
         # Check the response for the first content_key given.
         assert response_list[0]["content_key"] == test_content_key_1
         assert response_list[0]["list_price"] == {
-            "usd": test_content_key_1_float_price,
+            "usd": test_content_key_1_usd_price,
             "usd_cents": test_content_key_1_cents_price,
         }
         assert len(response_list[0]["redemptions"]) == 0
@@ -808,7 +808,7 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
         # Check the response for the second content_key given.
         assert response_list[1]["content_key"] == test_content_key_2
         assert response_list[1]["list_price"] == {
-            "usd": test_content_key_2_float_price,
+            "usd": test_content_key_2_usd_price,
             "usd_cents": test_content_key_2_cents_price,
         }
         assert len(response_list[1]["redemptions"]) == 0
@@ -855,7 +855,7 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
             "content_uuid": str(uuid4()),
             "content_key": "course-v1:demox+1234+2T2023",
             "source": "edX",
-            "content_price": "199.00",
+            "content_price": 19900,
         }
 
         query_params = {'content_key': 'course-v1:demox+1234+2T2023'}

--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -669,7 +669,7 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
                 list_price_integer_cents = content_metadata["content_price"]
                 # TODO: simplify this function by consolidating this conversion logic into the response serializer:
                 if list_price_integer_cents is not None:
-                    list_price_decimal_dollars = float(list_price_integer_cents / 100)
+                    list_price_decimal_dollars = float(list_price_integer_cents) / 100
                 else:
                     list_price_decimal_dollars = None
             except requests.exceptions.HTTPError:

--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -665,16 +665,13 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
             # Determine the price for content for display purposes only.
             try:
                 content_metadata = self.subsidy_client.get_subsidy_content_data(enterprise_customer_uuid, content_key)
-                # Note that the "content_price" key is guaranteed to exist, but the value may be None.  Also, the
-                # upstream field type is a string representing a decimal dollar.
-                list_price_decimal_dollars_str = content_metadata["content_price"]
+                # Note that the "content_price" key is guaranteed to exist, but the value may be None.
+                list_price_integer_cents = content_metadata["content_price"]
                 # TODO: simplify this function by consolidating this conversion logic into the response serializer:
-                if list_price_decimal_dollars_str:
-                    list_price_decimal_dollars = float(list_price_decimal_dollars_str)
-                    list_price_integer_cents = int(list_price_decimal_dollars * 100)
+                if list_price_integer_cents is not None:
+                    list_price_decimal_dollars = float(list_price_integer_cents / 100)
                 else:
                     list_price_decimal_dollars = None
-                    list_price_integer_cents = None
             except requests.exceptions.HTTPError:
                 # No need to record a failure reason here because evaluate_policies() -> policy.can_redeem() already
                 # caught any problematic or non-existent content keys, and provided a reason it could not be redeemed.

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -138,7 +138,6 @@ class SubsidyAccessPolicy(TimeStampedModel):
         """
         An EnterpriseSubsidyAPIClient instance.
         """
-        print('subsidy client!!!', get_versioned_subsidy_client, get_versioned_subsidy_client())
         return get_versioned_subsidy_client()
 
     @property

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -5,7 +5,6 @@ import sys
 from contextlib import contextmanager
 from uuid import UUID, uuid4
 
-from django.conf import settings
 from django.core.cache import cache as django_cache
 from django.db import models
 from django_extensions.db.models import TimeStampedModel
@@ -27,6 +26,7 @@ from enterprise_access.apps.subsidy_access_policy.constants import (
 from enterprise_access.apps.subsidy_access_policy.utils import get_versioned_subsidy_client
 
 POLICY_LOCK_RESOURCE_NAME = "subsidy_access_policy"
+
 
 class SubsidyAccessPolicyLockAttemptFailed(Exception):
     """

--- a/enterprise_access/apps/subsidy_access_policy/utils.py
+++ b/enterprise_access/apps/subsidy_access_policy/utils.py
@@ -1,0 +1,8 @@
+from django.conf import settings
+from edx_enterprise_subsidy_client import get_enterprise_subsidy_api_client
+
+def get_versioned_subsidy_client():
+    kwargs = {}
+    if getattr(settings, 'ENTERPRISE_SUBSIDY_API_CLIENT_VERSION', None):
+        kwargs['version'] = int(settings.ENTERPRISE_SUBSIDY_API_CLIENT_VERSION)
+    return get_enterprise_subsidy_api_client(**kwargs)

--- a/enterprise_access/apps/subsidy_access_policy/utils.py
+++ b/enterprise_access/apps/subsidy_access_policy/utils.py
@@ -1,7 +1,15 @@
+"""
+Utils for subsidy_access_policy
+"""
 from django.conf import settings
 from edx_enterprise_subsidy_client import get_enterprise_subsidy_api_client
 
+
 def get_versioned_subsidy_client():
+    """
+    Returns an instance of the enterprise subsidy client as the version specified by the
+    Django setting `ENTERPRISE_SUBSIDY_API_CLIENT_VERSION`, if any.
+    """
     kwargs = {}
     if getattr(settings, 'ENTERPRISE_SUBSIDY_API_CLIENT_VERSION', None):
         kwargs['version'] = int(settings.ENTERPRISE_SUBSIDY_API_CLIENT_VERSION)


### PR DESCRIPTION
Current implementation assumes the upstream `content_price` from subsidy will be a string like `"299.00"`; however, the `content_metadata` [API endpoint](https://enterprise-subsidy.edx.org/api/schema/redoc/#tag/api/operation/api_v1_content_metadata_retrieve) in subsidy returns USD cents like `29900`.

This PR updates the `list_price` API field in enterprise-access's `can-redeem` API response to return the correct denominations of USD and USD cents, e.g.:

```json
[{
	"list_price": {
		"usd": 299,
		"usd_cents": 29900
	}
}]
```

instead of the current state of saying the course is $29,900 USD:

```json
[{
	"list_price": {
		"usd": 29900,
		"usd_cents": 2990000
	}
}]
```