### PR TITLE
feat: [assignments] backend support for "State" and "Recent action" columns

### DIFF
--- a/enterprise_access/apps/api/serializers/__init__.py
+++ b/enterprise_access/apps/api/serializers/__init__.py
@@ -1,7 +1,10 @@
 """
 API serializers module.
 """
-from .content_assignments.assignment import LearnerContentAssignmentResponseSerializer
+from .content_assignments.assignment import (
+    LearnerContentAssignmentAdminResponseSerializer,
+    LearnerContentAssignmentResponseSerializer
+)
 from .content_assignments.assignment_configuration import (
     AssignmentConfigurationCreateRequestSerializer,
     AssignmentConfigurationDeleteRequestSerializer,

--- a/enterprise_access/apps/api/v1/tests/test_allocation_view.py
+++ b/enterprise_access/apps/api/v1/tests/test_allocation_view.py
@@ -9,11 +9,7 @@ from django.core.cache import cache as django_cache
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from enterprise_access.apps.content_assignments.constants import (
-    AssignmentLearnerStates,
-    AssignmentRecentActionTypes,
-    LearnerContentAssignmentStateChoices
-)
+from enterprise_access.apps.content_assignments.constants import LearnerContentAssignmentStateChoices
 from enterprise_access.apps.content_assignments.tests.factories import (
     AssignmentConfigurationFactory,
     LearnerContentAssignmentFactory
@@ -147,11 +143,6 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
                     'transaction_uuid': None,
                     'uuid': str(self.alice_assignment.uuid),
                     'actions': [],
-                    'recent_action': {
-                        'action_type': AssignmentRecentActionTypes.ASSIGNED,
-                        'timestamp': self.alice_assignment.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
-                    },
-                    'learner_state': None,
                 },
             ],
             'created': [
@@ -166,11 +157,6 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
                     'transaction_uuid': None,
                     'uuid': str(self.bob_assignment.uuid),
                     'actions': [],
-                    'recent_action': {
-                        'action_type': AssignmentRecentActionTypes.ASSIGNED,
-                        'timestamp': self.bob_assignment.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
-                    },
-                    'learner_state': AssignmentLearnerStates.NOTIFYING,
                 },
             ],
             'no_change': [
@@ -185,11 +171,6 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
                     'transaction_uuid': None,
                     'uuid': str(self.carol_assignment.uuid),
                     'actions': [],
-                    'recent_action': {
-                        'action_type': AssignmentRecentActionTypes.ASSIGNED,
-                        'timestamp': self.carol_assignment.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
-                    },
-                    'learner_state': AssignmentLearnerStates.NOTIFYING,
                 },
             ],
         }
@@ -420,11 +401,6 @@ class TestSubsidyAccessPolicyAllocationEndToEnd(APITestWithMocks):
                     'transaction_uuid': None,
                     'uuid': str(new_allocation.uuid),
                     'actions': [],
-                    'recent_action': {
-                        'action_type': AssignmentRecentActionTypes.ASSIGNED,
-                        'timestamp': new_allocation.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
-                    },
-                    'learner_state': AssignmentLearnerStates.NOTIFYING,
                 },
             ],
             'no_change': [],

