### PR TITLE
chore: upgrade subsidy client and django utils

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,6 +18,8 @@ attrs==23.1.0
     #   openedx-events
 backoff==1.10.0
     # via analytics-python
+backports-zoneinfo[tzdata]==0.2.1
+    # via kombu
 billiard==3.6.4.0
     # via celery
 celery==5.2.7
@@ -148,7 +150,7 @@ edx-celeryutils==1.2.2
     # via -r requirements/base.in
 edx-django-release-util==1.2.0
     # via -r requirements/base.in
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
@@ -157,7 +159,7 @@ edx-drf-extensions==8.8.0
     # via
     #   -r requirements/base.in
     #   edx-rbac
-edx-enterprise-subsidy-client==0.3.6
+edx-enterprise-subsidy-client==0.3.7
     # via -r requirements/base.in
 edx-opaque-keys[django]==2.3.0
     # via
@@ -191,9 +193,9 @@ jsonfield2==4.0.0.post0
     # via -r requirements/base.in
 jsonschema==4.17.3
     # via drf-spectacular
-kombu==5.2.4
+kombu==5.3.0
     # via celery
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 monotonic==1.6
     # via analytics-python
@@ -207,7 +209,7 @@ oauthlib==3.2.2
     #   social-auth-core
 openapi-codec==1.3.2
     # via django-rest-swagger
-openedx-events==8.0.0
+openedx-events==8.0.1
     # via -r requirements/base.in
 packaging==23.1
     # via drf-yasg
@@ -301,8 +303,12 @@ stevedore==5.1.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-typing-extensions==4.6.2
-    # via asgiref
+typing-extensions==4.6.3
+    # via
+    #   asgiref
+    #   kombu
+tzdata==2023.3
+    # via backports-zoneinfo
 uritemplate==4.1.1
     # via
     #   coreapi

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -32,6 +32,10 @@ backoff==1.10.0
     # via
     #   -r requirements/validation.txt
     #   analytics-python
+backports-zoneinfo[tzdata]==0.2.1
+    # via
+    #   -r requirements/validation.txt
+    #   kombu
 billiard==3.6.4.0
     # via
     #   -r requirements/validation.txt
@@ -232,7 +236,7 @@ edx-celeryutils==1.2.2
     # via -r requirements/validation.txt
 edx-django-release-util==1.2.0
     # via -r requirements/validation.txt
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
@@ -241,7 +245,7 @@ edx-drf-extensions==8.8.0
     # via
     #   -r requirements/validation.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.3.6
+edx-enterprise-subsidy-client==0.3.7
     # via -r requirements/validation.txt
 edx-i18n-tools==0.9.2
     # via -r requirements/dev.in
@@ -264,7 +268,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/validation.txt
-faker==18.10.0
+faker==18.10.1
     # via
     #   -r requirements/validation.txt
     #   factory-boy
@@ -337,7 +341,7 @@ keyring==23.13.1
     # via
     #   -r requirements/validation.txt
     #   twine
-kombu==5.2.4
+kombu==5.3.0
     # via
     #   -r requirements/validation.txt
     #   celery
@@ -349,7 +353,7 @@ markdown-it-py==2.2.0
     # via
     #   -r requirements/validation.txt
     #   rich
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/validation.txt
     #   jinja2
@@ -384,7 +388,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/validation.txt
     #   django-rest-swagger
-openedx-events==8.0.0
+openedx-events==8.0.1
     # via -r requirements/validation.txt
 packaging==23.1
     # via
@@ -656,13 +660,18 @@ tox==3.28.0
     # via -r requirements/validation.txt
 twine==4.0.2
     # via -r requirements/validation.txt
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via
     #   -r requirements/validation.txt
     #   asgiref
     #   astroid
+    #   kombu
     #   pylint
     #   rich
+tzdata==2023.3
+    # via
+    #   -r requirements/validation.txt
+    #   backports-zoneinfo
 uritemplate==4.1.1
     # via
     #   -r requirements/validation.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -40,6 +40,10 @@ backoff==1.10.0
     # via
     #   -r requirements/test.txt
     #   analytics-python
