### PR TITLE
fix: learner-facing assignments endpoints broken

### DIFF
--- a/enterprise_access/apps/api/v1/views/content_assignments/assignments.py
+++ b/enterprise_access/apps/api/v1/views/content_assignments/assignments.py
@@ -8,7 +8,7 @@ from edx_rbac.decorators import permission_required
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework import authentication, mixins, permissions, status, viewsets
 
-from enterprise_access.apps.api import filters, serializers
+from enterprise_access.apps.api import filters, serializers, utils
 from enterprise_access.apps.api.v1.views.utils import PaginationWithPageCount
 from enterprise_access.apps.content_assignments.models import LearnerContentAssignment
 from enterprise_access.apps.core.constants import CONTENT_ASSIGNMENT_LEARNER_READ_PERMISSION
@@ -16,6 +16,16 @@ from enterprise_access.apps.core.constants import CONTENT_ASSIGNMENT_LEARNER_REA
 logger = logging.getLogger(__name__)
 
 CONTENT_ASSIGNMENT_CRUD_API_TAG = 'Content Assignment CRUD'
+
+
+def assignment_permission_fn(request, *args, assignment_configuration_uuid=None, **kwargs):
+    """
+    Helper to use with @permission_required on all endpoints.
+
+    Args:
+        assignment_configuration_uuid (str): UUID representing a LearnerContentAssignment object.
+    """
+    return utils.get_assignment_config_customer_uuid(assignment_configuration_uuid)
 
 
 class LearnerContentAssignmentViewSet(
@@ -65,7 +75,7 @@ class LearnerContentAssignmentViewSet(
             status.HTTP_404_NOT_FOUND: None,
         },
     )
-    @permission_required(CONTENT_ASSIGNMENT_LEARNER_READ_PERMISSION)
+    @permission_required(CONTENT_ASSIGNMENT_LEARNER_READ_PERMISSION, fn=assignment_permission_fn)
     def retrieve(self, request, *args, uuid=None, **kwargs):
         """
         Retrieves a single ``LearnerContentAssignment`` record by uuid, if assigned to the requesting user for this
@@ -77,7 +87,7 @@ class LearnerContentAssignmentViewSet(
         tags=[CONTENT_ASSIGNMENT_CRUD_API_TAG],
         summary='List content assignments.',
     )
-    @permission_required(CONTENT_ASSIGNMENT_LEARNER_READ_PERMISSION)
+    @permission_required(CONTENT_ASSIGNMENT_LEARNER_READ_PERMISSION, fn=assignment_permission_fn)
     def list(self, request, *args, **kwargs):
         """
         Lists ``LearnerContentAssignment`` records assigned to the requesting user for the given assignment


### PR DESCRIPTION
My last PR was missing some unit tests (added in this commit) which led to me missing the fact that learner-facing assignments endpoints were broken due to misconfigured ViewSet permissions.

ENT-7680