### PR TITLE
feat: Removes 'group_uuid' field from SubsidyAccessPolicy

### DIFF
--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -540,7 +540,6 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
         assert response_json[0]["catalog_uuid"] == str(self.redeemable_policy.catalog_uuid)
         assert response_json[0]["description"] == self.redeemable_policy.description
         assert response_json[0]["enterprise_customer_uuid"] == str(self.enterprise_uuid)
-        assert response_json[0]["group_uuid"] == str(self.redeemable_policy.group_uuid)
         assert response_json[0]["per_learner_enrollment_limit"] == self.redeemable_policy.per_learner_enrollment_limit
         assert response_json[0]["per_learner_spend_limit"] == self.redeemable_policy.per_learner_spend_limit
         assert response_json[0]["spend_limit"] == self.redeemable_policy.spend_limit

--- a/enterprise_access/apps/events/data.py
+++ b/enterprise_access/apps/events/data.py
@@ -138,7 +138,6 @@ class AccessPolicyData:
 
     uuid = attr.ib(type=str)
     active = attr.ib(type=bool)
-    group_uuid = attr.ib(type=str)
     catalog_uuid = attr.ib(type=str)
     subsidy_uuid = attr.ib(type=str)
     access_method = attr.ib(type=str)
@@ -157,7 +156,6 @@ class AccessPolicyEvent:
             "fields": [
                 {"name": "uuid", "type": "string"},
                 {"name": "active", "type": "boolean"},
-                {"name": "group_uuid", "type": "string"},
                 {"name": "subsidy_uuid", "type": "string"},
                 {"name": "access_method", "type": "string"}
             ]
@@ -167,7 +165,6 @@ class AccessPolicyEvent:
     def __init__(self, *args, **kwargs):
         self.uuid = kwargs['uuid']
         self.active = kwargs['active']
-        self.group_uuid = kwargs['group_uuid']
         self.subsidy_uuid = kwargs['subsidy_uuid']
         self.access_method = kwargs['access_method']
 
@@ -180,7 +177,6 @@ class AccessPolicyEvent:
         return {
             'uuid': obj.uuid,
             'active': obj.active,
-            'group_uuid': obj.group_uuid,
             'subsidy_uuid': obj.subsidy_uuid,
             'access_method': obj.access_method,
         }

--- a/enterprise_access/apps/events/tests/test_data.py
+++ b/enterprise_access/apps/events/tests/test_data.py
@@ -30,7 +30,6 @@ class DataTests(TestCase):
         access_policy_event_data = {
             'uuid': uuid4(),
             'active': True,
-            'group_uuid': uuid4(),
             'subsidy_uuid': uuid4(),
             'access_method': AccessMethods.DIRECT,
         }

--- a/enterprise_access/apps/events/tests/test_utils.py
+++ b/enterprise_access/apps/events/tests/test_utils.py
@@ -36,7 +36,6 @@ class UtilsTests(TestCase):
         access_policy_event_data = {
             'uuid': uuid4(),
             'active': True,
-            'group_uuid': uuid4(),
             'subsidy_uuid': uuid4(),
             'access_method': AccessMethods.DIRECT,
         }

--- a/enterprise_access/apps/subsidy_access_policy/mocks.py
+++ b/enterprise_access/apps/subsidy_access_policy/mocks.py
@@ -3,21 +3,6 @@
 from unittest import mock
 
 
-class group_client():
-    """
-    API client for the groups service.
-    """
-    @classmethod
-    def group_contains_learner(cls, group_uuid, learner_id):
-        """Group service api"""
-        return mock.MagicMock(group_uuid, learner_id)
-
-    @classmethod
-    def get_groups_for_learner(cls, learner_id):
-        """Group service api"""
-        return mock.MagicMock(learner_id)
-
-
 class catalog_client():
     """
     API client for the enterprise-catalog service.

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -86,14 +86,6 @@ class SubsidyAccessPolicy(TimeStampedModel):
         db_index=True,
         help_text='The primary identifier of the subsidy associated with this policy.',
     )
-    group_uuid = models.UUIDField(
-        db_index=True,
-        null=True,
-        blank=True,
-        help_text=(
-            "Optional, currently useless field for future Enterprise Groups implementation."
-        ),
-    )
     access_method = models.CharField(
         max_length=32,
         choices=AccessMethods.CHOICES,

--- a/enterprise_access/apps/subsidy_access_policy/tests/factories.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/factories.py
@@ -23,7 +23,6 @@ class SubsidyAccessPolicyFactory(factory.django.DjangoModelFactory):
 
     uuid = factory.LazyFunction(uuid4)
     enterprise_customer_uuid = factory.LazyFunction(uuid4)
-    group_uuid = factory.LazyFunction(uuid4)
     catalog_uuid = factory.LazyFunction(uuid4)
     subsidy_uuid = factory.LazyFunction(uuid4)
     access_method = AccessMethods.DIRECT

--- a/enterprise_access/apps/subsidy_access_policy/tests/test_models.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/test_models.py
@@ -108,7 +108,6 @@ class SubsidyAccessPolicyTests(TestCase):
         with self.assertRaises(TypeError):
             SubsidyAccessPolicy.objects.create(
                 description='Base policy',
-                group_uuid='7c9daa69-519c-4313-ad81-90862bc08ca1',
                 catalog_uuid='7c9daa69-519c-4313-ad81-90862bc08c21',
                 subsidy_uuid='7c9daa69-519c-4313-ad81-90862bc08ca3',
             )
@@ -123,12 +122,10 @@ class SubsidyAccessPolicyTests(TestCase):
         }
 
         PerLearnerSpendCreditAccessPolicy.objects.create(
-            group_uuid='7c9daa69-519c-4313-ad81-90862bc08ca1',
             catalog_uuid='7c9daa69-519c-4313-ad81-90862bc08ca2',
             subsidy_uuid='7c9daa69-519c-4313-ad81-90862bc08ca3'
         )
         PerLearnerEnrollmentCreditAccessPolicy.objects.create(
-            group_uuid='7c9daa69-519c-4313-ad81-90862bc08ca2',
             catalog_uuid='7c9daa69-519c-4313-ad81-90862bc08ca3',
             subsidy_uuid='7c9daa69-519c-4313-ad81-90862bc08ca4'
         )
@@ -147,7 +144,6 @@ class SubsidyAccessPolicyTests(TestCase):
         expected_policy_type = 'PerLearnerSpendCreditAccessPolicy'
 
         policy = SubsidyAccessPolicy.objects.create(
-            group_uuid='7c9daa69-519c-4313-ad81-90862bc08ca1',
             catalog_uuid='7c9daa69-519c-4313-ad81-90862bc08ca2',
             subsidy_uuid='7c9daa69-519c-4313-ad81-90862bc08ca3',
             policy_type=expected_policy_type


### PR DESCRIPTION
Removes `group_uuid` from the subsidy access policy model, and all related code within this repo. The migrations HAVE NOT bene run yet on this PR and will be done in the following PR. 