### PR TITLE
feat: allocate view expects non-negative content price. provide well-serialized non-allocation reasons

### DIFF
--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -497,8 +497,10 @@ class SubsidyAccessPolicyAllocateRequestSerializer(serializers.Serializer):
     )
     content_price_cents = serializers.IntegerField(
         required=True,
-        help_text='The price, in USD cents, of this content at the time of allocation. Must be <= 0.',
-        max_value=0,
+        help_text=(
+            'The price, in USD cents, of this content at the time of allocation. Must be >= 0.'
+        ),
+        min_value=0,
     )
 
 

--- a/enterprise_access/apps/api/v1/tests/test_allocation_view.py
+++ b/enterprise_access/apps/api/v1/tests/test_allocation_view.py
@@ -19,6 +19,14 @@ from enterprise_access.apps.core.constants import (
     SYSTEM_ENTERPRISE_LEARNER_ROLE,
     SYSTEM_ENTERPRISE_OPERATOR_ROLE
 )
+from enterprise_access.apps.subsidy_access_policy.constants import (
+    REASON_CONTENT_NOT_IN_CATALOG,
+    REASON_NOT_ENOUGH_VALUE_IN_SUBSIDY,
+    REASON_POLICY_EXPIRED,
+    REASON_POLICY_SPEND_LIMIT_REACHED,
+    REASON_SUBSIDY_EXPIRED,
+    MissingSubsidyAccessReasonUserMessages
+)
 from enterprise_access.apps.subsidy_access_policy.models import AssignedLearnerCreditAccessPolicy
 from enterprise_access.apps.subsidy_access_policy.tests.factories import AssignedLearnerCreditAccessPolicyFactory
 from test_utils import APITest, APITestWithMocks
@@ -26,9 +34,10 @@ from test_utils import APITest, APITestWithMocks
 SUBSIDY_ACCESS_POLICY_LIST_ENDPOINT = reverse('api:v1:subsidy-access-policies-list')
 
 TEST_ENTERPRISE_UUID = uuid4()
+OTHER_TEST_ENTERPRISE_UUID = uuid4()
 
 
-def _can_allocate_url(policy_uuid):
+def _allocation_url(policy_uuid):
     return reverse(
         "api:v1:policy-allocation-allocate",
         kwargs={"policy_uuid": policy_uuid},
@@ -55,7 +64,7 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
             enterprise_customer_uuid=cls.enterprise_uuid,
             active=True,
             assignment_configuration=cls.assignment_configuration,
-            spend_limit=1000000,
+            spend_limit=10000 * 100,
         )
 
         cls.alice_assignment = LearnerContentAssignmentFactory(
@@ -111,11 +120,11 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
             'no_change': [self.carol_assignment],
         }
 
-        allocate_url = _can_allocate_url(self.assigned_learner_credit_policy.uuid)
+        allocate_url = _allocation_url(self.assigned_learner_credit_policy.uuid)
         allocate_payload = {
             'learner_emails': ['alice@foo.com', 'bob@foo.com', 'carol@foo.com'],
             'content_key': self.content_key,
-            'content_price_cents': -12345,
+            'content_price_cents': 12345,
         }
 
         response = self.client.post(allocate_url, data=allocate_payload)
@@ -181,25 +190,40 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
         'enterprise_access.apps.subsidy_access_policy.models.assignments_api.allocate_assignments',
         autospec=True,
     )
-    def test_cannot_allocate(self, mock_allocate, mock_can_allocate):
+    @mock.patch(
+        'enterprise_access.apps.api.v1.views.subsidy_access_policy.LmsApiClient',
+        return_value=mock.MagicMock(),
+    )
+    def test_cannot_allocate(self, mock_lms_api_client, mock_allocate, mock_can_allocate):
         """
         When the policy is un-allocatable, a request to allocate results in a
         422 response and no allocation takes place.
         """
