### PR TITLE
feat: use more structured redeem error response from subsidy api

### DIFF
--- a/enterprise_access/apps/subsidy_access_policy/exceptions.py
+++ b/enterprise_access/apps/subsidy_access_policy/exceptions.py
@@ -1,6 +1,7 @@
 """
 Exceptions that can be raised by the ``subsidy_access_policy`` app.
 """
+import requests
 
 
 class SubsidyAccessPolicyException(Exception):
@@ -26,3 +27,22 @@ class SubsidyAccessPolicyLockAttemptFailed(SubsidyAccessPolicyException):
     Raised when an attempt to lock SubsidyAccessPolicy failed due to an
     already existing lock acquired on the same resource.
     """
+
+
+class SubsidyAPIHTTPError(requests.exceptions.HTTPError):
+    """
+    Exception that distinguishes HTTPErrors that arise from
+    calls to the enterprise-subsidy API.
+
+    You should expect to use this as ``raise SubsidyAPIHTTPError() from {some HTTPError instance}``,
+    so that the cause (i.e. the original HTTPError) can be found in this Exception class'
+    ``__cause__`` attribute, which will allow us to access the original error response object,
+    including the payload and status code.
+    """
+    @property
+    def error_response(self):
+        """ Fetch the response object from the HTTPError that caused this exception. """
+        return self.__cause__.response  # pylint: disable=no-member
+
+    def error_payload(self):
+        return self.error_response.json()


### PR DESCRIPTION
Take advantage of https://github.com/openedx/enterprise-subsidy/pull/104
...to raise a 422 instead of uncaught 500 when the chained calls to subsidy API -> enterprise enrollment API fail.

![image](https://github.com/openedx/enterprise-access/assets/2307986/e452ab31-ee30-4bc3-8190-4b7bf23566ff)