### PR TITLE
fix: can_redeem - fix invalid enterprise 4xx responses.

### DIFF
--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -652,8 +652,12 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
             )
             if not redemptions and not redeemable_policies:
                 lms_client = LmsApiClient()
-                enterprise_customer_data = lms_client.get_enterprise_customer_data(enterprise_customer_uuid)
-                enterprise_admin_users = enterprise_customer_data.get('admin_users')
+                try:
+                    enterprise_customer_data = lms_client.get_enterprise_customer_data(enterprise_customer_uuid)
+                    enterprise_admin_users = enterprise_customer_data.get('admin_users')
+                except requests.exceptions.HTTPError as exc:
+                    logger.warning(f"enterprise_customer {enterprise_customer_uuid} not found.")
+                    raise NotFound(detail="Could not find given enterprise_customer.") from exc
                 for reason, policies in non_redeemable_policies.items():
                     reasons.append({
                         "reason": reason,

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -313,6 +313,14 @@ class SubsidyAccessPolicy(TimeStampedModel):
         Redeem a subsidy for the given learner and content.
         Returns:
             A ledger transaction, or None if the subsidy was not redeemed.
+        Raises:
+            HTTPError:
+                - 403 Forbidden: If auth failed.
+                - 429 Too Many Requests: If the ledger was locked (resource contention, try again later).
+                - 422 Unprocessable Entity: Catchall status for anything that prevented the transaction from being
+                  created.  Reasons include, but are not limited to:
+                      * Redemption of the given content_key would have exceeded the ledger balance.
+                      * The given content_key is not in any catalog for this customer.
         """
         if self.access_method == AccessMethods.DIRECT:
             try:


### PR DESCRIPTION
In some cases, these returned 500 errors, but now they're all 4xx.

ENT-7111