+        mock_lms_api_client().get_enterprise_customer_data.return_value = {
+            'slug': 'my-company',
+            'admin_users': [{'email': 'admin@example.com'}],
+        }
         mock_can_allocate.return_value = (False, 'some-reason')
 
-        allocate_url = _can_allocate_url(self.assigned_learner_credit_policy.uuid)
+        allocate_url = _allocation_url(self.assigned_learner_credit_policy.uuid)
         allocate_payload = {
             'learner_emails': ['alice@foo.com', 'bob@foo.com', 'carol@foo.com'],
             'content_key': self.content_key,
-            'content_price_cents': -12345,
+            'content_price_cents': 12345,
         }
 
         response = self.client.post(allocate_url, data=allocate_payload)
 
         self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
         self.assertEqual(
-            {'detail': 'some-reason'},
+            [
+                {
+                    'reason': 'some-reason',
+                    'user_message': 'None',
+                    'policy_uuids': [str(self.assigned_learner_credit_policy.uuid)],
+                    'metadata': {'enterprise_administrators': [{'email': 'admin@example.com'}]},
+                },
+            ],
             response.json(),
         )
         mock_can_allocate.assert_called_once_with(
@@ -215,23 +239,23 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
         'enterprise_access.apps.subsidy_access_policy.models.assignments_api.allocate_assignments',
         autospec=True,
     )
-    def test_cannot_allocate_positive_quantities(self, mock_allocate, mock_can_allocate):
+    def test_cannot_allocate_negative_quantities(self, mock_allocate, mock_can_allocate):
         """
-        Validate that you cannot request a positive amount of cents to allocate
+        Validate that you cannot request a negative amount of cents to allocate
         for a content key.
         """
-        allocate_url = _can_allocate_url(self.assigned_learner_credit_policy.uuid)
+        allocate_url = _allocation_url(self.assigned_learner_credit_policy.uuid)
         allocate_payload = {
             'learner_emails': ['alice@foo.com', 'bob@foo.com', 'carol@foo.com'],
             'content_key': self.content_key,
-            'content_price_cents': 1,
+            'content_price_cents': -1,
         }
 
         response = self.client.post(allocate_url, data=allocate_payload)
 
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         self.assertEqual(
-            {'content_price_cents': ['Ensure this value is less than or equal to 0.']},
+            {'content_price_cents': ['Ensure this value is greater than or equal to 0.']},
             response.json(),
         )
         self.assertFalse(mock_allocate.called)
