### PR TITLE
refactor: add /api/v1/policy-redemption route

### DIFF
--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -290,15 +290,6 @@ class TestPolicyRedemptionAuthNAndPermissionChecks(APITestWithMocks):
         if role_context_dict:
             self.set_jwt_cookie([role_context_dict])
 
-        # The policy redemption list endpoint
-        query_params = {
-            'enterprise_customer_uuid': str(self.enterprise_uuid),
-            'lms_user_id': '1234',
-            'content_key': 'course-v1:edX+edXPrivacy101+3T2020',
-        }
-        response = self.client.get(reverse('api:v1:policy-redemption'), query_params)
-        self.assertEqual(response.status_code, expected_response_code)
-
         # The redeem endpoint
         url = reverse('api:v1:policy-redeem', kwargs={'policy_uuid': self.redeemable_policy.uuid})
         payload = {
@@ -354,7 +345,6 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
             'api:v1:policy-redeem',
             kwargs={'policy_uuid': self.redeemable_policy.uuid}
         )
-        self.subsidy_access_policy_redemption_endpoint = reverse('api:v1:policy-redemption')
         self.subsidy_access_policy_credits_available_endpoint = reverse('api:v1:policy-credits-available')
         self.subsidy_access_policy_can_redeem_endpoint = reverse(
             "api:v1:policy-can-redeem",
@@ -531,35 +521,6 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
         response_json = self.load_json(response.content)
         assert response_json == mock_transaction_record
         self.mock_get_content_metadata.assert_called_once_with(payload['content_key'])
-
-    def test_redemption_endpoint(self):
-        """
-        Verify that SubsidyAccessPolicyViewset redemption endpoint works as expected
-        """
-        mock_transaction_record = {
-            'uuid': str(uuid4()),
-            'state': TransactionStateChoices.COMMITTED,
-            'other': True,
-            'content_key': 'course-v1:edX+test+courserun',
-        }
-        self.redeemable_policy.subsidy_client.list_subsidy_transactions.return_value = {
-            'results': [
-                mock_transaction_record
-            ],
-            'aggregates': {
-                'total_quantity': 100,
-            },
-        }
-        query_params = {
-            'enterprise_customer_uuid': str(self.enterprise_uuid),
-            'lms_user_id': '1234',
-            'content_key': 'course-v1:edX+edXPrivacy101+3T2020',
-        }
-        response = self.client.get(self.subsidy_access_policy_redemption_endpoint, query_params)
-        response_json = self.load_json(response.content)
-        assert response_json == {
-            str(self.redeemable_policy.uuid): [mock_transaction_record],
-        }
 
     def test_credits_available_endpoint(self):
         """

--- a/enterprise_access/apps/api/v1/urls.py
+++ b/enterprise_access/apps/api/v1/urls.py
@@ -10,7 +10,8 @@ urlpatterns = []
 router = DefaultRouter()
 
 router.register("admin/policy", views.SubsidyAccessPolicyCRUDViewset, 'admin-policy')
-router.register("policy", views.SubsidyAccessPolicyRedeemViewset, 'policy')
+router.register("policy", views.SubsidyAccessPolicyRedeemViewset, 'policy')  # DEPRECATED
+router.register("policy-redemption", views.SubsidyAccessPolicyRedeemViewset, 'policy-redemption')
 router.register("subsidy-access-policies", views.SubsidyAccessPolicyReadOnlyViewSet, 'subsidy-access-policies')
 router.register("license-requests", views.LicenseRequestViewSet, 'license-requests')
 router.register("coupon-code-requests", views.CouponCodeRequestViewSet, 'coupon-code-requests')

--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -412,15 +412,8 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
         """
         Redeem a policy for given `lms_user_id` and `content_key`
 
-        URL Location: POST /api/v1/policy/<policy_uuid>/redeem/
+        status codes::
 
-        JSON body parameters:
-        {
-            "lms_user_id":
-            "content_key":
-        }
-
-        status codes:
             400: There are missing or otherwise invalid input parameters.
             403: The requester has insufficient redeem permissions.
             422: The subisdy access policy is not redeemable in a way that IS NOT retryable.
@@ -528,30 +521,6 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
                 redemptions_by_policy_uuid[str(policy.uuid)] = redemptions
 
         return redemptions_by_policy_uuid
-
-    @extend_schema(
-        tags=['Subsidy Access Policy Redemption'],
-        summary='Retrieve redemption.',
-        parameters=[serializers.SubsidyAccessPolicyRedemptionRequestSerializer],
-    )
-    @action(detail=False, methods=['get'])
-    def redemption(self, request, *args, **kwargs):
-        """
-        Return redemption records for given `enterprise_customer_uuid`, `lms_user_id` and `content_key`
-
-        URL Location: GET /api/v1/policy/redemption/?enterprise_customer_uuid=<>&lms_user_id=<>&content_key=<>
-        """
-        serializer = serializers.SubsidyAccessPolicyRedemptionRequestSerializer(data=request.query_params)
-        serializer.is_valid(raise_exception=True)
-
-        enterprise_customer_uuid = serializer.data['enterprise_customer_uuid']
-        lms_user_id = serializer.data['lms_user_id']
-        content_key = serializer.data['content_key']
-
-        return Response(
-            self.get_redemptions_by_policy_uuid(enterprise_customer_uuid, lms_user_id, content_key),
-            status=status.HTTP_200_OK,
-        )
 
     def _get_user_message_for_reason(self, reason_slug, enterprise_admin_users):
         """


### PR DESCRIPTION
* Keeps /api/v1/policy as a duplicated route alongside it for now.
* Removes the /api/v1/policy/redemption view
https://2u-internal.atlassian.net/browse/ENT-7151

There will be nearly-duplicate entries in http://localhost:18270/api/schema/redoc/#tag/Subsidy-Access-Policy-Redemption until the original (now deprecated) `/api/v1/policy` route is removed.