### PR TITLE
feat: policy validation refactor, policy -> assignment dependency strictness

### DIFF
--- a/enterprise_access/apps/api/serializers/assignment_configuration.py
+++ b/enterprise_access/apps/api/serializers/assignment_configuration.py
@@ -6,7 +6,6 @@ import logging
 from rest_framework import serializers
 
 from enterprise_access.apps.content_assignments.models import AssignmentConfiguration
-from enterprise_access.apps.subsidy_access_policy.models import SubsidyAccessPolicy
 
 logger = logging.getLogger(__name__)
 
@@ -33,15 +32,11 @@ class AssignmentConfigurationCreateRequestSerializer(serializers.ModelSerializer
     """
     Serializer to validate request data for create() (POST) operations.
     """
-    # This causes field validation to check for a UUID (in the request) and validates that a SubsidyAccessPolicy
-    # actually exists with that UUID.
-    subsidy_access_policy = serializers.PrimaryKeyRelatedField(queryset=SubsidyAccessPolicy.objects.all())
-
     class Meta:
         model = AssignmentConfiguration
         fields = [
             'uuid',
-            'subsidy_access_policy',
+            'enterprise_customer_uuid',
             'active',
         ]
         read_only_fields = [
@@ -50,50 +45,8 @@ class AssignmentConfigurationCreateRequestSerializer(serializers.ModelSerializer
         ]
         extra_kwargs = {
             'uuid': {'read_only': True},
-            'subsidy_access_policy': {
-                'allow_null': False,
-                'required': True,
-            },
             'active': {'read_only': True},
         }
-
-    @property
-    def calling_view(self):
-        """
-        Return the view that called this serializer.
-        """
-        return self.context['view']
-
-    def create(self, validated_data):
-        """
-        Get or create or reactivate an AssignmentConfiguration object.
-        """
-        # First, search for any AssignmentConfigs that share the requested SubsidyAccessPolicy, and return that if found
-        # (activating it if necessary). We will essentially treat the 'subsidy_access_policy' as the idempotency key for
-        # de-duplication purposes.
-        existing_subsidy_access_policy = validated_data['subsidy_access_policy']
-        found_assignment_config = existing_subsidy_access_policy.assignment_configuration
-        if found_assignment_config:
-            if not found_assignment_config.active:
-                found_assignment_config.active = True
-                found_assignment_config.save()
-            self.calling_view.set_assignment_config_created(False)
-            return found_assignment_config
-        self.calling_view.set_assignment_config_created(True)
-
-        # Copy the enterprise customer UUID from the SubsidyAccessPolicy into the new AssignmentConfiguration object.
-        validated_data['enterprise_customer_uuid'] = existing_subsidy_access_policy.enterprise_customer_uuid
-
-        # Actually create the new AssignmentConfiguration.
-        new_assignment_config = super().create(validated_data)
-
-        # Manually link the new AssignmentConfiguration to the existing SubsidyAccessPolicy.  For some reason this
-        # reverse relationship is not automatically created by virtue of validated_data having the
-        # 'subsidy_access_policy' key.
-        existing_subsidy_access_policy.assignment_configuration = new_assignment_config
-        existing_subsidy_access_policy.save()
-
-        return new_assignment_config
 
     def to_representation(self, instance):
         """

--- a/enterprise_access/apps/content_assignments/models.py
+++ b/enterprise_access/apps/content_assignments/models.py
@@ -3,6 +3,7 @@ Models for content_assignments
 """
 from uuid import UUID, uuid4
 
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django_extensions.db.models import TimeStampedModel
 from simple_history.models import HistoricalRecords
@@ -56,6 +57,14 @@ class AssignmentConfiguration(TimeStampedModel):
                 self._change_reason = kwargs['reason']  # pylint: disable=attribute-defined-outside-init
             self.active = False
             self.save()
+
+    @property
+    def policy(self):
+        """ Helper to safely fetch the related policy object or None. """
+        try:
+            return self.subsidy_access_policy  # pylint: disable=no-member
+        except ObjectDoesNotExist:
+            return None
 
 
 class LearnerContentAssignment(TimeStampedModel):

--- a/enterprise_access/apps/subsidy_access_policy/tests/factories.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/factories.py
@@ -27,6 +27,7 @@ class SubsidyAccessPolicyFactory(factory.django.DjangoModelFactory):
     catalog_uuid = factory.LazyFunction(uuid4)
     subsidy_uuid = factory.LazyFunction(uuid4)
     access_method = AccessMethods.DIRECT
+    description = 'A generic description'
     active = True
 
 

--- a/enterprise_access/utils.py
+++ b/enterprise_access/utils.py
@@ -22,3 +22,11 @@ def get_subsidy_model(subsidy_type):
     if subsidy_type == SubsidyTypeChoices.LICENSE:
         subsidy_model = apps.get_model('subsidy_request.LicenseRequest')
     return subsidy_model
+
+
+def is_not_none(thing):
+    return thing is not None
+
+
+def is_none(thing):
+    return thing is None


### PR DESCRIPTION
### Support validation at model and serializer level with common rule set
In adding another type of SubsidyAccessPolicy, I was finding it harder to write validation logic around what types of fields
certain policy types *must* have and which they *must not* have, in a way that was consistent across the model level and the DRF serialization level.
Background:
1. It's really nice to have some validation of fields on model instances at the point where the instance has been created/updated in-memory, but not yet saved.  This helps validate model instance manipulation across Django Admin and our business logic layers.
2. DRF _really_ doesn't want to do model-level validation in serializers; it strongly prefers to validate inputs *before* doing any in-memory model instance manipulation.  See https://www.django-rest-framework.org/community/3.0-announcement/#differences-between-modelserializer-validation-and-modelform , arguments confused over this: https://github.com/encode/django-rest-framework/issues/3144 and a blog post from DRF-maintainer about motivations for the decision: https://www.dabapps.com/insights/django-models-and-encapsulation/

So, with (1) and (2) at odds, I tried to introduce a tool where we can define constraints around custom policy model fields (think learner spend limit) in a fairly flexible way, and that's by defining the `FIELD_CONSTRAINTS` dict on each policy class.  There's also some model-base logic to make use of these for *model-level* validation, and a utility function in the policy serializers to use the same data structure for *serializer-level* validation.

This approach differs from our previous approach, which was more along the lines of "deny anything not explicitly listed in the allow list for this policy type".  `FIELD_CONSTRAINTS` makes use of python function to be able to say both "you must have this field" and "this field must be null" for the same type of policy.

### Policies strictly depend on assignments
We previously implemented the API for assignment configuration such that they depended on a policy record existing before a configuration could be created in the API.  Modifying the validation logic above highlighted the fact that this dependency direction is actually the _reverse_ of the direction we're trying to maintain of policies -> assignment configs.
This PR updates the assignment configuration views/serializers such that assignment configurations are created independently of subsidy access policies.