### PR TITLE
fix: redemption mapping bug fix

### DIFF
--- a/enterprise_access/apps/subsidy_access_policy/subsidy_api.py
+++ b/enterprise_access/apps/subsidy_access_policy/subsidy_api.py
@@ -62,28 +62,45 @@ def get_and_cache_transactions_for_learner(subsidy_uuid, lms_user_id):
 def get_redemptions_by_content_and_policy_for_learner(policies, lms_user_id):
     """
     Returns a mapping of content keys to a mapping of policy uuids to lists of transactions
-    for the given learner, filtered to only those transactions associated with **subsidies**
+    for the given learner, filtered to only those transactions associated with a **subsidy**
     to which any of the given **policies** are associated.
+
+    The nice thing about ``get_and_cache_transactions_for_learner()`` is that it allows us
+    to make one call per subsidy for a customer’s set of policies, to get all transactions for the learner
+    and store them in a request cache for later computation (rather than making one call to the subsidy service
+    per [lms_user_id, content_key, policy uuid] combination).
+
+    This will usually result in just the one call against a given subsidy,
+    based on how we want to configure our customers, but we have to deal with the
+    possibility that there are multiple subsidies in play.
+
+    This particular function takes those resulting transactions and
+    maps them by content_key to maps of policy_uuid -> [transactions]
+    Within the list of transactions for a given subsidy, if we come across a transaction
+    with a policy uuid that’s *not* currently associated with the subsidy we requested transactions for,
+    we don’t want it the mapping, because we’ll later compute aggregates for the policies’
+    spend caps and learner limits based on that mapping.
     """
-    policies_by_subsidy_uuid = {policy.subsidy_uuid: policy for policy in policies}
+    policies_by_subsidy_uuid = defaultdict(set)
+    for policy in policies:
+        policies_by_subsidy_uuid[policy.subsidy_uuid].add(str(policy.uuid))
+
     result = defaultdict(lambda: defaultdict(list))
 
-    for subsidy_uuid, policy in policies_by_subsidy_uuid.items():
-        logger.info(f'Fetching learner transactions for subsidy {subsidy_uuid} via policy {policy.uuid}')
+    for subsidy_uuid, policies_with_subsidy in policies_by_subsidy_uuid.items():
+        logger.info(f'Fetching learner transactions for subsidy {subsidy_uuid} via policies {policies_with_subsidy}')
         transactions_in_subsidy = get_and_cache_transactions_for_learner(subsidy_uuid, lms_user_id)['transactions']
         for redemption in transactions_in_subsidy:
             transaction_uuid = redemption['uuid']
             content_key = redemption['content_key']
             subsidy_access_policy_uuid = redemption['subsidy_access_policy_uuid']
 
-            if subsidy_access_policy_uuid != str(policy.uuid):
-                message = (
-                    f"Transaction {transaction_uuid} has mismatched policy uuids for subsidy {subsidy_uuid}: "
-                    f"Looked in policy {policy.uuid} but found other policy uuid {subsidy_access_policy_uuid}"
+            if subsidy_access_policy_uuid in policies_with_subsidy:
+                result[content_key][subsidy_access_policy_uuid].append(redemption)
+            else:
+                logger.warning(
+                    f"Transaction {transaction_uuid} has unmatched policy uuid for subsidy {subsidy_uuid}: "
+                    f"Found policy uuid {subsidy_access_policy_uuid} that is no longer tied to this subsidy."
                 )
-                logger.error(message)
-                raise TransactionPolicyMismatchError(message)
-
-            result[content_key][subsidy_access_policy_uuid].append(redemption)
 
     return result

--- a/enterprise_access/apps/subsidy_access_policy/tests/test_subsidy_api.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/test_subsidy_api.py
@@ -6,7 +6,8 @@ from unittest import mock
 
 from django.test import TestCase
 
-from ..subsidy_api import get_and_cache_transactions_for_learner
+from ..subsidy_api import get_and_cache_transactions_for_learner, get_redemptions_by_content_and_policy_for_learner
+from .factories import PerLearnerSpendCapLearnerCreditAccessPolicyFactory
 
 
 class TransactionsForLearnerTests(TestCase):
@@ -90,3 +91,61 @@ class TransactionsForLearnerTests(TestCase):
             include_aggregates=False,
         )
         mock_client.client.get.assert_called_once_with(first_response_payload['next'])
+
+    @mock.patch('enterprise_access.apps.subsidy_access_policy.subsidy_api.get_and_cache_transactions_for_learner')
+    def test_redemptions_by_content_and_policy(self, mock_transaction_cache):
+        cake_subsidy_uuid = uuid.uuid4()
+        pie_subsidy_uuid = uuid.uuid4()
+
+        cherry_policy = PerLearnerSpendCapLearnerCreditAccessPolicyFactory(subsidy_uuid=pie_subsidy_uuid)
+        apple_policy = PerLearnerSpendCapLearnerCreditAccessPolicyFactory(subsidy_uuid=pie_subsidy_uuid)
+
+        german_chocolate_policy = PerLearnerSpendCapLearnerCreditAccessPolicyFactory(subsidy_uuid=cake_subsidy_uuid)
+
+        # The transaction uuids and content keys don't really matter much here, they don't even need
+        # to be proper uuids, just unique amongst this list of test data.
+        mock_pie_transactions = [
+            {
+                'uuid': 'alpha',
+                'content_key': 'content-1',
+                'subsidy_access_policy_uuid': str(cherry_policy.uuid),
+            },
+            {
+                'uuid': 'beta',
+                'content_key': 'content-2',
+                'subsidy_access_policy_uuid': str(apple_policy.uuid),
+            },
+        ]
+        mock_cake_transactions = [
+            {
+                'uuid': 'delta',
+                'content_key': 'content-3',
+                'subsidy_access_policy_uuid': str(german_chocolate_policy.uuid),
+            },
+            # Add some unmatched policy uuid in here,
+            # which we'll later verify is omitted from the mapping.
+            {
+                'uuid': 'epsilon',
+                'content_key': 'content-4',
+                'subsidy_access_policy_uuid': str(uuid.uuid4()),
+            },
+        ]
+
+        mock_transaction_cache.side_effect = [
+            {'transactions': mock_pie_transactions, 'aggregates': {}},
+            {'transactions': mock_cake_transactions, 'aggregates': {}},
+        ]
+
+        result = get_redemptions_by_content_and_policy_for_learner(
+            [cherry_policy, apple_policy, german_chocolate_policy],
+            123,
+        )
+
+        self.assertEqual(
+            {
+                'content-1': {str(cherry_policy.uuid): [mock_pie_transactions[0]]},
+                'content-2': {str(apple_policy.uuid): [mock_pie_transactions[1]]},
+                'content-3': {str(german_chocolate_policy.uuid): [mock_cake_transactions[0]]},
+            },
+            result,
+        )


### PR DESCRIPTION
We didn't previously account for multiple active policies all tied to a single subsidy in creating this mapping, even though that situation will be common.  Also adds a unit test to cover the creation of this mapping.
https://2u-internal.atlassian.net/browse/ENT-7230