### PR TITLE
feat: multi-policy resolution

### DIFF
--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -613,9 +613,8 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
                     non_redeemable_policies
                 ))
 
-            # TODO: Arbitrarily select one redeemable policy for now.
             if redeemable_policies:
-                resolved_policy = redeemable_policies[0]
+                resolved_policy = SubsidyAccessPolicy.resolve_policy(redeemable_policies)
 
             if resolved_policy or has_successful_redemption:
                 list_price = self._get_list_price(enterprise_customer_uuid, content_key)


### PR DESCRIPTION
## Description
- https://2u-internal.atlassian.net/browse/ENT-7484
- when multiple redeemable policies are present, resolve them first by type, then expiration date, then balance
- utilize `RequestCache` to avoid multiple round-trips to subsidy service
- gate this experimental functionality behind a setting, allowing us to observe performance in a controlled fashion on STAGE