+backports-zoneinfo[tzdata]==0.2.1
+    # via
+    #   -r requirements/test.txt
+    #   kombu
 beautifulsoup4==4.12.2
     # via pydata-sphinx-theme
 billiard==3.6.4.0
@@ -233,7 +237,7 @@ edx-celeryutils==1.2.2
     # via -r requirements/test.txt
 edx-django-release-util==1.2.0
     # via -r requirements/test.txt
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
@@ -242,7 +246,7 @@ edx-drf-extensions==8.8.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.3.6
+edx-enterprise-subsidy-client==0.3.7
     # via -r requirements/test.txt
 edx-lint==5.3.4
     # via -r requirements/test.txt
@@ -263,7 +267,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==18.10.0
+faker==18.10.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -321,7 +325,7 @@ jsonschema==4.17.3
     # via
     #   -r requirements/test.txt
     #   drf-spectacular
-kombu==5.2.4
+kombu==5.3.0
     # via
     #   -r requirements/test.txt
     #   celery
@@ -329,7 +333,7 @@ lazy-object-proxy==1.9.0
     # via
     #   -r requirements/test.txt
     #   astroid
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/test.txt
     #   jinja2
@@ -356,7 +360,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
-openedx-events==8.0.0
+openedx-events==8.0.1
     # via -r requirements/test.txt
 packaging==23.1
     # via
@@ -613,13 +617,18 @@ tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via
     #   -r requirements/test.txt
     #   asgiref
     #   astroid
+    #   kombu
     #   pydata-sphinx-theme
     #   pylint
+tzdata==2023.3
+    # via
+    #   -r requirements/test.txt
+    #   backports-zoneinfo
 uritemplate==4.1.1
     # via
     #   -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -27,6 +27,10 @@ backoff==1.10.0
     # via
     #   -r requirements/base.txt
     #   analytics-python
+backports-zoneinfo[tzdata]==0.2.1
+    # via
+    #   -r requirements/base.txt
+    #   kombu
 billiard==3.6.4.0
     # via
     #   -r requirements/base.txt
@@ -177,7 +181,7 @@ edx-celeryutils==1.2.2
     # via -r requirements/base.txt
 edx-django-release-util==1.2.0
     # via -r requirements/base.txt
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -186,7 +190,7 @@ edx-drf-extensions==8.8.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.3.6
+edx-enterprise-subsidy-client==0.3.7
     # via -r requirements/base.txt
 edx-opaque-keys[django]==2.3.0
     # via
@@ -240,11 +244,11 @@ jsonschema==4.17.3
     # via
     #   -r requirements/base.txt
     #   drf-spectacular
-kombu==5.2.4
+kombu==5.3.0
     # via
     #   -r requirements/base.txt
     #   celery
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/base.txt
     #   jinja2
@@ -269,7 +273,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-openedx-events==8.0.0
+openedx-events==8.0.1
     # via -r requirements/base.txt
 packaging==23.1
     # via
@@ -412,10 +416,15 @@ stevedore==5.1.0
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-opaque-keys
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via
     #   -r requirements/base.txt
     #   asgiref
+    #   kombu
+tzdata==2023.3
+    # via
+    #   -r requirements/base.txt
+    #   backports-zoneinfo
 uritemplate==4.1.1
     # via
     #   -r requirements/base.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -32,6 +32,10 @@ backoff==1.10.0
     # via
     #   -r requirements/test.txt
     #   analytics-python
+backports-zoneinfo[tzdata]==0.2.1
+    # via
+    #   -r requirements/test.txt
+    #   kombu
 billiard==3.6.4.0
     # via
     #   -r requirements/test.txt
@@ -217,7 +221,7 @@ edx-celeryutils==1.2.2
     # via -r requirements/test.txt
 edx-django-release-util==1.2.0
     # via -r requirements/test.txt
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
@@ -226,7 +230,7 @@ edx-drf-extensions==8.8.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.3.6
+edx-enterprise-subsidy-client==0.3.7
     # via -r requirements/test.txt
 edx-lint==5.3.4
     # via
@@ -249,7 +253,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==18.10.0
+faker==18.10.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -316,7 +320,7 @@ jsonschema==4.17.3
     #   drf-spectacular
 keyring==23.13.1
     # via twine
