### PR TITLE
fix: update UX messages for non redeemable policies

### DIFF
--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -572,12 +572,12 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
 
         MISSING_SUBSIDY_ACCESS_POLICY_REASONS = {
             REASON_POLICY_NOT_ACTIVE: user_message_organization_no_funds,
-            REASON_CONTENT_NOT_IN_CATALOG: user_message_organization_no_funds,
-            REASON_LEARNER_NOT_IN_ENTERPRISE: user_message_organization_no_funds,
             REASON_NOT_ENOUGH_VALUE_IN_SUBSIDY: user_message_organization_no_funds,
             REASON_POLICY_SPEND_LIMIT_REACHED: user_message_organization_no_funds,
+            REASON_LEARNER_NOT_IN_ENTERPRISE: MissingSubsidyAccessReasonUserMessages.LEARNER_NOT_IN_ENTERPRISE,
             REASON_LEARNER_MAX_SPEND_REACHED: MissingSubsidyAccessReasonUserMessages.LEARNER_LIMITS_REACHED,
             REASON_LEARNER_MAX_ENROLLMENTS_REACHED: MissingSubsidyAccessReasonUserMessages.LEARNER_LIMITS_REACHED,
+            REASON_CONTENT_NOT_IN_CATALOG: MissingSubsidyAccessReasonUserMessages.CONTENT_NOT_IN_CATALOG,
         }
 
         if reason_slug not in MISSING_SUBSIDY_ACCESS_POLICY_REASONS:

--- a/enterprise_access/apps/subsidy_access_policy/admin.py
+++ b/enterprise_access/apps/subsidy_access_policy/admin.py
@@ -5,5 +5,48 @@ from django.contrib import admin
 
 from enterprise_access.apps.subsidy_access_policy import models
 
-admin.site.register(models.PerLearnerEnrollmentCreditAccessPolicy)
-admin.site.register(models.PerLearnerSpendCreditAccessPolicy)
+
+class BaseSubsidyAccessPolicyMixin(admin.ModelAdmin):
+    """
+    Mixin for common admin properties on subsidy access policy models.
+    """
+    list_display = (
+        'uuid',
+        'active',
+        'enterprise_customer_uuid',
+        'catalog_uuid',
+        'subsidy_uuid',
+        'access_method',
+        'spend_limit',
+    )
+    list_filter = (
+        'active',
+        'access_method',
+        'subsidy_uuid',
+    )
+    search_fields = (
+        'uuid',
+        'enterprise_customer_uuid',
+        'catalog_uuid',
+        'subsidy_uuid',
+    )
+
+
+@admin.register(models.PerLearnerEnrollmentCreditAccessPolicy)
+class PerLearnerEnrollmentCreditAccessPolicy(BaseSubsidyAccessPolicyMixin):
+    """
+    Admin configuration for PerLearnerEnrollmentCreditAccessPolicy.
+    """
+    list_display = BaseSubsidyAccessPolicyMixin.list_display + (
+        'per_learner_enrollment_limit',
+    )
+
+
+@admin.register(models.PerLearnerSpendCreditAccessPolicy)
+class PerLearnerSpendCreditAccessPolicy(BaseSubsidyAccessPolicyMixin):
+    """
+    Admin configuration for PerLearnerEnrollmentCreditAccessPolicy.
+    """
+    list_display = BaseSubsidyAccessPolicyMixin.list_display + (
+        'per_learner_spend_limit',
+    )

--- a/enterprise_access/apps/subsidy_access_policy/admin.py
+++ b/enterprise_access/apps/subsidy_access_policy/admin.py
@@ -44,7 +44,7 @@ class PerLearnerEnrollmentCreditAccessPolicy(BaseSubsidyAccessPolicyMixin):
 @admin.register(models.PerLearnerSpendCreditAccessPolicy)
 class PerLearnerSpendCreditAccessPolicy(BaseSubsidyAccessPolicyMixin):
     """
-    Admin configuration for PerLearnerEnrollmentCreditAccessPolicy.
+    Admin configuration for PerLearnerSpendCreditAccessPolicy.
     """
     list_display = BaseSubsidyAccessPolicyMixin.list_display + (
         'per_learner_spend_limit',

--- a/enterprise_access/apps/subsidy_access_policy/admin.py
+++ b/enterprise_access/apps/subsidy_access_policy/admin.py
@@ -22,7 +22,6 @@ class BaseSubsidyAccessPolicyMixin(admin.ModelAdmin):
     list_filter = (
         'active',
         'access_method',
-        'subsidy_uuid',
     )
     search_fields = (
         'uuid',

--- a/enterprise_access/apps/subsidy_access_policy/constants.py
+++ b/enterprise_access/apps/subsidy_access_policy/constants.py
@@ -90,6 +90,10 @@ class MissingSubsidyAccessReasonUserMessages:
         "You can't enroll right now because your organization doesn't have enough funds. " \
         "Contact your administrator to request more."
     LEARNER_LIMITS_REACHED = "You can't enroll right now because of limits set by your organization."
+    CONTENT_NOT_IN_CATALOG = \
+        "You can't enroll right now because this course is no longer available in your organization's catalog."
+    LEARNER_NOT_IN_ENTERPRISE = \
+        "You can't enroll right now because your account is no longer associated with the organization."
 
 
 REASON_POLICY_NOT_ACTIVE = "policy_not_active"


### PR DESCRIPTION
1. Updates `user_message` for the `REASON_LEARNER_NOT_IN_ENTERPRISE` and `REASON_CONTENT_NOT_IN_CATALOG` reason types to have more explicit messaging on the course run card(s) in the Learner Portal UX.
2. Makes the subsidy access policy Django Admin pages a bit easier to work with by adding some additional display fields in the table, filters, and a search bar.

<img width="1183" alt="image" src="https://github.com/openedx/enterprise-access/assets/2828721/7635c026-8c19-4271-98c9-d70a78aabc75">