@@ -249,11 +273,11 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
         """
         mock_can_allocate.return_value = (True, None)
 
-        allocate_url = _can_allocate_url(self.assigned_learner_credit_policy.uuid)
+        allocate_url = _allocation_url(self.assigned_learner_credit_policy.uuid)
         allocate_payload = {
             'learner_emails': ['alice@foo.com', 'bob@foo.com', 'carol@foo.com'],
             'content_key': self.content_key,
-            'content_price_cents': -12345,
+            'content_price_cents': 12345,
         }
 
         # manually acquire a lock on our policy before the request is made
@@ -270,6 +294,447 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
         )
         self.assertFalse(mock_can_allocate.called)
         self.assertFalse(mock_allocate.called)
+
+
+@ddt.ddt
+class TestSubsidyAccessPolicyAllocationEndToEnd(APITestWithMocks):
+    """
+    End-to-end tests for the ``allocate`` view, which ensure
+    that expected assignment records exist due to API calls,
+    and that allocation checks take existing state of assignments into account.
+    """
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.enterprise_uuid = OTHER_TEST_ENTERPRISE_UUID
+        cls.content_key = 'course-v1:edX+edXPrivacy101+3T2020'
+
+        # Create a pair of AssignmentConfiguration + SubsidyAccessPolicy for the main test customer.
+        cls.assignment_configuration = AssignmentConfigurationFactory(
+            enterprise_customer_uuid=cls.enterprise_uuid,
+        )
+        cls.assigned_learner_credit_policy = AssignedLearnerCreditAccessPolicyFactory(
+            display_name='An assigned learner credit policy, for the test customer.',
+            enterprise_customer_uuid=cls.enterprise_uuid,
+            active=True,
+            assignment_configuration=cls.assignment_configuration,
+            spend_limit=10000 * 100,
+        )
+
+    def setUp(self):
+        super().setUp()
+
+        self.enterprise_uuid = OTHER_TEST_ENTERPRISE_UUID
+
+        self.set_jwt_cookie([{
+            'system_wide_role': SYSTEM_ENTERPRISE_ADMIN_ROLE,
+            'context': str(self.enterprise_uuid),
+        }])
+
+        # clear any leftover allocation locks
+        self.addCleanup(django_cache.clear)
+
+        # delete all assignment records for our policy between test function runs
+        def delete_assignments():
+            return self.assignment_configuration.assignments.all().delete()
+
+        self.addCleanup(delete_assignments)
+
+    @mock.patch.object(
+        AssignedLearnerCreditAccessPolicy, 'catalog_contains_content_key', autospec=True, return_value=True
+    )
+    @mock.patch.object(
+        AssignedLearnerCreditAccessPolicy, 'is_subsidy_active', new_callable=mock.PropertyMock, return_value=True,
+    )
+    @mock.patch.object(
+        AssignedLearnerCreditAccessPolicy, 'subsidy_balance', autospec=True,
+    )
+    @mock.patch.object(
+        AssignedLearnerCreditAccessPolicy, 'aggregates_for_policy', autospec=True,
+    )
+    def test_allocate_happy_path_e2e(
+        self,
+        mock_aggregates_for_policy,
+        mock_subsidy_balance,
+        mock_is_subsidy_active,
+        mock_catalog_inclusion,
+    ):
+        """
+        Tests that the allocate view does the underlying checks and creates
+        assignment records as we'd expect.
+        """
+        mock_aggregates_for_policy.return_value = {
+            'total_quantity': -100 * 100,
+        }
+        mock_subsidy_balance.return_value = 10000 * 100
+        allocate_url = _allocation_url(self.assigned_learner_credit_policy.uuid)
+        allocate_payload = {
+            'learner_emails': ['new@foo.com'],
+            'content_key': self.content_key,
+            'content_price_cents': 123.45 * 100,  # policy limit is 100000.00 USD, so this should be well below limit
+        }
+
+        response = self.client.post(allocate_url, data=allocate_payload)
+
+        new_allocation = self.assignment_configuration.assignments.filter(
+            learner_email='new@foo.com',
+            state=LearnerContentAssignmentStateChoices.ALLOCATED,
+            content_key=self.content_key,
+            content_quantity=-123.45 * 100,
+        ).first()
+        self.assertIsNotNone(new_allocation)
+        expected_response_payload = {
+            'updated': [],
+            'created': [
+                {
+                    'assignment_configuration': str(self.assignment_configuration.uuid),
+                    'learner_email': 'new@foo.com',
+                    'lms_user_id': None,
+                    'content_key': self.content_key,
+                    'content_quantity': -123.45 * 100,
+                    'last_notification_at': None,
+                    'state': LearnerContentAssignmentStateChoices.ALLOCATED,
+                    'transaction_uuid': None,
+                    'uuid': str(new_allocation.uuid),
+                },
+            ],
+            'no_change': [],
+        }
+        self.assertEqual(expected_response_payload, response.json())
+        mock_is_subsidy_active.assert_called_once_with()  # No args for PropertyMock
+        mock_catalog_inclusion.assert_called_once_with(self.assigned_learner_credit_policy, self.content_key)
+        mock_aggregates_for_policy.assert_called_once_with(self.assigned_learner_credit_policy)
+        mock_subsidy_balance.assert_called_once_with(self.assigned_learner_credit_policy)
+
+    @mock.patch.object(
+        AssignedLearnerCreditAccessPolicy, 'catalog_contains_content_key', autospec=True, return_value=False
+    )
+    @mock.patch(
+        'enterprise_access.apps.api.v1.views.subsidy_access_policy.LmsApiClient',
+        return_value=mock.MagicMock(),
+    )
+    def test_allocate_no_catalog_inclusion_e2e(self, mock_lms_api_client, mock_catalog_inclusion):
+        """
+        Test that we get a 422 when the requested content is not in the catalog.
+        """
+        mock_lms_api_client().get_enterprise_customer_data.return_value = {
+            'slug': 'my-company',
+            'admin_users': [{'email': 'admin@example.com'}],
+        }
+
+        allocate_url = _allocation_url(self.assigned_learner_credit_policy.uuid)
+        allocate_payload = {
+            'learner_emails': ['new@foo.com'],
+            'content_key': self.content_key,
+            'content_price_cents': 1,
+        }
+
+        response = self.client.post(allocate_url, data=allocate_payload)
+
+        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
+        self.assertEqual(
+            [
+                {
+                    'reason': REASON_CONTENT_NOT_IN_CATALOG,
+                    'user_message': MissingSubsidyAccessReasonUserMessages.CONTENT_NOT_IN_CATALOG,
+                    'policy_uuids': [str(self.assigned_learner_credit_policy.uuid)],
+                    'metadata': {'enterprise_administrators': [{'email': 'admin@example.com'}]},
+                },
+            ],
+            response.json(),
+        )
+        mock_catalog_inclusion.assert_called_once_with(self.assigned_learner_credit_policy, self.content_key)
+
+    @mock.patch.object(
+        AssignedLearnerCreditAccessPolicy, 'catalog_contains_content_key', autospec=True, return_value=True
+    )
+    @mock.patch.object(
+        AssignedLearnerCreditAccessPolicy, 'is_subsidy_active', new_callable=mock.PropertyMock, return_value=False
+    )
+    @mock.patch(
+        'enterprise_access.apps.api.v1.views.subsidy_access_policy.LmsApiClient',
+        return_value=mock.MagicMock(),
+    )
+    def test_allocate_inactive_subsidy_e2e(self, mock_lms_api_client, mock_is_subsidy_active, mock_catalog_inclusion):
+        """
+        Test that we get a 422 when the requested subsidy is inactive.
+        """
+        mock_lms_api_client().get_enterprise_customer_data.return_value = {
+            'slug': 'my-company',
+            'admin_users': [{'email': 'admin@example.com'}],
+        }
+
+        allocate_url = _allocation_url(self.assigned_learner_credit_policy.uuid)
+        allocate_payload = {
+            'learner_emails': ['new@foo.com'],
+            'content_key': self.content_key,
+            'content_price_cents': 1,
+        }
+
+        response = self.client.post(allocate_url, data=allocate_payload)
+
+        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
+        self.assertEqual(
+            [
+                {
+                    'reason': REASON_SUBSIDY_EXPIRED,
+                    'user_message': MissingSubsidyAccessReasonUserMessages.ORGANIZATION_EXPIRED_FUNDS,
+                    'policy_uuids': [str(self.assigned_learner_credit_policy.uuid)],
+                    'metadata': {'enterprise_administrators': [{'email': 'admin@example.com'}]},
+                },
+            ],
+            response.json(),
+        )
+        mock_catalog_inclusion.assert_called_once_with(self.assigned_learner_credit_policy, self.content_key)
+        mock_is_subsidy_active.assert_called_once_with()  # No args for PropertyMock
+
+    @mock.patch(
+        'enterprise_access.apps.api.v1.views.subsidy_access_policy.LmsApiClient',
+        return_value=mock.MagicMock(),
+    )
+    def test_allocate_policy_expired_e2e(self, mock_lms_api_client):
+        """
+        Test that we get a 422 when the requested policy is inactive
+        """
+        assignment_configuration = AssignmentConfigurationFactory(
+            enterprise_customer_uuid=self.enterprise_uuid,
+        )
+        inactive_policy = AssignedLearnerCreditAccessPolicyFactory(
+            display_name='An assigned learner credit policy, for the test customer.',
+            enterprise_customer_uuid=self.enterprise_uuid,
+            active=False,
+            assignment_configuration=assignment_configuration,
+            spend_limit=10,
+        )
+        mock_lms_api_client().get_enterprise_customer_data.return_value = {
+            'slug': 'my-company',
+            'admin_users': [{'email': 'admin@example.com'}],
+        }
+
+        allocate_url = _allocation_url(inactive_policy.uuid)
+        allocate_payload = {
+            'learner_emails': ['new@foo.com'],
+            'content_key': self.content_key,
+            'content_price_cents': 1,
+        }
+
+        response = self.client.post(allocate_url, data=allocate_payload)
+
+        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
+        self.assertEqual(
+            [
+                {
+                    'reason': REASON_POLICY_EXPIRED,
+                    'user_message': MissingSubsidyAccessReasonUserMessages.ORGANIZATION_NO_FUNDS,
+                    'policy_uuids': [str(inactive_policy.uuid)],
+                    'metadata': {'enterprise_administrators': [{'email': 'admin@example.com'}]},
+                },
+            ],
+            response.json(),
+        )
+
+    @mock.patch.object(
+        AssignedLearnerCreditAccessPolicy, 'subsidy_balance', autospec=True,
+    )
+    @mock.patch.object(
+        AssignedLearnerCreditAccessPolicy, 'aggregates_for_policy', autospec=True,
+    )
+    @mock.patch.object(
+        AssignedLearnerCreditAccessPolicy, 'catalog_contains_content_key', autospec=True, return_value=True
+    )
+    @mock.patch.object(
+        AssignedLearnerCreditAccessPolicy, 'is_subsidy_active', new_callable=mock.PropertyMock, return_value=True
+    )
+    @mock.patch(
+        'enterprise_access.apps.api.v1.views.subsidy_access_policy.LmsApiClient',
+        return_value=mock.MagicMock(),
+    )
+    def test_allocate_too_much_subsidy_spend_e2e(
+        self,
+        mock_lms_api_client,
+        mock_is_subsidy_active,
+        mock_catalog_inclusion,
+        mock_aggregates_for_policy,
+        mock_subsidy_balance,
+    ):
+        """
+        Test that we get a 422 when allocating the requested amount would
+        exceed the remaining balance of the related subsidy/ledger.
+        """
+        mock_lms_api_client().get_enterprise_customer_data.return_value = {
+            'slug': 'my-company',
+            'admin_users': [{'email': 'admin@example.com'}],
+        }
+
+        subsidy_balance = 300
+        mock_subsidy_balance.return_value = subsidy_balance
+        mock_aggregates_for_policy.return_value = {
+            'total_quantity': (subsidy_balance - 1) * -1,
+        }
+
+        allocate_url = _allocation_url(self.assigned_learner_credit_policy.uuid)
+        allocate_payload = {
+            'learner_emails': ['new@foo.com'],
+            'content_key': self.content_key,
+            'content_price_cents': 2,
+        }
+
+        response = self.client.post(allocate_url, data=allocate_payload)
+
+        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
+        self.assertEqual(
+            [
+                {
+                    'reason': REASON_NOT_ENOUGH_VALUE_IN_SUBSIDY,
+                    'user_message': MissingSubsidyAccessReasonUserMessages.ORGANIZATION_NO_FUNDS,
+                    'policy_uuids': [str(self.assigned_learner_credit_policy.uuid)],
+                    'metadata': {'enterprise_administrators': [{'email': 'admin@example.com'}]},
+                },
+            ],
+            response.json(),
+        )
+        mock_catalog_inclusion.assert_called_once_with(self.assigned_learner_credit_policy, self.content_key)
+        mock_is_subsidy_active.assert_called_once_with()  # No args for PropertyMock
+        mock_subsidy_balance.assert_called_once_with(self.assigned_learner_credit_policy)
+        mock_aggregates_for_policy.assert_called_once_with(self.assigned_learner_credit_policy)
+
+    @mock.patch.object(
+        AssignedLearnerCreditAccessPolicy, 'subsidy_balance', autospec=True,
+    )
+    @mock.patch.object(
+        AssignedLearnerCreditAccessPolicy, 'aggregates_for_policy', autospec=True,
+    )
+    @mock.patch.object(
+        AssignedLearnerCreditAccessPolicy, 'catalog_contains_content_key', autospec=True, return_value=True
+    )
+    @mock.patch.object(
+        AssignedLearnerCreditAccessPolicy, 'is_subsidy_active', new_callable=mock.PropertyMock, return_value=True
+    )
+    @mock.patch(
+        'enterprise_access.apps.api.v1.views.subsidy_access_policy.LmsApiClient',
+        return_value=mock.MagicMock(),
+    )
+    def test_allocate_too_much_existing_allocation_e2e(
+        self,
+        mock_lms_api_client,
+        mock_is_subsidy_active,  # pylint: disable=unused-argument
+        mock_catalog_inclusion,  # pylint: disable=unused-argument
+        mock_aggregates_for_policy,
+        mock_subsidy_balance,
+    ):
+        """
+        Test that we get a 422 when allocating the requested amount would
+        exceed the remaining balance of the related subsidy/ledger when
+        more than 0 allocated assignments already exist for the policy.
+        """
+        mock_lms_api_client().get_enterprise_customer_data.return_value = {
+            'slug': 'my-company',
+            'admin_users': [{'email': 'admin@example.com'}],
+        }
+
+        subsidy_balance = 300
+        mock_subsidy_balance.return_value = subsidy_balance
+        mock_aggregates_for_policy.return_value = {
+            'total_quantity': (subsidy_balance - 2) * -1,
+        }
+
+        allocate_url = _allocation_url(self.assigned_learner_credit_policy.uuid)
+        allocate_payload = {
+            'learner_emails': ['new@foo.com'],
+            'content_key': self.content_key,
+            'content_price_cents': 1,
+        }
+
+        ok_response = self.client.post(allocate_url, data=allocate_payload)
+
+        # The spend alone, with no existing allocations, plus
+        # one more cent should be fine to allocate.
+        self.assertEqual(status.HTTP_202_ACCEPTED, ok_response.status_code)
+
+        # We should be right at the subsidy balance now,
+        # the next allocation request should fail.
+        allocate_payload = {
+            'learner_emails': ['blue@foo.com'],
+            'content_key': self.content_key,
+            'content_price_cents': 1,
+        }
+        response = self.client.post(allocate_url, data=allocate_payload)
+
+        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
+        self.assertEqual(
+            [
+                {
+                    'reason': REASON_NOT_ENOUGH_VALUE_IN_SUBSIDY,
+                    'user_message': MissingSubsidyAccessReasonUserMessages.ORGANIZATION_NO_FUNDS,
+                    'policy_uuids': [str(self.assigned_learner_credit_policy.uuid)],
+                    'metadata': {'enterprise_administrators': [{'email': 'admin@example.com'}]},
+                },
+            ],
+            response.json(),
+        )
+
+    @mock.patch.object(
+        AssignedLearnerCreditAccessPolicy, 'subsidy_balance', autospec=True,
+    )
+    @mock.patch.object(
+        AssignedLearnerCreditAccessPolicy, 'aggregates_for_policy', autospec=True,
+    )
+    @mock.patch.object(
+        AssignedLearnerCreditAccessPolicy, 'catalog_contains_content_key', autospec=True, return_value=True
+    )
+    @mock.patch.object(
+        AssignedLearnerCreditAccessPolicy, 'is_subsidy_active', new_callable=mock.PropertyMock, return_value=True
+    )
+    @mock.patch(
+        'enterprise_access.apps.api.v1.views.subsidy_access_policy.LmsApiClient',
+        return_value=mock.MagicMock(),
+    )
+    def test_allocate_policy_spend_limit_exceeded_e2e(
+        self,
+        mock_lms_api_client,
+        mock_is_subsidy_active,  # pylint: disable=unused-argument
+        mock_catalog_inclusion,  # pylint: disable=unused-argument
+        mock_aggregates_for_policy,
+        mock_subsidy_balance,
+    ):
+        """
+        Test that we get a 422 when allocating the requested amount would
+        exceed the spend limit of the policy (but pass every other check).
+        """
+        mock_lms_api_client().get_enterprise_customer_data.return_value = {
+            'slug': 'my-company',
+            'admin_users': [{'email': 'admin@example.com'}],
+        }
+
+        subsidy_balance = 15000 * 100
+        mock_subsidy_balance.return_value = subsidy_balance
+        mock_aggregates_for_policy.return_value = {
+            'total_quantity': 0,
+        }
+
+        allocate_url = _allocation_url(self.assigned_learner_credit_policy.uuid)
+        allocate_payload = {
+            'learner_emails': ['new@foo.com'],
+            'content_key': self.content_key,
+            'content_price_cents': (
+                self.assigned_learner_credit_policy.spend_limit + 10
+            ),
+        }
+
+        response = self.client.post(allocate_url, data=allocate_payload)
+
+        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
+        self.assertEqual(
+            [
+                {
+                    'reason': REASON_POLICY_SPEND_LIMIT_REACHED,
+                    'user_message': MissingSubsidyAccessReasonUserMessages.ORGANIZATION_NO_FUNDS,
+                    'policy_uuids': [str(self.assigned_learner_credit_policy.uuid)],
+                    'metadata': {'enterprise_administrators': [{'email': 'admin@example.com'}]},
+                },
+            ],
+            response.json(),
+        )
 
 
 @ddt.ddt
@@ -331,11 +796,11 @@ class TestAssignmentConfigurationUnauthorizedCRUD(APITest):
         if role_context_dict:
             self.set_jwt_cookie([role_context_dict])
 
-        allocate_url = _can_allocate_url(self.assigned_learner_credit_policy.uuid)
+        allocate_url = _allocation_url(self.assigned_learner_credit_policy.uuid)
         allocate_payload = {
             'learner_emails': ['alice@foo.com', 'bob@foo.com'],
             'content_key': 'the-content-key',
-            'content_price_cents': -12345,
+            'content_price_cents': 12345,
         }
 
         response = self.client.post(allocate_url, data=allocate_payload)

--- a/enterprise_access/apps/content_assignments/models.py
+++ b/enterprise_access/apps/content_assignments/models.py
@@ -3,7 +3,7 @@ Models for content_assignments
 """
 from uuid import UUID, uuid4
 
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import models
 from django.utils import timezone
 from django_extensions.db.models import TimeStampedModel
