### PR TITLE
feat: serialize aggregates for policies to support budget details

### DIFF
--- a/enterprise_access/apps/api/tests/test_serializers.py
+++ b/enterprise_access/apps/api/tests/test_serializers.py
@@ -32,18 +32,27 @@ class TestSubsidyAccessPolicyResponseSerializer(TestCase):
     """
     @ddt.data(
         # Test environment: An oddball zero value subsidy, no redemptions, and no allocations.
-        {'starting_balance': 0, 'spend_limit': 0, 'redeemed': 0, 'allocated': 0, 'available': 0},
+        {'starting_balance': 0, 'spend_limit': 1, 'redeemed': 0, 'allocated': 0, 'available': 0},  # 000
+
+        # Test environment: 9 cent subsidy, oddball 0 cent policy.
+        # 4 possible cases, should always indicate no available spend.
+        {'starting_balance': 9, 'spend_limit': 0, 'redeemed': 0, 'allocated': 0, 'available': 0},  # 000
+        {'starting_balance': 9, 'spend_limit': 0, 'redeemed': 0, 'allocated': 1, 'available': 0},  # 010
+        {'starting_balance': 9, 'spend_limit': 0, 'redeemed': 1, 'allocated': 0, 'available': 0},  # 100
+        {'starting_balance': 9, 'spend_limit': 0, 'redeemed': 1, 'allocated': 1, 'available': 0},  # 110
 
         # Test environment: 9 cent subsidy, unlimited policy.
-        {'starting_balance': 9, 'spend_limit': 0, 'redeemed': 0, 'allocated': 0, 'available': 9},  # 001
-        {'starting_balance': 9, 'spend_limit': 0, 'redeemed': 0, 'allocated': 9, 'available': 0},  # 010
-        {'starting_balance': 9, 'spend_limit': 0, 'redeemed': 0, 'allocated': 5, 'available': 4},  # 011
-        {'starting_balance': 9, 'spend_limit': 0, 'redeemed': 9, 'allocated': 0, 'available': 0},  # 100
-        {'starting_balance': 9, 'spend_limit': 0, 'redeemed': 8, 'allocated': 0, 'available': 1},  # 101
-        {'starting_balance': 9, 'spend_limit': 0, 'redeemed': 5, 'allocated': 4, 'available': 0},  # 110
-        {'starting_balance': 9, 'spend_limit': 0, 'redeemed': 3, 'allocated': 3, 'available': 3},  # 111
+        # 7 possible cases, the sum of redeemed+allocated+available should always equal 9.
+        {'starting_balance': 9, 'spend_limit': 999, 'redeemed': 0, 'allocated': 0, 'available': 9},  # 001
+        {'starting_balance': 9, 'spend_limit': 999, 'redeemed': 0, 'allocated': 9, 'available': 0},  # 010
+        {'starting_balance': 9, 'spend_limit': 999, 'redeemed': 0, 'allocated': 5, 'available': 4},  # 011
+        {'starting_balance': 9, 'spend_limit': 999, 'redeemed': 9, 'allocated': 0, 'available': 0},  # 100
+        {'starting_balance': 9, 'spend_limit': 999, 'redeemed': 8, 'allocated': 0, 'available': 1},  # 101
+        {'starting_balance': 9, 'spend_limit': 999, 'redeemed': 5, 'allocated': 4, 'available': 0},  # 110
+        {'starting_balance': 9, 'spend_limit': 999, 'redeemed': 3, 'allocated': 3, 'available': 3},  # 111
 
         # Test environment: 9 cent subsidy, 8 cent policy.
+        # 7 possible cases, the sum of redeemed+allocated+available should always equal 8.
         {'starting_balance': 9, 'spend_limit': 8, 'redeemed': 0, 'allocated': 0, 'available': 8},  # 001
         {'starting_balance': 9, 'spend_limit': 8, 'redeemed': 0, 'allocated': 8, 'available': 0},  # 010
         {'starting_balance': 9, 'spend_limit': 8, 'redeemed': 0, 'allocated': 3, 'available': 5},  # 011

--- a/enterprise_access/apps/api/tests/test_serializers.py
+++ b/enterprise_access/apps/api/tests/test_serializers.py
@@ -1,20 +1,115 @@
 """
 Tests for the serializers in the API.
 """
+from datetime import datetime, timedelta
 from unittest import mock
 from uuid import uuid4
 
+import ddt
 from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
 
 from enterprise_access.apps.api.serializers.subsidy_access_policy import (
+    SubsidyAccessPolicyAggregatesSerializer,
     SubsidyAccessPolicyCreditsAvailableResponseSerializer,
     SubsidyAccessPolicyRedeemableResponseSerializer
 )
+from enterprise_access.apps.content_assignments.tests.factories import (
+    AssignmentConfigurationFactory,
+    LearnerContentAssignmentFactory
+)
 from enterprise_access.apps.subsidy_access_policy.tests.factories import (
+    AssignedLearnerCreditAccessPolicyFactory,
     PerLearnerEnrollmentCapLearnerCreditAccessPolicyFactory
 )
+
+
+@ddt.ddt
+class TestSubsidyAccessPolicyResponseSerializer(TestCase):
+    """
+    Tests for the SubsidyAccessPolicyResponseSerializer.
+    """
+    @ddt.data(
+        # Test environment: An oddball zero value subsidy, no redemptions, and no allocations.
+        {'starting_balance': 0, 'spend_limit': 0, 'redeemed': 0, 'allocated': 0, 'available': 0},
+
+        # Test environment: 9 cent subsidy, unlimited policy.
+        {'starting_balance': 9, 'spend_limit': 0, 'redeemed': 0, 'allocated': 0, 'available': 9},  # 001
+        {'starting_balance': 9, 'spend_limit': 0, 'redeemed': 0, 'allocated': 9, 'available': 0},  # 010
+        {'starting_balance': 9, 'spend_limit': 0, 'redeemed': 0, 'allocated': 5, 'available': 4},  # 011
+        {'starting_balance': 9, 'spend_limit': 0, 'redeemed': 9, 'allocated': 0, 'available': 0},  # 100
+        {'starting_balance': 9, 'spend_limit': 0, 'redeemed': 8, 'allocated': 0, 'available': 1},  # 101
+        {'starting_balance': 9, 'spend_limit': 0, 'redeemed': 5, 'allocated': 4, 'available': 0},  # 110
+        {'starting_balance': 9, 'spend_limit': 0, 'redeemed': 3, 'allocated': 3, 'available': 3},  # 111
+
+        # Test environment: 9 cent subsidy, 8 cent policy.
+        {'starting_balance': 9, 'spend_limit': 8, 'redeemed': 0, 'allocated': 0, 'available': 8},  # 001
+        {'starting_balance': 9, 'spend_limit': 8, 'redeemed': 0, 'allocated': 8, 'available': 0},  # 010
+        {'starting_balance': 9, 'spend_limit': 8, 'redeemed': 0, 'allocated': 3, 'available': 5},  # 011
+        {'starting_balance': 9, 'spend_limit': 8, 'redeemed': 8, 'allocated': 0, 'available': 0},  # 100
+        {'starting_balance': 9, 'spend_limit': 8, 'redeemed': 7, 'allocated': 0, 'available': 1},  # 101
+        {'starting_balance': 9, 'spend_limit': 8, 'redeemed': 4, 'allocated': 4, 'available': 0},  # 110
+        {'starting_balance': 9, 'spend_limit': 8, 'redeemed': 3, 'allocated': 3, 'available': 2},  # 111
+    )
+    @ddt.unpack
+    @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.subsidy_client')
+    def test_aggregates(
+        self,
+        mock_subsidy_client,
+        starting_balance,
+        spend_limit,
+        redeemed,
+        allocated,
+        available,
+    ):
+        """
+        Test that the policy aggregates serializer returns the correct aggregate values.
+        """
+        test_enterprise_uuid = uuid4()
+
+        # Synthesize subsidy with the current_balance derived from ``starting_balance`` and ``redeemed``.
+        test_subsidy_uuid = uuid4()
+        mock_subsidy_client.retrieve_subsidy.return_value = {
+            'uuid': str(test_subsidy_uuid),
+            'enterprise_customer_uuid': str(test_enterprise_uuid),
+            'active_datetime': datetime.utcnow() - timedelta(days=1),
+            'expiration_datetime': datetime.utcnow() + timedelta(days=1),
+            'current_balance': starting_balance - redeemed,
+            'is_active': True,
+        }
+
+        # Create a test policy with a limit set to ``policy_spend_limit``.  Reminder: a value of 0 means no limit.
+        assignment_configuration = AssignmentConfigurationFactory(
+            enterprise_customer_uuid=test_enterprise_uuid,
+        )
+        policy = AssignedLearnerCreditAccessPolicyFactory(
+            enterprise_customer_uuid=test_enterprise_uuid,
+            subsidy_uuid=test_subsidy_uuid,
+            spend_limit=spend_limit,
+            assignment_configuration=assignment_configuration,
+            active=True,
+        )
+
+        # Synthesize a number of 1 cent transactions equal to ``redeemed``.
+        mock_subsidy_client.list_subsidy_transactions.return_value = {
+            "results": [{"quantity": -1} for _ in range(redeemed)],
+            "aggregates": {"total_quantity": redeemed * -1},
+        }
+
+        # Synthesize a number of 1 cent assignments equal to ``allocated``.
+        for _ in range(allocated):
+            LearnerContentAssignmentFactory(
+                assignment_configuration=assignment_configuration,
+                content_quantity=-1,
+            )
+
+        serializer = SubsidyAccessPolicyAggregatesSerializer(policy)
+        data = serializer.data
+
+        assert data["amount_redeemed_usd_cents"] == redeemed
+        assert data["amount_allocated_usd_cents"] == allocated
+        assert data["spend_available_usd_cents"] == available
 
 
 class TestSubsidyAccessPolicyRedeemableResponseSerializer(TestCase):

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -78,6 +78,7 @@ class CRUDViewTestMixin:
             'id': 123455,
             'active_datetime': self.yesterday,
             'expiration_datetime': self.tomorrow,
+            'current_balance': 4,
             'is_active': True,
         }
         subsidy_client_patcher = patch.object(
@@ -229,8 +230,13 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
     """
 
     def setUp(self):
