### PR TITLE
feat: Deprecate old 'admin/policy' endpoint

### DIFF
--- a/enterprise_access/apps/api/v1/urls.py
+++ b/enterprise_access/apps/api/v1/urls.py
@@ -9,7 +9,6 @@ urlpatterns = []
 
 router = DefaultRouter()
 
-router.register("admin/policy", views.SubsidyAccessPolicyCRUDViewset, 'admin-policy')  # DEPRECATED viewset
 router.register("policy-redemption", views.SubsidyAccessPolicyRedeemViewset, 'policy-redemption')
 router.register("subsidy-access-policies", views.SubsidyAccessPolicyViewSet, 'subsidy-access-policies')
 router.register("license-requests", views.LicenseRequestViewSet, 'license-requests')


### PR DESCRIPTION
Deprecates the `admin/policy` endpoint using the `SubsidyAccessPolicyCRUDViewset` in favor of `subsidy-access-policies` endpoint using the `SubsidyAccessPolicyViewSet`.

Refactor tests and verified its still working in the frontend with this refactor PR -> https://github.com/openedx/frontend-app-support-tools/pull/347