### PR TITLE
feat: don't request aggregates when we don't need them

### DIFF
--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -243,7 +243,6 @@ class SubsidyAccessPolicy(TimeStampedModel):
         subsidy_transactions = get_and_cache_transactions_for_learner(
             self.subsidy_uuid, lms_user_id
         )['transactions']
-
         policy_transactions = [
             transaction for transaction in subsidy_transactions
             if str(transaction['subsidy_access_policy_uuid']) == str(self.uuid)

--- a/enterprise_access/apps/subsidy_access_policy/tests/test_subsidy_api.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/test_subsidy_api.py
@@ -1,0 +1,92 @@
+"""
+Tests for the subsidy_api module.
+"""
+import uuid
+from unittest import mock
+
+from django.test import TestCase
+
+from ..subsidy_api import get_and_cache_transactions_for_learner
+
+
+class TransactionsForLearnerTests(TestCase):
+    """
+    Tests the ``get_and_cache_transactions_for_learner`` function.
+    """
+    @mock.patch('enterprise_access.apps.subsidy_access_policy.subsidy_api.get_versioned_subsidy_client')
+    def test_request_caching_works(self, mock_client_getter):
+        """
+        Test that we utilize the request cache.
+        """
+        response_payload = {
+            'next': None,
+            'previous': None,
+            'count': 1,
+            'results': [{'thing': 3}],
+        }
+        mock_client = mock_client_getter.return_value
+        mock_client.list_subsidy_transactions.return_value = response_payload
+
+        subsidy_uuid = uuid.uuid4()
+        lms_user_id = 42
+
+        result = get_and_cache_transactions_for_learner(subsidy_uuid, lms_user_id)
+
+        expected_result = {
+            'transactions': [{'thing': 3}],
+            'aggregates': {},
+        }
+        self.assertEqual(result, expected_result)
+
+        # call it again, should be using the cache this time
+        next_result = get_and_cache_transactions_for_learner(subsidy_uuid, lms_user_id)
+
+        self.assertEqual(next_result, expected_result)
+
+        # we should only have used the client in the first call
+        mock_client.list_subsidy_transactions.assert_called_once_with(
+            subsidy_uuid=subsidy_uuid,
+            lms_user_id=lms_user_id,
+            include_aggregates=False,
+        )
+        # no pagination happened here
+        self.assertFalse(mock_client.client.get.called)
+
+    @mock.patch('enterprise_access.apps.subsidy_access_policy.subsidy_api.get_versioned_subsidy_client')
+    def test_multiple_pages_are_traversed(self, mock_client_getter):
+        """
+        Test that we read multiple pages of data, if present
+        in the client's response for ``list_subsidy_transactions()``.
+        """
+        first_response_payload = {
+            'next': 'http://the.next.page',
+            'previous': None,
+            'count': 12,
+            'results': [{'thing': 1}, {'thing': 2}],
+        }
+        second_response_payload = {
+            'next': None,
+            'previous': None,
+            'count': 3,
+            'results': [{'thing': 3}],
+        }
+        mock_client = mock_client_getter.return_value
+        mock_client.list_subsidy_transactions.return_value = first_response_payload
+        mock_client.client.get.return_value = second_response_payload
+
+        subsidy_uuid = uuid.uuid4()
+        lms_user_id = 42
+
+        result = get_and_cache_transactions_for_learner(subsidy_uuid, lms_user_id)
+
+        expected_result = {
+            'transactions': [{'thing': 1}, {'thing': 2}, {'thing': 3}],
+            'aggregates': {},
+        }
+        self.assertEqual(result, expected_result)
+        mock_client.list_subsidy_transactions.assert_called_once_with(
+            subsidy_uuid=subsidy_uuid,
+            lms_user_id=lms_user_id,
+            include_aggregates=False,
+        )
+        mock_client.client.get.assert_called_once_with(first_response_payload['next'])

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ amqp==5.1.1
     # via kombu
 analytics-python==1.4.post1
     # via -r requirements/base.in
-asgiref==3.7.1
+asgiref==3.7.2
     # via django
 async-timeout==4.0.2
     # via redis
@@ -157,7 +157,7 @@ edx-drf-extensions==8.8.0
     # via
     #   -r requirements/base.in
     #   edx-rbac
-edx-enterprise-subsidy-client==0.3.3
+edx-enterprise-subsidy-client==0.3.4
     # via -r requirements/base.in
 edx-opaque-keys[django]==2.3.0
     # via
@@ -268,7 +268,7 @@ requests==2.31.0
     #   social-auth-core
 requests-oauthlib==1.3.1
     # via social-auth-core
-ruamel-yaml==0.17.26
+ruamel-yaml==0.17.30
     # via drf-yasg
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,7 +10,7 @@ amqp==5.1.1
     #   kombu
 analytics-python==1.4.post1
     # via -r requirements/validation.txt
-asgiref==3.7.1
+asgiref==3.7.2
     # via
     #   -r requirements/validation.txt
     #   django
@@ -110,7 +110,7 @@ coreschema==0.0.4
     #   -r requirements/validation.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.6
+coverage[toml]==7.2.7
     # via
     #   -r requirements/validation.txt
     #   pytest-cov
@@ -241,7 +241,7 @@ edx-drf-extensions==8.8.0
     # via
     #   -r requirements/validation.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.3.3
+edx-enterprise-subsidy-client==0.3.4
     # via -r requirements/validation.txt
 edx-i18n-tools==0.9.2
     # via -r requirements/dev.in
@@ -570,7 +570,7 @@ rich==13.3.5
     # via
     #   -r requirements/validation.txt
     #   twine
-ruamel-yaml==0.17.26
+ruamel-yaml==0.17.30
     # via
     #   -r requirements/validation.txt
     #   drf-yasg

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -14,7 +14,7 @@ amqp==5.1.1
     #   kombu
 analytics-python==1.4.post1
     # via -r requirements/test.txt
-asgiref==3.7.1
+asgiref==3.7.2
     # via
     #   -r requirements/test.txt
     #   django
@@ -110,7 +110,7 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.6
+coverage[toml]==7.2.7
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -242,7 +242,7 @@ edx-drf-extensions==8.8.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.3.3
+edx-enterprise-subsidy-client==0.3.4
     # via -r requirements/test.txt
 edx-lint==5.3.4
     # via -r requirements/test.txt
@@ -513,7 +513,7 @@ requests-oauthlib==1.3.1
     #   social-auth-core
 restructuredtext-lint==1.4.0
     # via doc8
-ruamel-yaml==0.17.26
+ruamel-yaml==0.17.30
     # via
     #   -r requirements/test.txt
     #   drf-yasg

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -10,7 +10,7 @@ amqp==5.1.1
     #   kombu
 analytics-python==1.4.post1
     # via -r requirements/base.txt
-asgiref==3.7.1
+asgiref==3.7.2
     # via
     #   -r requirements/base.txt
     #   django
@@ -186,7 +186,7 @@ edx-drf-extensions==8.8.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.3.3
+edx-enterprise-subsidy-client==0.3.4
     # via -r requirements/base.txt
 edx-opaque-keys[django]==2.3.0
     # via
@@ -361,7 +361,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-ruamel-yaml==0.17.26
+ruamel-yaml==0.17.30
     # via
     #   -r requirements/base.txt
     #   drf-yasg

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -10,7 +10,7 @@ amqp==5.1.1
     #   kombu
 analytics-python==1.4.post1
     # via -r requirements/test.txt
-asgiref==3.7.1
+asgiref==3.7.2
     # via
     #   -r requirements/test.txt
     #   django
@@ -100,7 +100,7 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.6
+coverage[toml]==7.2.7
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -226,7 +226,7 @@ edx-drf-extensions==8.8.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.3.3
+edx-enterprise-subsidy-client==0.3.4
     # via -r requirements/test.txt
 edx-lint==5.3.4
     # via
@@ -517,7 +517,7 @@ rfc3986==2.0.0
     # via twine
 rich==13.3.5
     # via twine
-ruamel-yaml==0.17.26
+ruamel-yaml==0.17.30
     # via
     #   -r requirements/test.txt
     #   drf-yasg

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,7 +10,7 @@ amqp==5.1.1
     #   kombu
 analytics-python==1.4.post1
     # via -r requirements/base.txt
-asgiref==3.7.1
+asgiref==3.7.2
     # via
     #   -r requirements/base.txt
     #   django
@@ -95,7 +95,7 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.6
+coverage[toml]==7.2.7
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -213,7 +213,7 @@ edx-drf-extensions==8.8.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.3.3
+edx-enterprise-subsidy-client==0.3.4
     # via -r requirements/base.txt
 edx-lint==5.3.4
     # via -r requirements/test.in
@@ -436,7 +436,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-ruamel-yaml==0.17.26
+ruamel-yaml==0.17.30
     # via
     #   -r requirements/base.txt
     #   drf-yasg

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -13,7 +13,7 @@ analytics-python==1.4.post1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-asgiref==3.7.1
+asgiref==3.7.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -125,7 +125,7 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.6
+coverage[toml]==7.2.7
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -296,7 +296,7 @@ edx-drf-extensions==8.8.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.3.3
+edx-enterprise-subsidy-client==0.3.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -678,7 +678,7 @@ rich==13.3.5
     # via
     #   -r requirements/quality.txt
     #   twine
-ruamel-yaml==0.17.26
+ruamel-yaml==0.17.30
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-7222
We don't need to request learner aggregates when we make that “bulk” call introduced in ENT-7221 - the policy layer will compute its own aggregates for the learner in memory. This change sets `include_aggregates=False` in subsidy client call to fetch all transactions for a given learner within a subsidy.