### PR TITLE
feat: Remove `/policy` endpoint

### DIFF
--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -243,7 +243,7 @@ class SubsidyAccessPolicyRedeemableResponseSerializer(serializers.ModelSerialize
         """
         Generate a fully qualified URI that can be POSTed to redeem a policy.
         """
-        location = reverse('api:v1:policy-redeem', kwargs={'policy_uuid': obj.uuid})
+        location = reverse('api:v1:policy-redemption-redeem', kwargs={'policy_uuid': obj.uuid})
         return urljoin(settings.ENTERPRISE_ACCESS_URL, location)
 
 

--- a/enterprise_access/apps/api/tests/test_serializers.py
+++ b/enterprise_access/apps/api/tests/test_serializers.py
@@ -18,7 +18,7 @@ class TestSubsidyAccessPolicyRedeemableResponseSerializer(TestCase):
     def setUp(self):
         self.non_redeemable_policy = PerLearnerEnrollmentCapLearnerCreditAccessPolicyFactory()
         self.subsidy_access_policy_redeem_endpoint = reverse(
-            'api:v1:policy-redeem',
+            'api:v1:policy-redemption-redeem',
             kwargs={'policy_uuid': self.non_redeemable_policy.uuid}
         )
 
@@ -32,5 +32,6 @@ class TestSubsidyAccessPolicyRedeemableResponseSerializer(TestCase):
 
         data = serializer.data
         self.assertIn("policy_redemption_url", data)
-        expected_url = f"{settings.ENTERPRISE_ACCESS_URL}/api/v1/policy/{self.non_redeemable_policy.uuid}/redeem/"
+        expected_url = f"{settings.ENTERPRISE_ACCESS_URL}/api/v1/policy-redemption/" \
+                       f"{self.non_redeemable_policy.uuid}/redeem/"
         self.assertEqual(data["policy_redemption_url"], expected_url)

--- a/enterprise_access/apps/api/v1/urls.py
+++ b/enterprise_access/apps/api/v1/urls.py
@@ -10,7 +10,6 @@ urlpatterns = []
 router = DefaultRouter()
 
 router.register("admin/policy", views.SubsidyAccessPolicyCRUDViewset, 'admin-policy')
-router.register("policy", views.SubsidyAccessPolicyRedeemViewset, 'policy')  # DEPRECATED
 router.register("policy-redemption", views.SubsidyAccessPolicyRedeemViewset, 'policy-redemption')
 router.register("subsidy-access-policies", views.SubsidyAccessPolicyReadOnlyViewSet, 'subsidy-access-policies')
 router.register("license-requests", views.LicenseRequestViewSet, 'license-requests')

--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -393,31 +393,6 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
 
     @extend_schema(
         tags=['Subsidy Access Policy Redemption'],
-        summary='List redeemable policies.',
-        parameters=[serializers.SubsidyAccessPolicyListRequestSerializer],
-        responses=serializers.SubsidyAccessPolicyRedeemableResponseSerializer(many=True),
-    )
-    def list(self, request):
-        """
-        Return a list of all redeemable policies for given `enterprise_customer_uuid`, `lms_user_id` and `content_key`
-        """
-        serializer = serializers.SubsidyAccessPolicyListRequestSerializer(data=request.query_params)
-        serializer.is_valid(raise_exception=True)
-
-        enterprise_customer_uuid = serializer.data['enterprise_customer_uuid']
-        lms_user_id = serializer.data['lms_user_id']
-        content_key = serializer.data['content_key']
-
-        redeemable_policies, _ = self.evaluate_policies(enterprise_customer_uuid, lms_user_id, content_key)
-        response_data = serializers.SubsidyAccessPolicyRedeemableResponseSerializer(redeemable_policies, many=True).data
-
-        return Response(
-            response_data,
-            status=status.HTTP_200_OK,
-        )
-
-    @extend_schema(
-        tags=['Subsidy Access Policy Redemption'],
         summary='Redeem with a policy.',
         request=serializers.SubsidyAccessPolicyRedeemRequestSerializer,
     )


### PR DESCRIPTION
Removes the `/api/v1/policy` endpoint in favor of the `/api/v1/policy-redemption` endpoint using the `SubsidyAccessPolicyRedeemViewset` viewset. Retains `/api/v1/admin/policy` endpoint.

Also removes the `list` endpoint from the `SubsidyAccessPolicyRedeemViewset`
