### PR TITLE
feat: remove JWT_AUTH_REFRESH_COOKIE depr190

### DIFF
--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -291,7 +291,6 @@ JWT_AUTH = {
     'JWT_AUTH_COOKIE': 'edx-jwt-cookie',
     'JWT_AUTH_COOKIE_HEADER_PAYLOAD': 'edx-jwt-cookie-header-payload',
     'JWT_AUTH_COOKIE_SIGNATURE': 'edx-jwt-cookie-signature',
-    'JWT_AUTH_REFRESH_COOKIE': 'edx-jwt-refresh-cookie',
     'JWT_SECRET_KEY': 'SET-ME-PLEASE',
     # JWT_ISSUERS enables token decoding for multiple issuers (Note: This is not a native DRF-JWT field)
     # We use it to allow different values for the 'ISSUER' field, but keep the same SECRET_KEY and


### PR DESCRIPTION
**Description**:
The setting JWT_AUTH_REFRESH_COOKIE is meaningless and unused and should be cleaned up to avoid confusion.
In the very early days of introducing MFEs, we thought we were going to need this cookie in addition to the JWT cookie. However, it turned out we didn't need it, but the setting stuck around the contagion of it (being in cookiecutter and other template libraries) has resulted in it uselessly being copied to many repos.

**Supporting information:**
as per the original ticket https://github.com/openedx/public-engineering/issues/190, this setting is removed.

**Rationale**
The setting JWT_AUTH_REFRESH_COOKIE is meaningless and unused, and should be cleaned up to avoid confusion.

In the very early days of introducing MFEs, we thought we were going to need this cookie in addition to the JWT cookie. However, it turned out we didn't need it, but the setting stuck around the contagion of it (being in cookiecutter and other template libraries) has resulted in it uselessly being copied to many repos.

**Removal**
The setting JWT_AUTH_REFRESH_COOKIE can simply be removed with no ramifications.