--- a/enterprise_access/apps/api/v1/tests/test_allocation_view.py
+++ b/enterprise_access/apps/api/v1/tests/test_allocation_view.py
@@ -9,7 +9,11 @@ from django.core.cache import cache as django_cache
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from enterprise_access.apps.content_assignments.constants import LearnerContentAssignmentStateChoices
+from enterprise_access.apps.content_assignments.constants import (
+    AssignmentLearnerStates,
+    AssignmentRecentActionTypes,
+    LearnerContentAssignmentStateChoices
+)
 from enterprise_access.apps.content_assignments.tests.factories import (
     AssignmentConfigurationFactory,
     LearnerContentAssignmentFactory
@@ -142,6 +146,12 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
                     'state': LearnerContentAssignmentStateChoices.ERRORED,
                     'transaction_uuid': None,
                     'uuid': str(self.alice_assignment.uuid),
+                    'actions': [],
+                    'recent_action': {
+                        'action_type': AssignmentRecentActionTypes.ASSIGNED,
+                        'timestamp': self.alice_assignment.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                    },
+                    'learner_state': None,
                 },
             ],
             'created': [
@@ -155,6 +165,12 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
                     'state': LearnerContentAssignmentStateChoices.ALLOCATED,
                     'transaction_uuid': None,
                     'uuid': str(self.bob_assignment.uuid),
+                    'actions': [],
+                    'recent_action': {
+                        'action_type': AssignmentRecentActionTypes.ASSIGNED,
+                        'timestamp': self.bob_assignment.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                    },
+                    'learner_state': AssignmentLearnerStates.NOTIFYING,
                 },
             ],
             'no_change': [
@@ -168,6 +184,12 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
                     'state': LearnerContentAssignmentStateChoices.ALLOCATED,
                     'transaction_uuid': None,
                     'uuid': str(self.carol_assignment.uuid),
+                    'actions': [],
+                    'recent_action': {
+                        'action_type': AssignmentRecentActionTypes.ASSIGNED,
+                        'timestamp': self.carol_assignment.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                    },
+                    'learner_state': AssignmentLearnerStates.NOTIFYING,
                 },
             ],
         }
@@ -323,6 +345,7 @@ class TestSubsidyAccessPolicyAllocationEndToEnd(APITestWithMocks):
 
     def setUp(self):
         super().setUp()
+        self.maxDiff = None
 
         self.enterprise_uuid = OTHER_TEST_ENTERPRISE_UUID
 
@@ -396,6 +419,12 @@ class TestSubsidyAccessPolicyAllocationEndToEnd(APITestWithMocks):
                     'state': LearnerContentAssignmentStateChoices.ALLOCATED,
                     'transaction_uuid': None,
                     'uuid': str(new_allocation.uuid),
+                    'actions': [],
+                    'recent_action': {
+                        'action_type': AssignmentRecentActionTypes.ASSIGNED,
+                        'timestamp': new_allocation.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                    },
+                    'learner_state': AssignmentLearnerStates.NOTIFYING,
                 },
             ],
             'no_change': [],

--- a/enterprise_access/apps/api/v1/tests/test_assignment_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_assignment_views.py
@@ -7,7 +7,11 @@ import ddt
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from enterprise_access.apps.content_assignments.constants import LearnerContentAssignmentStateChoices
+from enterprise_access.apps.content_assignments.constants import (
+    AssignmentLearnerStates,
+    AssignmentRecentActionTypes,
+    LearnerContentAssignmentStateChoices
+)
 from enterprise_access.apps.content_assignments.models import LearnerContentAssignment
 from enterprise_access.apps.content_assignments.tests.factories import (
     AssignmentConfigurationFactory,
@@ -91,6 +95,8 @@ class CRUDViewTestMixin:
             transaction_uuid=None,
             assignment_configuration=self.assignment_configuration,
         )
+        self.assignment_allocated_post_link.add_successful_linked_action()
+        self.assignment_allocated_post_link.add_successful_notified_action()
 
         # This assignment has been accepted by the learner (state=accepted), AND the assigned learner is the requester.
         self.requester_assignment_accepted = LearnerContentAssignmentFactory(
@@ -100,6 +106,8 @@ class CRUDViewTestMixin:
             transaction_uuid=uuid4(),
             assignment_configuration=self.assignment_configuration,
         )
+        self.requester_assignment_accepted.add_successful_linked_action()
+        self.requester_assignment_accepted.add_successful_notified_action()
 
         # This assignment has been accepted by the learner (state=accepted), AND the assigned learner is not the
         # requester.
@@ -109,6 +117,8 @@ class CRUDViewTestMixin:
             transaction_uuid=uuid4(),
             assignment_configuration=self.assignment_configuration,
         )
+        self.assignment_accepted.add_successful_linked_action()
+        self.assignment_accepted.add_successful_notified_action()
 
         # This assignment has been cancelled (state=cancelled), AND the assigned learner is the requester.
         self.requester_assignment_cancelled = LearnerContentAssignmentFactory(
@@ -118,6 +128,8 @@ class CRUDViewTestMixin:
             transaction_uuid=uuid4(),
             assignment_configuration=self.assignment_configuration,
         )
