### PR TITLE
feat: populate assignment.lms_user_id on core.User.save()

### DIFF
--- a/enterprise_access/apps/content_assignments/apps.py
+++ b/enterprise_access/apps/content_assignments/apps.py
@@ -4,5 +4,14 @@ from django.apps import AppConfig
 
 
 class ContentAssignmentsConfig(AppConfig):
+    """
+    App config for content_assignments.
+    """
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'enterprise_access.apps.content_assignments'
+
+    def ready(self):
+        super().ready()
+
+        # pylint: disable=unused-import, import-outside-toplevel
+        import enterprise_access.apps.content_assignments.signals

--- a/enterprise_access/apps/content_assignments/signals.py
+++ b/enterprise_access/apps/content_assignments/signals.py
@@ -1,0 +1,36 @@
+"""
+Signal handlers for content_assignments app.
+"""
+import logging
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from enterprise_access.apps.content_assignments.models import LearnerContentAssignment
+from enterprise_access.apps.core.models import User
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(post_save, sender=User)
+def update_assignment_lms_user_id_from_user_email(sender, **kwargs):  # pylint: disable=unused-argument
+    """
+    Post save hook to update assignment lms_user_id from core user records.
+    """
+    user = kwargs['instance']
+    if user.lms_user_id:
+        assignments_to_update = LearnerContentAssignment.objects.filter(
+            learner_email=user.email,
+            lms_user_id=None,
+        )
+
+        # Update multiple assignments in a history-safe way.
+        for assignment in assignments_to_update:
+            assignment.lms_user_id = user.lms_user_id
+        num_assignments_updated = LearnerContentAssignment.bulk_update(assignments_to_update, ['lms_user_id'])
+
+        # Intentionally not logging PII (email).
+        if len(assignments_to_update) > 0:
+            logger.info(
+                f'Set lms_user_id={user.lms_user_id} on {num_assignments_updated} assignments for User.id={user.id}'
+            )

--- a/enterprise_access/apps/content_assignments/tests/test_signals.py
+++ b/enterprise_access/apps/content_assignments/tests/test_signals.py
@@ -1,0 +1,73 @@
+"""
+Signals and handlers tests.
+"""
+from django.test import TestCase
+from django.utils import timezone
+
+from enterprise_access.apps.content_assignments.tests.factories import LearnerContentAssignmentFactory
+from enterprise_access.apps.core.tests.factories import UserFactory
+
+TEST_EMAIL = 'test@example.com'
+
+
+class SignalsTests(TestCase):
+    """
+    Tests for signals and handlers.
+    """
+
+    def test_update_assignment_lms_user_id_from_user_email_registration(self):
+        """
+        Test that `update_assignment_lms_user_id_from_user_email()` correctly updates the `lms_user_id` field on any
+        assignments for new learners registering.
+        """
+        # Simulate creating asignments for the test learner BEFORE learner registration.
+        assignments_pre_register = [
+            LearnerContentAssignmentFactory(learner_email=TEST_EMAIL, lms_user_id=None),
+            LearnerContentAssignmentFactory(learner_email=TEST_EMAIL, lms_user_id=None),
+        ]
+        # Simulate registration by creating a user for test learner.
+        test_user = UserFactory(email=TEST_EMAIL)
+        # User creation *should* trigger the post_save hook to update lms_user_id for assignments_pre_create.
+        for assignment in assignments_pre_register:
+            assignment.refresh_from_db()
+            assert assignment.lms_user_id == test_user.lms_user_id
+
+    def test_update_assignment_lms_user_id_from_user_email_login(self):
+        """
+        Test that `update_assignment_lms_user_id_from_user_email()` correctly updates the `lms_user_id` field on any
+        assignments for existing learners logging in.
+        """
+        # Simulate registration by creating a user for test learner.
+        test_user = UserFactory(email=TEST_EMAIL)
+        # Simulate creating asignments for the test learner AFTER user creation.
+        assignments_post_register = [
+            LearnerContentAssignmentFactory(learner_email=TEST_EMAIL, lms_user_id=None),
+            LearnerContentAssignmentFactory(learner_email=TEST_EMAIL, lms_user_id=None),
+        ]
+        # Simulate the learner logging in.
+        test_user.last_login = timezone.now()
+        test_user.save()
+        # User login *should* trigger the post_save hook to update lms_user_id for assignments_post_create.
+        for assignment in assignments_post_register:
+            assignment.refresh_from_db()
+            assert assignment.lms_user_id == test_user.lms_user_id
+
+    def test_update_assignment_lms_user_id_from_user_email_other_assignments(self):
+        """
+        Test that `update_assignment_lms_user_id_from_user_email()` DOES NOT update any assignments for learners that
+        aren't registering/logging in during the test.
+        """
+        # Assignments for a different learner should never have their lms_user_id set during the course of this test.
+        assignments_other_learner = [
+            LearnerContentAssignmentFactory(learner_email='other@example.com', lms_user_id=None),
+            LearnerContentAssignmentFactory(learner_email='other@example.com', lms_user_id=None),
+        ]
+        # Simulate registration by creating a user for test learner.
+        test_user = UserFactory(email=TEST_EMAIL)
+        # Simulate the learner logging in.
+        test_user.last_login = timezone.now()
+        test_user.save()
+        # Assignments for other learners *should not* have their lms_user_id updated.
+        for assignment in assignments_other_learner:
+            assignment.refresh_from_db()
+            assert assignment.lms_user_id is None


### PR DESCRIPTION
During the post_save hook for core.User, lookup any existing assignments for the user and populate the lms_user_id into the assignments.  This should happen whenever the user logs in, so it theoretically covers the case where a learner is assigned content before authing with enterprise-access.

The case where a learner is assigned content AFTER authing with enterprise-access would be covered by ENT-7874.

ENT-7875