### PR TITLE
fix: don't fetch list price unless redeemable

### DIFF
--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -1012,10 +1012,6 @@ class TestSubsidyAccessPolicyCanRedeemView(APITestWithMocks):
         test_content_key_2 = "course-v1:edX+edXPrivacy101+3T2020_2"
         test_content_key_1_metadata_price = 29900
         test_content_key_2_metadata_price = 81900
-        test_content_key_1_usd_price = 299
-        test_content_key_2_usd_price = 819
-        test_content_key_1_cents_price = 29900
-        test_content_key_2_cents_price = 81900
 
         def mock_get_subsidy_content_data(*args, **kwargs):
             if test_content_key_1 in args:
@@ -1052,10 +1048,9 @@ class TestSubsidyAccessPolicyCanRedeemView(APITestWithMocks):
 
         # Check the response for the first content_key given.
         assert response_list[0]["content_key"] == test_content_key_1
-        assert response_list[0]["list_price"] == {
-            "usd": test_content_key_1_usd_price,
-            "usd_cents": test_content_key_1_cents_price,
-        }
+        # We should not assume that a list price is fetchable if the
+        # content cant' be redeemed - the content may not be in any catalog for any policy.
+        assert response_list[0]["list_price"] is None
         assert len(response_list[0]["redemptions"]) == 0
         assert response_list[0]["has_successful_redemption"] is False
         assert response_list[0]["redeemable_subsidy_access_policy"] is None
@@ -1081,10 +1076,8 @@ class TestSubsidyAccessPolicyCanRedeemView(APITestWithMocks):
 
         # Check the response for the second content_key given.
         assert response_list[1]["content_key"] == test_content_key_2
-        assert response_list[1]["list_price"] == {
-            "usd": test_content_key_2_usd_price,
-            "usd_cents": test_content_key_2_cents_price,
-        }
+        assert response_list[1]["list_price"] is None
+
         assert len(response_list[1]["redemptions"]) == 0
         assert response_list[1]["has_successful_redemption"] is False
         assert response_list[1]["redeemable_subsidy_access_policy"] is None

--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -594,6 +594,7 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
             redeemable_policies = []
             non_redeemable_policies = []
             resolved_policy = None
+            list_price = None
 
             redemptions_by_policy_uuid = redemptions_by_content_and_policy[content_key]
             # Flatten dict of lists because the response doesn't need to be bucketed by policy_uuid.
@@ -632,9 +633,12 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
             if redeemable_policies:
                 resolved_policy = redeemable_policies[0]
 
+            if resolved_policy or has_successful_redemption:
+                list_price = self._get_list_price(enterprise_customer_uuid, content_key)
+
             element_response = {
                 "content_key": content_key,
-                "list_price": self._get_list_price(enterprise_customer_uuid, content_key),
+                "list_price": list_price,
                 "redemptions": redemptions,
                 "has_successful_redemption": has_successful_redemption,
                 "redeemable_subsidy_access_policy": resolved_policy,


### PR DESCRIPTION
ENT-7319
This avoids an edge case where a learner accesses a learner portal course about page for a course that _cannot_ be redeemed via a new enterprise subsidy.  We shouldn't assume that we can fetch a course list price under that condition, because the content may not be associated with any catalog for the customer.