+        self.maxDiff = None
         super().setUp()
         super().setup_subsidy_mocks()
+        self.mock_subsidy_client.list_subsidy_transactions.return_value = {
+            "results": [{"quantity": -1}],
+            "aggregates": {"total_quantity": -1},
+        }
 
     @ddt.data(
         # A good admin role, but for a context/customer that doesn't match anything we're aware of, gets you a 403.
@@ -268,6 +274,14 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
             'subsidy_active_datetime': self.yesterday.isoformat(),
             'subsidy_expiration_datetime': self.tomorrow.isoformat(),
             'is_subsidy_active': True,
+            'aggregates': {
+                'amount_redeemed_usd_cents': 1,
+                'amount_redeemed_usd': 0.01,
+                'amount_allocated_usd_cents': 0,
+                'amount_allocated_usd': 0.00,
+                'spend_available_usd_cents': 2,
+                'spend_available_usd': 0.02,
+            }
         }, response.json())
 
     @ddt.data(
@@ -311,6 +325,14 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
                 'subsidy_active_datetime': self.yesterday.isoformat(),
                 'subsidy_expiration_datetime': self.tomorrow.isoformat(),
                 'is_subsidy_active': True,
+                'aggregates': {
+                    'amount_redeemed_usd_cents': 1,
+                    'amount_redeemed_usd': 0.01,
+                    'amount_allocated_usd_cents': 0,
+                    'amount_allocated_usd': 0.00,
+                    'spend_available_usd_cents': 4,
+                    'spend_available_usd': 0.04,
+                }
             },
             {
                 'access_method': 'direct',
@@ -328,6 +350,14 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
                 'subsidy_active_datetime': self.yesterday.isoformat(),
                 'subsidy_expiration_datetime': self.tomorrow.isoformat(),
                 'is_subsidy_active': True,
+                'aggregates': {
+                    'amount_redeemed_usd_cents': 1,
+                    'amount_redeemed_usd': 0.01,
+                    'amount_allocated_usd_cents': 0,
+                    'amount_allocated_usd': 0.00,
+                    'spend_available_usd_cents': 2,
+                    'spend_available_usd': 0.02,
+                }
             },
         ]
 
