### PR TITLE
fix: nested serialization of assignment config within policy

### DIFF
--- a/enterprise_access/apps/api/serializers/content_assignments/assignment_configuration.py
+++ b/enterprise_access/apps/api/serializers/content_assignments/assignment_configuration.py
@@ -14,8 +14,9 @@ class AssignmentConfigurationResponseSerializer(serializers.ModelSerializer):
     """
     A read-only Serializer for responding to requests for ``AssignmentConfiguration`` records.
     """
-    # This causes the related SubsidyAccessPolicy to be serialized as a UUID (in the response).
-    subsidy_access_policy = serializers.PrimaryKeyRelatedField(read_only=True)
+    subsidy_access_policy = serializers.SerializerMethodField(
+        help_text="The Assignment-based access policy related to this assignment configuration, if any.",
+    )
 
     class Meta:
         model = AssignmentConfiguration
@@ -26,6 +27,14 @@ class AssignmentConfigurationResponseSerializer(serializers.ModelSerializer):
             'active',
         ]
         read_only_fields = fields
+
+    def get_subsidy_access_policy(self, obj):
+        """
+        Returns a string-ified policy UUID for this assignment configuration, if one exists.
+        """
+        if policy := obj.policy:
+            return str(policy.uuid)
+        return None
 
 
 class AssignmentConfigurationCreateRequestSerializer(serializers.ModelSerializer):

--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -16,6 +16,7 @@ from enterprise_access.apps.subsidy_access_policy.constants import CENTS_PER_DOL
 from enterprise_access.apps.subsidy_access_policy.models import SubsidyAccessPolicy
 
 from .content_assignments.assignment import LearnerContentAssignmentResponseSerializer
+from .content_assignments.assignment_configuration import AssignmentConfigurationResponseSerializer
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +108,9 @@ class SubsidyAccessPolicyResponseSerializer(serializers.ModelSerializer):
         # This causes the entire unserialized model to be passed into the nested serializer.
         source='*',
     )
+    assignment_configuration = AssignmentConfigurationResponseSerializer(
+        help_text='AssignmentConfiguration object for this policy.',
+    )
 
     class Meta:
         model = SubsidyAccessPolicy
@@ -127,6 +131,7 @@ class SubsidyAccessPolicyResponseSerializer(serializers.ModelSerializer):
             'subsidy_expiration_datetime',
             'is_subsidy_active',
             'aggregates',
+            'assignment_configuration',
         ]
         read_only_fields = fields
 

--- a/enterprise_access/apps/api/v1/tests/test_assignment_configuration_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_assignment_configuration_views.py
@@ -206,12 +206,13 @@ class TestAssignmentConfigurationAuthorizedCRUD(CRUDViewTestMixin, APITest):
         response = self.client.get(detail_url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.json() == {
+        expected_config_response = {
             'uuid': str(self.assignment_configuration_existing.uuid),
             'active': True,
             'enterprise_customer_uuid': str(TEST_ENTERPRISE_UUID),
             'subsidy_access_policy': str(self.assigned_learner_credit_policy.uuid),
         }
+        assert response.json() == expected_config_response
 
     @ddt.data(
         # A good admin role, and with a context matching the main testing customer.

--- a/enterprise_access/apps/subsidy_access_policy/admin.py
+++ b/enterprise_access/apps/subsidy_access_policy/admin.py
@@ -101,6 +101,19 @@ class BaseSubsidyAccessPolicyMixin(admin.ModelAdmin):
             return None
         return cents_to_usd_string(obj.spend_limit)
 
+    def get_fieldsets(self, request, obj=None):
+        """
+        Render the API serialization only when we're not
+        adding a new policy record.
+        """
+        fieldsets = super().get_fieldsets(request, obj=obj)
+        if obj and not obj._state.adding:  # pylint: disable=protected-access
+            try:
+                return fieldsets + [('Extra', {'fields': ['api_serialized_repr']})]
+            except Exception:  # pylint: disable=broad-except
+                return fieldsets
+        return fieldsets
+
 
 @admin.register(models.PerLearnerEnrollmentCreditAccessPolicy)
 class PerLearnerEnrollmentCreditAccessPolicy(DjangoQLSearchMixin, BaseSubsidyAccessPolicyMixin):
@@ -143,12 +156,6 @@ class PerLearnerEnrollmentCreditAccessPolicy(DjangoQLSearchMixin, BaseSubsidyAcc
                     'per_learner_enrollment_limit',
                 ] if not super_admin_enabled() else EVERY_SPEND_LIMIT_FIELD
             }
-        ),
-        (
-            'Extra',
-            {
-                'fields': ['api_serialized_repr'],
-            },
         ),
     ]
 
@@ -199,12 +206,6 @@ class PerLearnerSpendCreditAccessPolicy(DjangoQLSearchMixin, BaseSubsidyAccessPo
                 ] if not super_admin_enabled() else EVERY_SPEND_LIMIT_FIELD
             }
         ),
-        (
-            'Extra',
-            {
-                'fields': ['api_serialized_repr'],
-            },
-        ),
     ]
 
     @admin.display(description='Per-learner spend limit (dollars)')
@@ -253,11 +254,5 @@ class LearnerContentAssignmentAccessPolicy(DjangoQLSearchMixin, BaseSubsidyAcces
                     'policy_spend_limit_dollars',
                 ] if not super_admin_enabled() else EVERY_SPEND_LIMIT_FIELD
             }
-        ),
-        (
-            'Extra',
-            {
-                'fields': ['api_serialized_repr'],
-            },
         ),
     ]


### PR DESCRIPTION
also, fixes policy django admin pages to not display policy serialization when adding a new record.

![image](https://github.com/openedx/enterprise-access/assets/2307986/981668eb-6224-4d31-9d2d-bfea073dedef)
