### PR TITLE
chore: allow optional logging of Django's SQL

### DIFF
--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -525,8 +525,13 @@ class SubsidyAccessPolicyCreditsAvailableResponseSerializer(SubsidyAccessPolicyR
 
     @extend_schema_field(serializers.IntegerField)
     def get_remaining_balance_per_user(self, obj):
-        lms_user_id = self.context.get('lms_user_id')
-        return obj.remaining_balance_per_user(lms_user_id=lms_user_id)
+        """
+        The remaining balance per user for this policy, in USD cents, if applicable.
+        """
+        if hasattr(obj, 'remaining_balance_per_user'):
+            lms_user_id = self.context.get('lms_user_id')
+            return obj.remaining_balance_per_user(lms_user_id=lms_user_id)
+        return None
 
     @extend_schema_field(serializers.IntegerField)
     def get_remaining_balance(self, obj):

--- a/enterprise_access/settings/local.py
+++ b/enterprise_access/settings/local.py
@@ -61,8 +61,22 @@ JWT_AUTH.update({
 ENABLE_AUTO_AUTH = True
 
 LOGGING = get_logger_config(debug=DEBUG)
+LOG_SQL = False
+
 
 #####################################################################
 # Lastly, see if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
     from .private import *  # pylint: disable=import-error
+
+    # LOG_SQL may be set to True in private.py, which will
+    # enable logging of SQL statements via the django.db.backends module.
+    if LOG_SQL:
+        LOGGING['loggers']['django.db.backends'] = {
+            'level': 'DEBUG',
+            'handlers': ['console'],
+            # We have a root 'django' logger enabled
+            # that we don't want to propagage too, so that
+            # this doesn't print multiple times.
+            'propagate': False,
+        }


### PR DESCRIPTION
We often want to understand which SQL statements are executed by the Django ORM, here's a change in `settings/local.py` to optional enable this via a setting in `private.py`.