### PR TITLE
fix: raise a more specific error from subsidy http errors. ENT-7626

### DIFF
--- a/enterprise_access/apps/subsidy_access_policy/exceptions.py
+++ b/enterprise_access/apps/subsidy_access_policy/exceptions.py
@@ -45,4 +45,8 @@ class SubsidyAPIHTTPError(requests.exceptions.HTTPError):
         return self.__cause__.response  # pylint: disable=no-member
 
     def error_payload(self):
-        return self.error_response.json()
+        if self.error_response:
+            return self.error_response.json()
+        return {
+            'detail': str(self),
+        }


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-7626
Fixes the can_redeem view to raise a different, specific exception type when it gets 403 responses from the enterprise-subsidy service.