### PR TITLE
feat: cache content metadata and containment

### DIFF
--- a/enterprise_access/__init__.py
+++ b/enterprise_access/__init__.py
@@ -5,3 +5,6 @@ Django starts so that shared_task will use this app.
 from .celery import app as celery_app
 
 __all__ = ('celery_app',)
+
+
+__version__ = '1.0.0'

--- a/enterprise_access/apps/subsidy_access_policy/content_metadata_api.py
+++ b/enterprise_access/apps/subsidy_access_policy/content_metadata_api.py
@@ -1,0 +1,62 @@
+"""
+Python API for interacting with content metadata
+for use in the domain of SubsidyAccessPolicies.
+"""
+from django.conf import settings
+from edx_django_utils.cache import TieredCache
+from requests.exceptions import HTTPError
+
+from ..api_client.enterprise_catalog_client import EnterpriseCatalogApiClient
+from .utils import get_versioned_subsidy_client, versioned_cache_key
+
+DEFAULT_CACHE_TIMEOUT = getattr(settings, 'CONTENT_METADATA_CACHE_TIMEOUT', 60 * 5)
+
+
+def get_and_cache_content_metadata(enterprise_customer_uuid, content_key, timeout=None):
+    """
+    Returns the metadata for some customer and content key,
+    as told by the enterprise-subsidy service.
+
+    Returns: A dictionary containing content metadata for the given key
+    Raises: An HTTPError if there's a problem getting the content metadata
+      via the subsidy service.
+    """
+    cache_key = versioned_cache_key('get_subsidy_content_metadata', enterprise_customer_uuid, content_key)
+    cached_response = TieredCache.get_cached_response(cache_key)
+    if cached_response.is_found:
+        return cached_response.value
+
+    client = get_versioned_subsidy_client()
+    try:
+        metadata = client.get_subsidy_content_data(
+            enterprise_customer_uuid,
+            content_key,
+        )
+    except HTTPError as exc:
+        raise exc
+
+    TieredCache.set_all_tiers(cache_key, metadata, timeout or DEFAULT_CACHE_TIMEOUT)
+    return metadata
+
+
+def get_and_cache_catalog_contains_content(enterprise_catalog_uuid, content_key, timeout=None):
+    """
+    Returns a boolean indicating if the given content is in the given catalog.
+    This value is cached in a ``TieredCache`` (meaning in both the RequestCache,
+    _and_ the django cache for the configured expiration period).
+    """
+    cache_key = versioned_cache_key('contains_content_key', enterprise_catalog_uuid, content_key)
+    cached_response = TieredCache.get_cached_response(cache_key)
+    if cached_response.is_found:
+        return cached_response.value
+
+    try:
+        result = EnterpriseCatalogApiClient().contains_content_items(
+            enterprise_catalog_uuid,
+            [content_key],
+        )
+    except HTTPError as exc:
+        raise exc
+
+    TieredCache.set_all_tiers(cache_key, result, timeout or DEFAULT_CACHE_TIMEOUT)
+    return result

--- a/enterprise_access/apps/subsidy_access_policy/utils.py
+++ b/enterprise_access/apps/subsidy_access_policy/utils.py
@@ -2,7 +2,13 @@
 Utils for subsidy_access_policy
 """
 from django.conf import settings
+from edx_django_utils.cache import RequestCache
 from edx_enterprise_subsidy_client import get_enterprise_subsidy_api_client
+
+from enterprise_access import __version__ as code_version
+
+CACHE_KEY_SEP = ':'
+CACHE_NAMESPACE = 'subsidy_access_policy'
 
 
 def get_versioned_subsidy_client():
@@ -14,3 +20,23 @@ def get_versioned_subsidy_client():
     if getattr(settings, 'ENTERPRISE_SUBSIDY_API_CLIENT_VERSION', None):
         kwargs['version'] = int(settings.ENTERPRISE_SUBSIDY_API_CLIENT_VERSION)
     return get_enterprise_subsidy_api_client(**kwargs)
+
+
+def versioned_cache_key(*args):
+    """
+    Utility to produce a versioned cache key, which includes
+    an optional settings variable and the current code version,
+    so that we can perform key-based cache invalidation.
+    """
+    components = [str(arg) for arg in args]
+    components.append(code_version)
+    if stamp_from_settings := getattr(settings, 'CACHE_KEY_VERSION_STAMP', None):
+        components.append(stamp_from_settings)
+    return CACHE_KEY_SEP.join(components)
+
+
+def request_cache():
+    """
+    Helper that returns a namespaced RequestCache instance.
+    """
+    return RequestCache(namespace=CACHE_NAMESPACE)


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-7199
Features:
* Adds a `content_metadata_api` module to encapsulate the fetching and caching of content metadata and catalog inclusion.
* The `SubsidyAccessPolicy` is modified to interact with this module for content needs, rather than going directly to the catalog or subsidy client.
* Introduces optional kwarg to `can_redeem()` to skip the check for learner inclusion in a customer.  We now call `can_redeem` with that kwarg set to True from the view, which is being requested by an already authN'd user, who a priori must be a member of the customer.
* Adds optional settings `CACHE_KEY_VERSION_STAMP` and `CONTENT_METADATA_CACHE_TIMEOUT` to control key-based cache eviction and timeouts for cached content metadata, respectively.
* I've tried to update the tests to be slightly more sane in terms of all the mocking of integration points, but it's an uphill battle.
* Subtle, one-line win: `resolve_policy` can early return if there's only one policy to find the priority of.  This saves a subsidy API balance fetch.

Notes:
* We had previously considered eliminating the call to check catalog inclusion, in favor of relying on the subsidy `content-metadata` calls, where 404 response to infer that the content is not in the catalog.  However, the `content-metadata` endpoint provided by the subsidy service (and ultimately by the enterprise-catalog service) returns metadata records as long as they are associated with _any_ catalog for the provided customer uuid.  We’ll have cases where one customer has multiple catalogs, so we still have to do a catalog inclusion check.
* In the future, we could modify the [customer content-metadata endpoint](https://github.com/openedx/enterprise-catalog/blob/f0e625dc2007776b464f872d199dbe4f607da686/enterprise_catalog/apps/api/v1/views/enterprise_customer.py#L183) in enterprise-catalog to take an optional catalog identifier by which the response should be filtered, which could get us down to 1 catalog call.
* For now, I've gone in the direction of relying on django-caching + request caching (thanks, `TieredCache`) to make the redeemability checks more performant.