+        self.requester_assignment_cancelled.add_successful_linked_action()
+        self.requester_assignment_cancelled.add_successful_notified_action()
 
         # This assignment has been cancelled (state=cancelled), AND the assigned learner is not the requester.
         self.assignment_cancelled = LearnerContentAssignmentFactory(
@@ -126,6 +138,8 @@ class CRUDViewTestMixin:
             transaction_uuid=uuid4(),
             assignment_configuration=self.assignment_configuration,
         )
+        self.assignment_cancelled.add_successful_linked_action()
+        self.assignment_cancelled.add_successful_notified_action()
 
         # This assignment encountered a system error (state=errored), AND the assigned learner is the requester.
         self.requester_assignment_errored = LearnerContentAssignmentFactory(
@@ -135,6 +149,9 @@ class CRUDViewTestMixin:
             transaction_uuid=uuid4(),
             assignment_configuration=self.assignment_configuration,
         )
+        linked_action, _ = self.assignment_cancelled.add_successful_linked_action()
+        linked_action.error_reason = 'Phony error reason.'
+        linked_action.save()
 
         ###
         # Below are additional assignments pertaining to a completely different customer than the main test customer.
@@ -322,6 +339,20 @@ class TestAdminAssignmentAuthorizedCRUD(CRUDViewTestMixin, APITest):
             'lms_user_id': None,
             'state': LearnerContentAssignmentStateChoices.ALLOCATED,
             'transaction_uuid': self.assignment_allocated_pre_link.transaction_uuid,
+            'actions': [
+                {
+                    'uuid': str(action.uuid),
+                    'action_type': action.action_type,
+                    'completed_at': action.completed_at.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                    'error_reason': None,
+                }
+                for action in self.assignment_allocated_pre_link.actions.order_by('completed_at')
+            ],
+            'recent_action': {
+                'action_type': AssignmentRecentActionTypes.ASSIGNED,
+                'timestamp': self.assignment_allocated_pre_link.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+            },
+            'learner_state': AssignmentLearnerStates.NOTIFYING,
         }
 
     @ddt.data(
@@ -349,6 +380,110 @@ class TestAdminAssignmentAuthorizedCRUD(CRUDViewTestMixin, APITest):
         )
         expected_assignment_uuids = {assignment.uuid for assignment in expected_assignments_for_enterprise_customer}
         actual_assignment_uuids = {UUID(assignment['uuid']) for assignment in response.json()['results']}
