### PR TITLE
feat: log can_redeem results in viewset's evaluate_policies

### DIFF
--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -455,6 +455,10 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
         for policy in all_policies_for_enterprise:
             try:
                 redeemable, reason, _ = policy.can_redeem(lms_user_id, content_key, skip_customer_user_check=True)
+                logger.info(
+                    f'[can_redeem] {policy} inputs: (lms_user_id={lms_user_id}, content_key={content_key}) results: '
+                    f'redeemable={redeemable}, reason={reason}.'
+                )
             except ContentPriceNullException as exc:
                 logger.warning(f'{exc} when checking can_redeem() for {enterprise_customer_uuid}')
                 raise RedemptionRequestException(

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -555,6 +555,9 @@ class SubsidyAccessPolicy(TimeStampedModel):
             self.active = False
             self.save()
 
+    def __str__(self):
+        return f'<{self.__class__} uuid={self.uuid}>'
+
 
 class CreditPolicyMixin:
     """
@@ -641,8 +644,11 @@ class PerLearnerSpendCreditAccessPolicy(CreditPolicyMixin, SubsidyAccessPolicy):
         limits specified on the policy.
         """
         # perform generic access checks
-        should_attempt_redemption, reason, existing_redemptions = \
-            super().can_redeem(lms_user_id, content_key, skip_customer_user_check)
+        should_attempt_redemption, reason, existing_redemptions = super().can_redeem(
+            lms_user_id,
+            content_key,
+            skip_customer_user_check,
+        )
         if not should_attempt_redemption:
             return (False, reason, existing_redemptions)
 


### PR DESCRIPTION
I frequently want this for faster investigation.