@@ -172,6 +172,13 @@ class LearnerContentAssignment(TimeStampedModel):
         return (
             f'uuid={self.uuid}, state={self.state}, learner_email={self.learner_email}, content_key={self.content_key}'
         )
+
+    def clean(self):
+        """
+        Validates that content_quantity <= 0.
+        """
+        if self.content_quantity and self.content_quantity > 0:
+            raise ValidationError(f'{self} cannot have a positive content quantity.')
 
     @classmethod
     def bulk_create(cls, assignment_records):

--- a/enterprise_access/apps/content_assignments/tests/test_api.py
+++ b/enterprise_access/apps/content_assignments/tests/test_api.py
@@ -108,18 +108,18 @@ class TestContentAssignmentApi(TestCase):
             actual_amount = get_allocated_quantity_for_configuration(other_config)
             self.assertEqual(actual_amount, 0)
 
-    def test_allocate_assignments_positive_quantity(self):
+    def test_allocate_assignments_negative_quantity(self):
         """
-        Tests the allocation of new assignments for a price > 0
+        Tests the allocation of new assignments for a price < 0
         raises an exception.
         """
         content_key = 'demoX'
-        content_price_cents = 1
+        content_price_cents = -1
         learners_to_assign = [
             f'{name}@foo.com' for name in ('alice', 'bob', 'carol', 'david', 'eugene')
         ]
 