+        assert actual_assignment_uuids == expected_assignment_uuids
+
+    @ddt.data(
+        None,
+        'recent_action_time',
+        '-recent_action_time',
+    )
+    def test_list_ordering_recent_action_time(self, ordering_key):
+        """
+        Test that the list view returns objects in the correct order when recent_action_time is the ordering key.  Also
+        check that when no ordering parameter is supplied, the default ordering uses recent_action_time.
+        """
+        self.set_jwt_cookie([{
+            'system_wide_role': SYSTEM_ENTERPRISE_OPERATOR_ROLE,
+            'context': str(TEST_ENTERPRISE_UUID),
+        }])
+
+        # Add reminder action to perturb the output ordering:
+        self.assignment_allocated_post_link.add_successful_reminded_action()
+
+        # Add non-reminder actions to another assignment to make sure it does NOT perturb the output ordering.
+        self.assignment_allocated_pre_link.add_successful_linked_action()
+        self.assignment_allocated_pre_link.add_successful_notified_action()
+
+        query_params = None
+        if ordering_key:
+            query_params = {'ordering': ordering_key}
+
+        # Send a list request for all Assignments for the main test customer, optionally with a specific ordering.
+        response = self.client.get(ADMIN_ASSIGNMENTS_LIST_ENDPOINT, data=query_params)
+
+        # Explicitly define the REVERSE order of assignments returned by the list view.  This should be the order if
+        # ?ordering=+recent_action_time
+        recent_action_time_ordering = [
+            # First 6 assignments oredered by their creation time.
+            self.assignment_allocated_pre_link,  # Still chronologically first, despite recent non-reminder actions.
+            self.requester_assignment_accepted,
+            self.assignment_accepted,
+            self.requester_assignment_cancelled,
+            self.assignment_cancelled,
+            self.requester_assignment_errored,
+            # This assignment was created first, but is knocked to the end of the list because we added a reminded
+            # action most recently.
+            self.assignment_allocated_post_link,
+        ]
+        expected_assignments_ordering = None
+        if not ordering_key or ordering_key.startswith('-'):
+            # The default ordering is reversed of chronological order.
+            expected_assignments_ordering = reversed(recent_action_time_ordering)
+        else:
+            # Ordering is chronological IFF ?ordering=recent_action_time
+            expected_assignments_ordering = recent_action_time_ordering
+        expected_assignment_uuids = [assignment.uuid for assignment in expected_assignments_ordering]
+        actual_assignment_uuids = [UUID(assignment['uuid']) for assignment in response.json()['results']]
+        assert actual_assignment_uuids == expected_assignment_uuids
+
+    @ddt.data(
+        'learner_state_sort_order',
+        '-learner_state_sort_order',
+    )
+    def test_list_ordering_learner_state_sort_order(self, ordering_key):
+        """
+        Test that the list view returns objects in the correct order when learner_state_sort_order is the ordering key.
+        """
+        self.set_jwt_cookie([{
+            'system_wide_role': SYSTEM_ENTERPRISE_OPERATOR_ROLE,
+            'context': str(TEST_ENTERPRISE_UUID),
+        }])
+
+        query_params = None
+        if ordering_key:
+            query_params = {'ordering': ordering_key}
+
+        # Send a list request for all Assignments for the main test customer, optionally with a specific ordering.
+        response = self.client.get(ADMIN_ASSIGNMENTS_LIST_ENDPOINT, data=query_params)
+
+        list_response_ordering = [
+            # First, list allocated, non-notified assignments.
+            self.assignment_allocated_pre_link,
+            # Then, list allocated, notified assignments.
+            self.assignment_allocated_post_link,
+            # Then, list errored assignments.
+            self.requester_assignment_errored,
+
+            # No need to test sort order of accepted and cancelled assignments since they are not displayed.
+            # self.assignment_accepted,
+            # self.requester_assignment_accepted,
+            # self.requester_assignment_cancelled,
+            # self.assignment_cancelled,
+        ]
+        expected_assignments_ordering = list_response_ordering
+        if ordering_key.startswith('-'):
+            # The default ordering is reversed of chronological order.
+            expected_assignments_ordering = reversed(list_response_ordering)
+        expected_assignment_uuids = [assignment.uuid for assignment in expected_assignments_ordering]
+        actual_assignment_uuids = [
+            UUID(assignment['uuid'])
+            for assignment in response.json()['results']
+            # Only gather the assignments with the states under test from the response.
+            if assignment['state'] in (
+                LearnerContentAssignmentStateChoices.ALLOCATED,
+                LearnerContentAssignmentStateChoices.ERRORED,
+            )
+        ]
         assert actual_assignment_uuids == expected_assignment_uuids
 
     def test_cancel(self):
@@ -449,6 +584,20 @@ class TestAssignmentAuthorizedCRUD(CRUDViewTestMixin, APITest):
             'lms_user_id': self.requester_assignment_accepted.lms_user_id,
             'state': LearnerContentAssignmentStateChoices.ACCEPTED,
             'transaction_uuid': str(self.requester_assignment_accepted.transaction_uuid),
+            'actions': [
+                {
+                    'uuid': str(action.uuid),
+                    'action_type': action.action_type,
+                    'completed_at': str(action.completed_at.strftime('%Y-%m-%dT%H:%M:%S.%fZ')),
+                    'error_reason': None,
+                }
+                for action in self.requester_assignment_accepted.actions.order_by('completed_at')
+            ],
+            'recent_action': {
+                'action_type': AssignmentRecentActionTypes.ASSIGNED,
+                'timestamp': self.requester_assignment_accepted.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+            },
+            'learner_state': None,
         }
 
     def test_retrieve_other_assignment_not_found(self):