@@ -388,6 +418,14 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
             'subsidy_active_datetime': self.yesterday.isoformat(),
             'subsidy_expiration_datetime': self.tomorrow.isoformat(),
             'is_subsidy_active': True,
+            'aggregates': {
+                'amount_redeemed_usd_cents': 1,
+                'amount_redeemed_usd': 0.01,
+                'amount_allocated_usd_cents': 0,
+                'amount_allocated_usd': 0.00,
+                'spend_available_usd_cents': 2,
+                'spend_available_usd': 0.02,
+            }
         }
         self.assertEqual(expected_response, response.json())
 
@@ -458,6 +496,14 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
             'subsidy_active_datetime': self.yesterday.isoformat(),
             'subsidy_expiration_datetime': self.tomorrow.isoformat(),
             'is_subsidy_active': True,
+            'aggregates': {
+                'amount_redeemed_usd_cents': 1,
+                'amount_redeemed_usd': 0.01,
+                'amount_allocated_usd_cents': 0,
+                'amount_allocated_usd': 0.00,
+                'spend_available_usd_cents': 4,
+                'spend_available_usd': 0.04,
+            }
         }
         self.assertEqual(expected_response, response.json())
 

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -330,8 +330,8 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
                     'amount_redeemed_usd': 0.01,
                     'amount_allocated_usd_cents': 0,
                     'amount_allocated_usd': 0.00,