-        with self.assertRaisesRegex(AllocationException, 'price must be <= 0'):
+        with self.assertRaisesRegex(AllocationException, 'price must be >= 0'):
             allocate_assignments(
                 self.assignment_configuration,
                 learners_to_assign,
@@ -132,7 +132,7 @@ class TestContentAssignmentApi(TestCase):
         Tests the allocation of new assignments against a given configuration.
         """
         content_key = 'demoX'
-        content_price_cents = -100
+        content_price_cents = 100
         learners_to_assign = [
             f'{name}@foo.com' for name in ('alice', 'bob', 'carol', 'david', 'eugene')
         ]
@@ -141,14 +141,14 @@ class TestContentAssignmentApi(TestCase):
             assignment_configuration=self.assignment_configuration,
             learner_email='alice@foo.com',
             content_key=content_key,
-            content_quantity=content_price_cents,
+            content_quantity=-content_price_cents,
             state=LearnerContentAssignmentStateChoices.ALLOCATED,
         )
         accepted_assignment = LearnerContentAssignmentFactory.create(
             assignment_configuration=self.assignment_configuration,
             learner_email='bob@foo.com',
             content_key=content_key,
-            content_quantity=content_price_cents,
+            content_quantity=-content_price_cents,
             state=LearnerContentAssignmentStateChoices.ACCEPTED,
         )
         cancelled_assignment = LearnerContentAssignmentFactory.create(
@@ -205,7 +205,7 @@ class TestContentAssignmentApi(TestCase):
         self.assertEqual(created_assignment.assignment_configuration, self.assignment_configuration)
         self.assertEqual(created_assignment.learner_email, 'eugene@foo.com')
         self.assertEqual(created_assignment.content_key, content_key)
-        self.assertEqual(created_assignment.content_quantity, content_price_cents)
+        self.assertEqual(created_assignment.content_quantity, -1 * content_price_cents)
         self.assertEqual(created_assignment.state, LearnerContentAssignmentStateChoices.ALLOCATED)
 
     def test_cancel_assignments_happy_path(self):

--- a/enterprise_access/apps/subsidy_access_policy/tests/test_models.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/test_models.py
@@ -927,3 +927,13 @@ class AssignedLearnerCreditAccessPolicyTests(MockPolicyDependenciesMixin, TestCa
         self.mock_assignments_api.get_allocated_quantity_for_configuration.assert_called_once_with(
             self.active_policy.assignment_configuration,
         )
+
+    def test_can_allocate_negative_quantity(self):
+        """
+        Test that attempting to allocate a negative quantity
+        results in a ValidationError.  The cost of the content should
+        be negated just prior to storing the ``content_quantity`` of
+        an assignment record.
+        """
+        with self.assertRaisesRegex(ValidationError, 'non-negative'):
+            self.active_policy.can_allocate(1, self.content_key, -1)


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-7689
Couple of main things here.
* Everything above the model/persistence layer now expects to deal in **non-negative** content prices in cents.  That is, the allocate view layer, serialization/validation, and business logic layers all want positive prices in cents, which are converted to negative `content_quantities` before assignment model instances are created/updated.
* We previously didn't have a good happy path, end-to-end test case for requests to the allocate view all the way through the `can_allocate()` business logic checks in the policy layer.  We now have such test cases.
* Changes in the allocate view to return more structured 422 responses, with reason-for-non-allocation error codes and corresponding user-facing messages; very similar to the response pattern for the redeem view.  Added good e2e tests for each of the possible reasons that something may be un-allocatable.