@@ -480,7 +629,7 @@ class TestAssignmentAuthorizedCRUD(CRUDViewTestMixin, APITest):
     )
     def test_list(self, role_context_dict):
         """
-        Test that the list view returns a 200 response code and the expected (list) results of serialization..
+        Test that the list view returns a 200 response code and the expected (list) results of serialization.
 
         This also tests that only Assignments for the requesting user are returned.
         """

--- a/enterprise_access/apps/api/v1/tests/test_assignment_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_assignment_views.py
@@ -593,11 +593,6 @@ class TestAssignmentAuthorizedCRUD(CRUDViewTestMixin, APITest):
                 }
                 for action in self.requester_assignment_accepted.actions.order_by('completed_at')
             ],
-            'recent_action': {
-                'action_type': AssignmentRecentActionTypes.ASSIGNED,
-                'timestamp': self.requester_assignment_accepted.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
-            },
-            'learner_state': None,
         }
 
     def test_retrieve_other_assignment_not_found(self):

--- a/enterprise_access/apps/api/v1/views/content_assignments/assignments.py
+++ b/enterprise_access/apps/api/v1/views/content_assignments/assignments.py
@@ -61,6 +61,10 @@ class LearnerContentAssignmentViewSet(
         """
         A base queryset to list or retrieve ``LearnerContentAssignment`` records.  In this viewset, only the assignments
         assigned to the requester are returned.
+
+        Unlike in LearnerContentAssignmentAdminViewSet, here we are not going to annotate the extra dynamic fields using
+        `annotate_dynamic_fields_onto_queryset()`, so we will NOT serialize `learner_state` and `recent_action` for each
+        assignment.
         """
         return LearnerContentAssignment.objects.filter(
             learner_email=self.requesting_user_email,

--- a/enterprise_access/apps/api/v1/views/content_assignments/assignments_admin.py
+++ b/enterprise_access/apps/api/v1/views/content_assignments/assignments_admin.py
@@ -46,7 +46,7 @@ class LearnerContentAssignmentAdminViewSet(
     Viewset supporting all Admin CRUD operations on ``LearnerContentAssignment`` records.
     """
     permission_classes = (permissions.IsAuthenticated,)
-    serializer_class = serializers.LearnerContentAssignmentResponseSerializer
+    serializer_class = serializers.LearnerContentAssignmentAdminResponseSerializer
     authentication_classes = (JwtAuthentication, authentication.SessionAuthentication)
     filter_backends = (filters.NoFilterOnDetailBackend, OrderingFilter)
     filterset_class = filters.LearnerContentAssignmentAdminFilter
@@ -94,7 +94,7 @@ class LearnerContentAssignmentAdminViewSet(
         tags=[CONTENT_ASSIGNMENT_ADMIN_CRUD_API_TAG],
         summary='Retrieve a content assignment by UUID.',
         responses={
-            status.HTTP_200_OK: serializers.LearnerContentAssignmentResponseSerializer,
+            status.HTTP_200_OK: serializers.LearnerContentAssignmentAdminResponseSerializer,
             status.HTTP_404_NOT_FOUND: None,  # TODO: test that this actually returns 404 instead of 403 on RBAC error.
         },
     )
@@ -120,7 +120,7 @@ class LearnerContentAssignmentAdminViewSet(
         tags=[CONTENT_ASSIGNMENT_ADMIN_CRUD_API_TAG],
         summary='Cancel an assignment by UUID.',
         responses={
-            status.HTTP_200_OK: serializers.LearnerContentAssignmentResponseSerializer,
+            status.HTTP_200_OK: serializers.LearnerContentAssignmentAdminResponseSerializer,
             status.HTTP_404_NOT_FOUND: None,
             status.HTTP_422_UNPROCESSABLE_ENTITY: None,
         },
@@ -150,7 +150,7 @@ class LearnerContentAssignmentAdminViewSet(
             # Serialize the assignment object obtained via get_queryset() instead of the one from the assignments_api.
             # Only the former has the additional dynamic fields annotated, and those are required for serialization.
             assignment_to_cancel.refresh_from_db()
-            response_serializer = serializers.LearnerContentAssignmentResponseSerializer(assignment_to_cancel)
+            response_serializer = serializers.LearnerContentAssignmentAdminResponseSerializer(assignment_to_cancel)
             return Response(response_serializer.data, status=status.HTTP_200_OK)
         else:
             return Response(status=status.HTTP_422_UNPROCESSABLE_ENTITY)

--- a/enterprise_access/apps/content_assignments/constants.py
+++ b/enterprise_access/apps/content_assignments/constants.py
@@ -11,6 +11,7 @@ class LearnerContentAssignmentStateChoices:
     ACCEPTED = 'accepted'
     CANCELLED = 'cancelled'
     ERRORED = 'errored'
+
     CHOICES = (
         (ALLOCATED, 'Allocated'),
         (ACCEPTED, 'Accepted'),
@@ -51,4 +52,35 @@ class AssignmentActionErrors:
     CHOICES = (
         (EMAIL_ERROR, 'Email error'),
         (INTERNAL_API_ERROR, 'Internal API error'),
+    )
+
+
+class AssignmentRecentActionTypes:
+    """
+    Types for dynamic field: assignment.recent_action.
+    """
+    ASSIGNED = 'assigned'
+    REMINDED = 'reminded'
+    CHOICES = (
+        (ASSIGNED, 'Learner assigned content.'),
+        (REMINDED, 'Learner sent reminder message.'),
+    )
+
+
+class AssignmentLearnerStates:
+    """
+    States for dynamic field: assignment.learner_state.
+    """
+    NOTIFYING = 'notifying'
+    WAITING = 'waiting'
+    FAILED = 'failed'
+    CHOICES = (
+        (NOTIFYING, 'Sending assignment notification message to learner.'),
+        (WAITING, 'Waiting on learner to accept assignment.'),
+        (FAILED, 'Assignment unexpectedly failed creation or acceptance.'),
+    )
+    SORT_ORDER = (
+        NOTIFYING,
+        WAITING,
+        FAILED,
     )


### PR DESCRIPTION
Assignment serializer contains three additional output keys:

* `actions` (list of dict): A list of all serialized actions for the assignment.
* `recent_action` (dict): intended to power the "Recent action" column in the frontend display.
* `learner_state` (str): intended to power the "Status" column in the frontend display.

Assignment list views are now sortable on two keys:

* `learner_state_sort_order`: This sorts based on the internal sort order of dynamic field `learner_state`.
* `recent_action_time`: This is a dynamic field defined as `coalesce(most recent reminder, assignment creation)`

Sample URLs
-----------

Listing assignments sorted by learner_state:
```
/api/v1/assignment-configurations/{assignment_configuration_uuid}/admin/assignments/?ordering=learner_state_sort_order
/api/v1/assignment-configurations/{assignment_configuration_uuid}/admin/assignments/?ordering=-learner_state_sort_order
```

Listing assignments sorted by recent_action_time:
```
/api/v1/assignment-configurations/{assignment_configuration_uuid}/admin/assignments/?ordering=recent_action_time
/api/v1/assignment-configurations/{assignment_configuration_uuid}/admin/assignments/?ordering=-recent_action_time
```

Sample Response Snippets
------------------------

Serialized assignment:
```
{
    [...]
    'actions': [
        {
            'uuid': <action uuid>,
            'action_type': <one of AssignmentActions: ["learner_linked", "notified", "reminded"]>,
            'completed_at': <action completed_at timestamp>,
            'error_reason': <action error message>,
        },
        [...]
    ],
    'recent_action': {
        'action_type': <one of AssignmentRecentActionTypes: ["assigned", "reminded"]>,
        'timestamp': <timestamp of recent action>,
    },
    'learner_state': <one of AssignmentLearnerStates: ["notifying", "waiting", "failed"]>,
}
```

ENT-7780

---

Redoc preview:

![image](https://github.com/openedx/enterprise-access/assets/85151/ce7885c5-0bc2-4eaa-bf90-2713e4d0c513)
