### PR TITLE
feat: memcached config and package for devstack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
   memcache:
     image: memcached:1.4.24
     container_name: enterprise_access.memcache
+    networks:
+      - devstack_default
+    command: memcached -vv
 
   app:
     # Uncomment this line to use the official enterprise_access base image

--- a/enterprise_access/settings/devstack.py
+++ b/enterprise_access/settings/devstack.py
@@ -13,6 +13,15 @@ DATABASES = {
     }
 }
 
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'LOCATION': 'enterprise_access.memcache:11211',
+    }
+}
+
+
 # Generic OAuth2 variables irrespective of SSO/backend service key types.
 OAUTH2_PROVIDER_URL = 'http://edx.devstack.lms:18000/oauth2'
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -29,6 +29,7 @@ edx-rest-api-client
 jsonfield2
 mysqlclient
 openedx-events
+pymemcache
 pytz
 redis
 rules

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -230,6 +230,8 @@ pyjwt[crypto]==2.7.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
+pymemcache==4.0.0
+    # via -r requirements/base.in
 pymongo==3.13.0
     # via edx-opaque-keys
 pynacl==1.5.0
@@ -299,7 +301,7 @@ stevedore==5.1.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-typing-extensions==4.6.1
+typing-extensions==4.6.2
     # via asgiref
 uritemplate==4.1.1
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -481,6 +481,8 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/validation.txt
     #   pylint-celery
     #   pylint-django
+pymemcache==4.0.0
+    # via -r requirements/validation.txt
 pymongo==3.13.0
     # via
     #   -r requirements/validation.txt
@@ -502,7 +504,7 @@ pytest==7.3.1
     #   -r requirements/validation.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/validation.txt
 pytest-django==4.5.2
     # via -r requirements/validation.txt
@@ -654,7 +656,7 @@ tox==3.28.0
     # via -r requirements/validation.txt
 twine==4.0.2
     # via -r requirements/validation.txt
-typing-extensions==4.6.1
+typing-extensions==4.6.2
     # via
     #   -r requirements/validation.txt
     #   asgiref

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -441,6 +441,8 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
+pymemcache==4.0.0
+    # via -r requirements/test.txt
 pymongo==3.13.0
     # via
     #   -r requirements/test.txt
@@ -458,7 +460,7 @@ pytest==7.3.1
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.txt
 pytest-django==4.5.2
     # via -r requirements/test.txt
@@ -611,7 +613,7 @@ tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
-typing-extensions==4.6.1
+typing-extensions==4.6.2
     # via
     #   -r requirements/test.txt
     #   asgiref

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -307,6 +307,8 @@ pyjwt[crypto]==2.7.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
+pymemcache==4.0.0
+    # via -r requirements/base.txt
 pymongo==3.13.0
     # via
     #   -r requirements/base.txt
@@ -410,7 +412,7 @@ stevedore==5.1.0
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-opaque-keys
-typing-extensions==4.6.1
+typing-extensions==4.6.2
     # via
     #   -r requirements/base.txt
     #   asgiref

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -441,6 +441,8 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
+pymemcache==4.0.0
+    # via -r requirements/test.txt
 pymongo==3.13.0
     # via
     #   -r requirements/test.txt
@@ -458,7 +460,7 @@ pytest==7.3.1
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.txt
 pytest-django==4.5.2
     # via -r requirements/test.txt
@@ -595,7 +597,7 @@ tox==3.28.0
     #   -r requirements/test.txt
 twine==4.0.2
     # via -r requirements/quality.in
-typing-extensions==4.6.1
+typing-extensions==4.6.2
     # via
     #   -r requirements/test.txt
     #   asgiref

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -373,6 +373,8 @@ pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
+pymemcache==4.0.0
+    # via -r requirements/base.txt
 pymongo==3.13.0
     # via
     #   -r requirements/base.txt
@@ -389,7 +391,7 @@ pytest==7.3.1
     # via
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.in
 pytest-django==4.5.2
     # via -r requirements/test.in
@@ -502,7 +504,7 @@ tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.in
-typing-extensions==4.6.1
+typing-extensions==4.6.2
     # via
     #   -r requirements/base.txt
     #   asgiref

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -575,6 +575,10 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
+pymemcache==4.0.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 pymongo==3.13.0
     # via
     #   -r requirements/quality.txt
@@ -596,7 +600,7 @@ pytest==7.3.1
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -773,7 +777,7 @@ tox==3.28.0
     #   -r requirements/test.txt
 twine==4.0.2
     # via -r requirements/quality.txt
-typing-extensions==4.6.1
+typing-extensions==4.6.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
Before this change: the django cache config is just using local memory cache (surprise!).
After this change: the django cache config points at the memcached container we already have setup for enterprise-access devstack.

You'll have to run `make dev.down dev.up.build` to get the requirements and docker network connection right.

Proof that it works locally:
```
>>> cache.set('foo', 22)
>>> cache.get('foo')
22
>>> settings.CACHES
{'default': {'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache', 'LOCATION': 'enterprise_access.memcache:11211'}}
```