### PR TITLE
feat: existing reversed transaction should not prevent redemption

### DIFF
--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -602,9 +602,14 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
                 for redemption in redemptions
             ]
 
-            # Determine if the learner has already redeemed the requested content_key.
+            # Determine if the learner has already redeemed the requested content_key.  Just because a transaction has
+            # state='committed' doesn't mean it counts as a successful redemption; it must also NOT have a committed
+            # reversal.
             has_successful_redemption = any(
-                redemption['state'] == TransactionStateChoices.COMMITTED
+                redemption['state'] == TransactionStateChoices.COMMITTED and (
+                    not redemption['reversal'] or
+                    redemption['reversal'].get('state') != TransactionStateChoices.COMMITTED
+                )
                 for redemption in redemptions
             )
 


### PR DESCRIPTION
Prior to this change, if the requesting learner has an existing reversed transaction (i.e. they redeemed content, then unenrolled), subsequent calls to can_redeem on the same content would result in a response containing can_redeem=False.  After this change, the response will contain can_redeem=True.  This is achieved by narrowing the scope of what counts as a currently active redemption to also require a non-existent or non-committed reversal.

ENT-7204