### PR TITLE
feat: add expiration date field in credits serializer

### DIFF
--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -415,6 +415,7 @@ class SubsidyAccessPolicyCreditsAvailableResponseSerializer(SubsidyAccessPolicyR
     """
     remaining_balance_per_user = serializers.SerializerMethodField()
     remaining_balance = serializers.SerializerMethodField()
+    subsidy_expiration_date = serializers.SerializerMethodField()
 
     def get_remaining_balance_per_user(self, obj):
         lms_user_id = self.context.get('lms_user_id')
@@ -422,6 +423,9 @@ class SubsidyAccessPolicyCreditsAvailableResponseSerializer(SubsidyAccessPolicyR
 
     def get_remaining_balance(self, obj):
         return obj.remaining_balance()
+
+    def get_subsidy_expiration_date(self, obj):
+        return obj.subsidy_expiration_datetime
 
 
 class SubsidyAccessPolicyCanRedeemReasonResponseSerializer(serializers.Serializer):

--- a/enterprise_access/apps/api/tests/test_serializers.py
+++ b/enterprise_access/apps/api/tests/test_serializers.py
@@ -1,11 +1,17 @@
 """
 Tests for the serializers in the API.
 """
+from unittest import mock
+from uuid import uuid4
+
 from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
 
-from enterprise_access.apps.api.serializers.subsidy_access_policy import SubsidyAccessPolicyRedeemableResponseSerializer
+from enterprise_access.apps.api.serializers.subsidy_access_policy import (
+    SubsidyAccessPolicyCreditsAvailableResponseSerializer,
+    SubsidyAccessPolicyRedeemableResponseSerializer
+)
 from enterprise_access.apps.subsidy_access_policy.tests.factories import (
     PerLearnerEnrollmentCapLearnerCreditAccessPolicyFactory
 )
@@ -35,3 +41,48 @@ class TestSubsidyAccessPolicyRedeemableResponseSerializer(TestCase):
         expected_url = f"{settings.ENTERPRISE_ACCESS_URL}/api/v1/policy-redemption/" \
                        f"{self.non_redeemable_policy.uuid}/redeem/"
         self.assertEqual(data["policy_redemption_url"], expected_url)
+
+
+class TestSubsidyAccessPolicyCreditsAvailableResponseSerializer(TestCase):
+    """
+    Tests for the SubsidyAccessPolicyCreditsAvailableResponseSerializer.
+    """
+    def setUp(self):
+        self.user_id = 24
+        self.enterprise_uuid = uuid4()
+        self.redeemable_policy = PerLearnerEnrollmentCapLearnerCreditAccessPolicyFactory(
+            enterprise_customer_uuid=self.enterprise_uuid,
+            spend_limit=300,
+            active=True
+        )
+
+    @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.transactions_for_learner')
+    @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.subsidy_record')
+    def test_get_subsidy_end_date(self, mock_subsidy_record, mock_transactions_for_learner):
+        """
+        Test that the get_subsidy_end_date method returns the correct
+        subsidy expiration date.
+        """
+        mock_transactions_for_learner.return_value = {
+            'transactions': [],
+            'aggregates': {
+                'total_quantity': 0,
+            },
+        }
+        subsidy_exp_date = '2030-01-01 12:00:00Z'
+        mock_subsidy_record.return_value = {
+            'uuid': str(uuid4()),
+            'title': 'Test Subsidy',
+            'enterprise_customer_uuid': str(self.enterprise_uuid),
+            'expiration_datetime': subsidy_exp_date,
+            'active_datetime': '2020-01-01 12:00:00Z',
+            'current_balance': '1000',
+        }
+        serializer = SubsidyAccessPolicyCreditsAvailableResponseSerializer(
+            [self.redeemable_policy],
+            many=True,
+            context={'lms_user_id': self.user_id}
+        )
+        data = serializer.data
+        self.assertIn('subsidy_expiration_date', data[0])
+        self.assertEqual(data[0].get('subsidy_expiration_date'), subsidy_exp_date)

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -1067,7 +1067,8 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
             assert new_idempotency_key_sent == baseline_idempotency_key
 
     @mock.patch('enterprise_access.apps.subsidy_access_policy.models.get_and_cache_transactions_for_learner')
-    def test_credits_available_endpoint(self, mock_transactions_cache_for_learner):
+    @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.subsidy_record')
+    def test_credits_available_endpoint(self, mock_subsidy_record, mock_transactions_cache_for_learner):
         """
         Verify that SubsidyAccessPolicyViewset credits_available returns credit based policies with redeemable credit.
         """
@@ -1086,6 +1087,14 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
             'aggregates': {
                 'total_quantity': 0,
             },
+        }
+        mock_subsidy_record.return_value = {
+            'uuid': str(uuid4()),
+            'title': 'Test Subsidy',
+            'enterprise_customer_uuid': str(self.enterprise_uuid),
+            'expiration_datetime': '2030-01-01 12:00:00Z',
+            'active_datetime': '2020-01-01 12:00:00Z',
+            'current_balance': '1000',
         }
         enroll_cap_policy = PerLearnerEnrollmentCapLearnerCreditAccessPolicyFactory(
             enterprise_customer_uuid=self.enterprise_uuid,


### PR DESCRIPTION
**Change**: Add a new field "subsidy_end_date" in Credits Available response serializer. 
**Reason**: We need this data on frontend to show when the policy is going to expire. It will be displayed against the "Available Until" header. 
