### PR TITLE
fix: allow non-opaque-keys as content key for allocate requests

### DIFF
--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -604,7 +604,7 @@ class SubsidyAccessPolicyAllocateRequestSerializer(serializers.Serializer):
         allow_empty=False,
         help_text='Learner emails to whom LearnerContentAssignments should be allocated.',
     )
-    content_key = ContentKeyField(
+    content_key = serializers.CharField(
         required=True,
         help_text='Course content_key to which these learners are assigned.',
     )


### PR DESCRIPTION
Stops requiring allocate request payload `content_key` to be a valid opaque key.