-kombu==5.2.4
+kombu==5.3.0
     # via
     #   -r requirements/test.txt
     #   celery
@@ -326,7 +330,7 @@ lazy-object-proxy==1.9.0
     #   astroid
 markdown-it-py==2.2.0
     # via rich
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/test.txt
     #   jinja2
@@ -357,7 +361,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
-openedx-events==8.0.0
+openedx-events==8.0.1
     # via -r requirements/test.txt
 packaging==23.1
     # via
@@ -597,13 +601,18 @@ tox==3.28.0
     #   -r requirements/test.txt
 twine==4.0.2
     # via -r requirements/quality.in
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via
     #   -r requirements/test.txt
     #   asgiref
     #   astroid
+    #   kombu
     #   pylint
     #   rich
+tzdata==2023.3
+    # via
+    #   -r requirements/test.txt
+    #   backports-zoneinfo
 uritemplate==4.1.1
     # via
     #   -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -31,6 +31,10 @@ backoff==1.10.0
     # via
     #   -r requirements/base.txt
     #   analytics-python
+backports-zoneinfo[tzdata]==0.2.1
+    # via
+    #   -r requirements/base.txt
+    #   kombu
 billiard==3.6.4.0
     # via
     #   -r requirements/base.txt
@@ -204,7 +208,7 @@ edx-celeryutils==1.2.2
     # via -r requirements/base.txt
 edx-django-release-util==1.2.0
     # via -r requirements/base.txt
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -213,7 +217,7 @@ edx-drf-extensions==8.8.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.3.6
+edx-enterprise-subsidy-client==0.3.7
     # via -r requirements/base.txt
 edx-lint==5.3.4
     # via -r requirements/test.in
@@ -232,7 +236,7 @@ exceptiongroup==1.1.1
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==18.10.0
+faker==18.10.1
     # via factory-boy
 fastavro==1.7.4
     # via
@@ -278,13 +282,13 @@ jsonschema==4.17.3
     # via
     #   -r requirements/base.txt
     #   drf-spectacular
-kombu==5.2.4
+kombu==5.3.0
     # via
     #   -r requirements/base.txt
     #   celery
 lazy-object-proxy==1.9.0
     # via astroid
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/base.txt
     #   jinja2
@@ -309,7 +313,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-openedx-events==8.0.0
+openedx-events==8.0.1
     # via -r requirements/base.txt
 packaging==23.1
     # via
@@ -504,12 +508,17 @@ tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.in
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via
     #   -r requirements/base.txt
     #   asgiref
     #   astroid
+    #   kombu
     #   pylint
+tzdata==2023.3
+    # via
+    #   -r requirements/base.txt
+    #   backports-zoneinfo
 uritemplate==4.1.1
     # via
     #   -r requirements/base.txt

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -40,6 +40,11 @@ backoff==1.10.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   analytics-python
+backports-zoneinfo[tzdata]==0.2.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   kombu
 billiard==3.6.4.0
     # via
     #   -r requirements/quality.txt
@@ -285,7 +290,7 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -296,7 +301,7 @@ edx-drf-extensions==8.8.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==0.3.6
+edx-enterprise-subsidy-client==0.3.7
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -328,7 +333,7 @@ factory-boy==3.2.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-faker==18.10.0
+faker==18.10.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -414,7 +419,7 @@ keyring==23.13.1
     # via
     #   -r requirements/quality.txt
     #   twine
-kombu==5.2.4
+kombu==5.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -428,7 +433,7 @@ markdown-it-py==2.2.0
     # via
     #   -r requirements/quality.txt
     #   rich
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -471,7 +476,7 @@ openapi-codec==1.3.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django-rest-swagger
-openedx-events==8.0.0
+openedx-events==8.0.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -777,14 +782,20 @@ tox==3.28.0
     #   -r requirements/test.txt
 twine==4.0.2
     # via -r requirements/quality.txt
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   asgiref
     #   astroid
+    #   kombu
     #   pylint
     #   rich
+tzdata==2023.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   backports-zoneinfo
 uritemplate==4.1.1
     # via
     #   -r requirements/quality.txt


### PR DESCRIPTION
Gets the python upgrades from https://github.com/openedx/edx-enterprise-subsidy-client/releases/tag/0.3.7