### PR TITLE
feat: add expiration date field in credits_available serializer

### DIFF
--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -415,6 +415,7 @@ class SubsidyAccessPolicyCreditsAvailableResponseSerializer(SubsidyAccessPolicyR
     """
     remaining_balance_per_user = serializers.SerializerMethodField()
     remaining_balance = serializers.SerializerMethodField()
+    subsidy_end_date = serializers.SerializerMethodField()
 
     def get_remaining_balance_per_user(self, obj):
         lms_user_id = self.context.get('lms_user_id')
@@ -422,6 +423,9 @@ class SubsidyAccessPolicyCreditsAvailableResponseSerializer(SubsidyAccessPolicyR
 
     def get_remaining_balance(self, obj):
         return obj.remaining_balance()
+
+    def get_subsidy_end_date(self, obj):
+        return obj.subsidy_expiration_datetime
 
 
 class SubsidyAccessPolicyCanRedeemReasonResponseSerializer(serializers.Serializer):

--- a/enterprise_access/apps/api/tests/test_serializers.py
+++ b/enterprise_access/apps/api/tests/test_serializers.py
@@ -1,11 +1,17 @@
 """
 Tests for the serializers in the API.
 """
+from unittest import mock
+from uuid import uuid4
+
 from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
 
-from enterprise_access.apps.api.serializers.subsidy_access_policy import SubsidyAccessPolicyRedeemableResponseSerializer
+from enterprise_access.apps.api.serializers.subsidy_access_policy import (
+    SubsidyAccessPolicyCreditsAvailableResponseSerializer,
+    SubsidyAccessPolicyRedeemableResponseSerializer
+)
 from enterprise_access.apps.subsidy_access_policy.tests.factories import (
     PerLearnerEnrollmentCapLearnerCreditAccessPolicyFactory
 )
@@ -35,3 +41,48 @@ class TestSubsidyAccessPolicyRedeemableResponseSerializer(TestCase):
         expected_url = f"{settings.ENTERPRISE_ACCESS_URL}/api/v1/policy-redemption/" \
                        f"{self.non_redeemable_policy.uuid}/redeem/"
         self.assertEqual(data["policy_redemption_url"], expected_url)
+
+
+class TestSubsidyAccessPolicyCreditsAvailableResponseSerializer(TestCase):
+    """
+    Tests for the SubsidyAccessPolicyCreditsAvailableResponseSerializer.
+    """
+    def setUp(self):
+        self.user_id = 24
+        self.enterprise_uuid = uuid4()
+        self.redeemable_policy = PerLearnerEnrollmentCapLearnerCreditAccessPolicyFactory(
+            enterprise_customer_uuid=self.enterprise_uuid,
+            spend_limit=300,
+            active=True
+        )
+
+    @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.transactions_for_learner')
+    @mock.patch('enterprise_access.apps.subsidy_access_policy.models.get_and_cache_subsidy_record')
+    def test_get_subsidy_end_date(self, mock_subsidy_record, mock_transactions_for_learner):
+        """
+        Test that the get_subsidy_end_date method returns the correct
+        subsidy expiration date.
+        """
+        mock_transactions_for_learner.return_value = {
+            'transactions': [],
+            'aggregates': {
+                'total_quantity': 0,
+            },
+        }
+        subsidy_exp_date = '2030-01-01 12:00:00Z'
+        mock_subsidy_record.return_value = {
+            'uuid': str(uuid4()),
+            'title': 'Test Subsidy',
+            'enterprise_customer_uuid': str(self.enterprise_uuid),
+            'expiration_datetime': subsidy_exp_date,
+            'active_datetime': '2020-01-01 12:00:00Z',
+            'current_balance': '1000',
+        }
+        serializer = SubsidyAccessPolicyCreditsAvailableResponseSerializer(
+            [self.redeemable_policy],
+            many=True,
+            context={'lms_user_id': self.user_id}
+        )
+        data = serializer.data
+        self.assertIn('subsidy_end_date', data[0])
+        self.assertEqual(data[0].get('subsidy_end_date'), subsidy_exp_date)

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -28,7 +28,7 @@ from .constants import (
 )
 from .content_metadata_api import get_and_cache_catalog_contains_content, get_and_cache_content_metadata
 from .exceptions import ContentPriceNullException, SubsidyAccessPolicyLockAttemptFailed, SubsidyAPIHTTPError
-from .subsidy_api import get_and_cache_transactions_for_learner
+from .subsidy_api import get_and_cache_subsidy_record, get_and_cache_transactions_for_learner
 from .utils import ProxyAwareHistoricalRecords, create_idempotency_key_for_transaction, get_versioned_subsidy_client
 
 POLICY_LOCK_RESOURCE_NAME = "subsidy_access_policy"
@@ -220,7 +220,7 @@ class SubsidyAccessPolicy(TimeStampedModel):
             return super().__new__(proxy_class)  # pylint: disable=lost-exception
 
     def subsidy_record(self):
-        return self.subsidy_client.retrieve_subsidy(subsidy_uuid=self.subsidy_uuid)
+        return get_and_cache_subsidy_record(subsidy_uuid=self.subsidy_uuid)
 
     def subsidy_balance(self):
         """

--- a/enterprise_access/apps/subsidy_access_policy/subsidy_api.py
+++ b/enterprise_access/apps/subsidy_access_policy/subsidy_api.py
@@ -23,6 +23,25 @@ def learner_transaction_cache_key(subsidy_uuid, lms_user_id):
     return versioned_cache_key('get_transactions_for_learner', subsidy_uuid, lms_user_id)
 
 
+def subsidy_record_cache_key(subsidy_uuid):
+    return versioned_cache_key('get_subsidy_record', subsidy_uuid)
+
+
+def get_and_cache_subsidy_record(subsidy_uuid):
+    """
+    Get a subsidy record associated with a policy.
+    """
+    cache_key = subsidy_record_cache_key(subsidy_uuid)
+    cached_response = request_cache().get_cached_response(cache_key)
+    if cached_response.is_found:
+        return cached_response.value
+
+    client = get_versioned_subsidy_client()
+    response = client.retrieve_subsidy(subsidy_uuid=subsidy_uuid)
+    request_cache().set(cache_key, response)
+    return response
+
+
 def get_and_cache_transactions_for_learner(subsidy_uuid, lms_user_id):
     """
     Get all transactions for a learner in a given subsidy.  This can

--- a/enterprise_access/apps/subsidy_access_policy/tests/test_models.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/test_models.py
@@ -2,6 +2,7 @@
 Tests for subsidy_access_policy models.
 """
 from datetime import datetime, timedelta
+from unittest import mock
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -541,7 +542,8 @@ class SubsidyAccessPolicyTests(TestCase):
         with self.assertRaisesRegex(Exception, 'Expected a sum of transaction quantities <= 0'):
             self.per_learner_enroll_policy.content_would_exceed_limit(10, 100, 15)
 
-    def test_mock_subsidy_datetimes(self):
+    @mock.patch('enterprise_access.apps.subsidy_access_policy.models.get_and_cache_subsidy_record')
+    def test_mock_subsidy_datetimes(self, mock_subsidy_record):
         yesterday = datetime.utcnow() - timedelta(days=1)
         tomorrow = datetime.utcnow() + timedelta(days=1)
         mock_subsidy = {
@@ -550,7 +552,7 @@ class SubsidyAccessPolicyTests(TestCase):
             'expiration_datetime': tomorrow,
             'is_active': True,
         }
-        self.mock_subsidy_client.retrieve_subsidy.return_value = mock_subsidy
+        mock_subsidy_record.return_value = mock_subsidy
         policy = PerLearnerEnrollmentCapLearnerCreditAccessPolicyFactory.create()
         assert policy.subsidy_record() == mock_subsidy
 


### PR DESCRIPTION
**Change**: Add a new field "subsidy_end_date" in Credits Available response serializer. 
**Reason**: We need this data on frontend to show when the policy is going to expire. It will be displayed against the "Available Until" header. 

<img width="440" alt="Screenshot 2023-08-16 at 1 03 38 AM" src="https://github.com/openedx/enterprise-access/assets/55431213/322c0422-b7eb-4307-8e93-162ae49c59c6">
