### PR TITLE
fix: paginate pages of user transactions correctly. ENT-7637

### DIFF
--- a/enterprise_access/apps/subsidy_access_policy/subsidy_api.py
+++ b/enterprise_access/apps/subsidy_access_policy/subsidy_api.py
@@ -55,8 +55,9 @@ def get_and_cache_transactions_for_learner(subsidy_uuid, lms_user_id):
     next_page = response_payload.get('next')
     while next_page:
         next_response = client.client.get(next_page)
-        result['transactions'].extend(next_response['results'])
-        next_page = next_response.get('next')
+        next_payload = next_response.json()
+        result['transactions'].extend(next_payload['results'])
+        next_page = next_payload.get('next')
 
     logger.info(
         'Fetched transactions for subsidy %s and lms_user_id %s. Number transactions = %s',

--- a/enterprise_access/apps/subsidy_access_policy/tests/test_subsidy_api.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/test_subsidy_api.py
@@ -73,7 +73,9 @@ class TransactionsForLearnerTests(TestCase):
         }
         mock_client = mock_client_getter.return_value
         mock_client.list_subsidy_transactions.return_value = first_response_payload
-        mock_client.client.get.return_value = second_response_payload
+        mock_second_response = mock.Mock()
+        mock_second_response.json.return_value = second_response_payload
+        mock_client.client.get.return_value = mock_second_response
 
         subsidy_uuid = uuid.uuid4()
         lms_user_id = 42


### PR DESCRIPTION
When there is more than 1 page of learner transactions to traverse, we hit a bug like the following:
```
‘Response’ object is not subscriptable
at /edx/app/enterprise-access/enterprise_access/apps/subsidy_access_policy/subsidy_api.py, line 58, in get_and_cache_transactions_for_learner
```
This is because we’re trying to access data from the response object, instead of getting the payload out of the response.json() result.
This PR uses `response.json()` so that we actually access the payload during pagination.
https://2u-internal.atlassian.net/browse/ENT-7637