-                    'spend_available_usd_cents': 4,
-                    'spend_available_usd': 0.04,
+                    'spend_available_usd_cents': 0,
+                    'spend_available_usd': 0.00,
                 }
             },
             {

--- a/enterprise_access/apps/subsidy_access_policy/constants.py
+++ b/enterprise_access/apps/subsidy_access_policy/constants.py
@@ -43,10 +43,12 @@ class PolicyTypes:
 
     PER_LEARNER_ENROLLMENT_CREDIT = 'PerLearnerEnrollmentCreditAccessPolicy'
     PER_LEARNER_SPEND_CREDIT = 'PerLearnerSpendCreditAccessPolicy'
+    ASSIGNED_LEARNER_CREDIT = 'AssignedLearnerCreditAccessPolicy'
 
     CHOICES = (
         (PER_LEARNER_ENROLLMENT_CREDIT, PER_LEARNER_ENROLLMENT_CREDIT),
         (PER_LEARNER_SPEND_CREDIT, PER_LEARNER_SPEND_CREDIT),
+        (ASSIGNED_LEARNER_CREDIT, ASSIGNED_LEARNER_CREDIT),
     )
 
 

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -329,7 +329,7 @@ class SubsidyAccessPolicy(TimeStampedModel):
             int: quantity >= 0 of USD Cents representing the policy-wide spend available.
         """
         # This is how much available spend the policy limit would allow, ignoring the subsidy balance.
-        if self.spend_limit:
+        if self.spend_limit is not None:
             # total_redeemed is negative
             policy_limit_balance = max(0, self.spend_limit + self.total_redeemed)
             # Finally, take both the policy-wide limit and the subsidy balance into account:

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -318,11 +318,48 @@ class SubsidyAccessPolicy(TimeStampedModel):
         current_balance = self.subsidy_record().get('current_balance') or 0
         return int(current_balance)
 
-    def remaining_balance(self):
+    @property
+    def spend_available(self):
         """
-        Synonym for subsidy_balance().
+        Policy-wide spend available.  This takes only policy-wide limits into account (no per-learner or other
+        custom parameters) and is used in the enterprise admin dashboard to help summarize the high-level status of a
+        policy.
+
+        Returns:
+            int: quantity >= 0 of USD Cents representing the policy-wide spend available.
         """
-        return self.subsidy_balance()
+        # This is how much available spend the policy limit would allow, ignoring the subsidy balance.
+        if self.spend_limit:
+            # total_redeemed is negative
+            policy_limit_balance = max(0, self.spend_limit + self.total_redeemed)
+            # Finally, take both the policy-wide limit and the subsidy balance into account:
+            return min(policy_limit_balance, self.subsidy_balance())
+        else:
+            # Take ONLY the subsidy balance into account:
+            return self.subsidy_balance()
+
+    @property
+    def total_redeemed(self):
+        """
+        Total amount already transacted via this policy.
+
+        Returns:
+            int: quantity <= 0 of USD Cents.
+        """
+        return self.aggregates_for_policy().get('total_quantity') or 0
+
+    @property
+    def total_allocated(self):
+        """
+        Total amount of assignments currently allocated via this policy.
+
+        Override this in sub-classess that use assignments.  Empty definition needed here in order to make serializer
+        happy.
+
+        Returns:
+            int: negative USD cents representing the total amount of currently allocated assignments.
+        """
+        return 0
 
     def catalog_contains_content_key(self, content_key):
         """
@@ -427,9 +464,8 @@ class SubsidyAccessPolicy(TimeStampedModel):
             return False
 
         content_price = self.get_content_price(content_key, content_metadata=content_metadata)
-        spent_amount = self.aggregates_for_policy().get('total_quantity') or 0
 
-        return self.content_would_exceed_limit(spent_amount, self.spend_limit, content_price)
+        return self.content_would_exceed_limit(self.total_redeemed, self.spend_limit, content_price)
 
     def can_redeem(self, lms_user_id, content_key, skip_customer_user_check=False):
         """
@@ -552,7 +588,7 @@ class SubsidyAccessPolicy(TimeStampedModel):
             return False
 
         # verify associated subsidy has remaining balance
-        if self.remaining_balance() <= 0:
+        if self.subsidy_balance() <= 0:
             logger.info('[credit_available] SubsidyAccessPolicy.subsidy_record() returned empty balance')
             return False
 
@@ -949,6 +985,30 @@ class AssignedLearnerCreditAccessPolicy(CreditPolicyMixin, SubsidyAccessPolicy):
         """
         self.access_method = AccessMethods.ASSIGNED
         super().save(*args, **kwargs)
+
+    @property
+    def total_allocated(self):
+        """
+        Total amount of assignments currently allocated via this policy.
+
+        Returns:
+            int: Negative USD cents representing the total amount of currently allocated assignments.
+        """
+        return assignments_api.get_allocated_quantity_for_configuration(
+            self.assignment_configuration,
+        )
+
+    @property
+    def spend_available(self):
+        """
+        Policy-wide spend available.  This sub-class definition additionally takes assignments into account.
+
+        Returns:
+            int: quantity >= 0 of USD Cents representing the policy-wide spend available.
+        """
+        # super().spend_available is POSITIVE USD Cents representing available spend ignoring assignments.
+        # self.total_allocated is NEGATIVE USD Cents representing currently allocated assignments.
+        return max(0, super().spend_available + self.total_allocated)
 
     def can_redeem(self, lms_user_id, content_key, skip_customer_user_check=False):
         raise NotImplementedError


### PR DESCRIPTION
* Adds an "aggregates" key to the policy serializer containing a nested dict of values.
  - `amount_redeemed_usd_cents`: Total amount currently redeemed (positive USD Cents).
  - `amount_redeemed_usd`: Same as above, in USD dollars.
  - `amount_allocated_usd_cents`: Total amount currently allocated (positive USD Cents).
  - `amount_allocated_usd`: Same as above, in USD dollars.
  - `spend_available_usd_cents`: Total amount currently available to spend (positive USD Cents).
  - `spend_available_usd`: Same as above, in USD dollars.
* Removes unnecessarily layer of abstraction: remaining_balance() method deleted.
* Adds a missing policy type enum value: PolicyTypes.ASSIGNED_LEARNER_CREDIT

ENT-7693