### PR TITLE
fix: tweak logging whitespace

### DIFF
--- a/enterprise_access/settings/utils.py
+++ b/enterprise_access/settings/utils.py
@@ -25,7 +25,7 @@ def get_logger_config(logging_env="no_env",
     syslog_format = (
         "[service_variant={service_variant}]"
         "[%(name)s][env:{logging_env}] %(levelname)s "
-        "[{hostname}  %(process)d] [user %(userid)s] [ip %(remoteip)s] [request_id %(request_id)s]"
+        "[{hostname}  %(process)d] [user %(userid)s] [ip %(remoteip)s] [request_id %(request_id)s] "
         "[%(filename)s:%(lineno)d] - %(message)s"
     ).format(
         service_variant=service_variant,


### PR DESCRIPTION
- we want a space after the `[request_id <id>]` and the log info after (eg `middleware.py`)

![Screenshot 2023-05-24 at 12 41 57 PM](https://github.com/openedx/enterprise-access/assets/31442/b952351a-6a09-4574-89ce-07f06b0e29ce)
