### PR TITLE
Fetch content metadata for serialized assignments in `credits_available` response payload

### DIFF
--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -1325,12 +1325,14 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
             # with an inactive (i.e., expired, not yet started) subsidy, we should get no records back.
             assert len(response_json) == 0
 
+    @mock.patch('enterprise_access.apps.api.serializers.subsidy_access_policy.get_content_metadata_for_assignments')
     @mock.patch('enterprise_access.apps.subsidy_access_policy.models.get_and_cache_transactions_for_learner')
     @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.subsidy_record')
     def test_credits_available_endpoint_with_content_assignments(
         self,
         mock_subsidy_record,
-        mock_transactions_cache_for_learner  # pylint: disable=unused-argument
+        mock_transactions_cache_for_learner,  # pylint: disable=unused-argument
+        mock_get_metadata,
     ):
         """
         Verify that SubsidyAccessPolicyViewset credits_available returns learner content assignments for assigned
@@ -1360,6 +1362,8 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
             state=LearnerContentAssignmentStateChoices.ALLOCATED,
         )
         action, _ = assignment1.add_successful_linked_action()
+
+        # Implicitly tests that this response only includes allocated assignments
         LearnerContentAssignmentFactory.create(
             assignment_configuration=assignment_configuration,
             learner_email='bob@foo.com',
@@ -1379,6 +1383,31 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
             'is_active': True,
         }
         self.lms_client_instance.enterprise_contains_learner.return_value = True
+        query_params = {
+            'enterprise_customer_uuid': str(self.enterprise_uuid),
+            'lms_user_id': 1234,
+        }
+        # See LearnerContentAssignmentWithContentMetadataResponseSerializer
+        # for what we expect to be in the response payload w.r.t. content metadata.
+        mock_get_metadata.return_value = {
+            content_key: {
+                'key': content_key,
+                'normalized_metadata': {
+                    'start_date': '2020-01-01 12:00:00Z',
+                    'end_date': '2022-01-01 12:00:00Z',
+                    'enroll_by_date': '2021-01-01 12:00:00Z',
+                    'content_price': 123,
+                },
+                'owners': [
+                    {'name': 'Smart Folks', 'logo_image_url': 'http://pictures.yes'},
+                ],
+            },
+        }
+
+        response = self.client.get(self.subsidy_access_policy_credits_available_endpoint, query_params)
+
+        response_json = response.json()
+        self.assertEqual(len(response_json[0]['learner_content_assignments']), 1)
         expected_learner_content_assignment = {
             'uuid': str(assignment1.uuid),
             'assignment_configuration': str(assignment_configuration.uuid),
@@ -1399,15 +1428,17 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
                     'completed_at': action.completed_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                     'error_reason': None
                 }
-            ]
+            ],
+            'content_metadata': {
+                'start_date': '2020-01-01 12:00:00Z',
+                'end_date': '2022-01-01 12:00:00Z',
+                'enroll_by_date': '2021-01-01 12:00:00Z',
+                'content_price': 123,
+                'partners': [
+                    {'name': 'Smart Folks', 'logo_image_url': 'http://pictures.yes'},
+                ],
+            },
         }
-        query_params = {
-            'enterprise_customer_uuid': str(self.enterprise_uuid),
-            'lms_user_id': 1234,
-        }
-        response = self.client.get(self.subsidy_access_policy_credits_available_endpoint, query_params)
-        response_json = response.json()
-        self.assertEqual(len(response_json[0]['learner_content_assignments']), 1)
         self.assertEqual(response_json[0]['learner_content_assignments'][0], expected_learner_content_assignment)
 
 

--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -448,6 +448,9 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
         """
         Return a list of all redeemable policies for given `enterprise_customer_uuid`, `lms_user_id` that have
         redeemable credit available.
+        Note that, for each redeemable policy that is *assignable*, the policy record
+        in the response payload will also contain a list of `learner_content_assignments`
+        associated with the requested `lms_user_id`.
         """
         serializer = serializers.SubsidyAccessPolicyCreditsAvailableRequestSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
@@ -456,10 +459,13 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
         lms_user_id = serializer.data['lms_user_id']
 
         policies_with_credit_available = self.policies_with_credit_available(enterprise_customer_uuid, lms_user_id)
+
         response_data = serializers.SubsidyAccessPolicyCreditsAvailableResponseSerializer(
             policies_with_credit_available,
             many=True,
-            context={'lms_user_id': lms_user_id}
+            context={
+                'lms_user_id': lms_user_id,
+            },
         ).data
 
         return Response(

--- a/enterprise_access/apps/api_client/enterprise_catalog_client.py
+++ b/enterprise_access/apps/api_client/enterprise_catalog_client.py
@@ -32,3 +32,38 @@ class EnterpriseCatalogApiClient(BaseOAuthClient):
         response.raise_for_status()
         response_json = response.json()
         return response_json.get('contains_content_items', False)
+
+    def catalog_content_metadata(self, catalog_uuid, content_keys, traverse_pagination=True, **kwargs):
+        """
+        Returns a list of requested content metadata records for the given catalog_uuid.
+        See the enterprise-catalog ``EnterpriseCatalogGetContentMetadata`` view.
+
+        Arguments:
+            catalog_uuid (UUID): UUID of the enterprise catalog to check.
+            content_keys (list of str): List of content keys in the catalog for which metadata should be fetched.
+                Note that the endpoint called by this client only supports up to 100 keys per request.
+            traverse_pagination (bool, default True): If true, forces the requested endpoint
+                to tranverse pagination for us.
+                This means a single response payload will contain all results
+                and there's no need for us to fetch multiple pages.
+
+        Returns:
+            A paginated results dict, where the "results" key contains
+            a list of dicts. These are content metadata dicts for the requested keys
+            (as long as they are associated with the given catalog_uuid).
+            When the "next" key of results is not null, there are further
+            pages of results that can be fetched - it's up to the caller to fetch these.
+        """
+        if not content_keys and traverse_pagination:
+            raise Exception('Cannot request all metadata for a catalog when traverse_pagination is true.')
+
+        query_params = {
+            'content_keys': content_keys,
+            'traverse_pagination': traverse_pagination,
+            **kwargs,
+        }
+        endpoint = self.enterprise_catalog_endpoint + str(catalog_uuid) + '/get_content_metadata/'
+
+        response = self.client.get(endpoint, params=query_params)
+        response.raise_for_status()
+        return response.json()

--- a/enterprise_access/apps/api_client/tests/test_enterprise_catalog_client.py
+++ b/enterprise_access/apps/api_client/tests/test_enterprise_catalog_client.py
@@ -3,9 +3,11 @@ Tests for Discovery client.
 """
 
 from unittest import mock
+from uuid import uuid4
 
 from django.test import TestCase
 from requests import Response
+from requests.exceptions import HTTPError
 
 from enterprise_access.apps.api_client.enterprise_catalog_client import EnterpriseCatalogApiClient
 
@@ -34,4 +36,60 @@ class TestEnterpriseCatalogApiClient(TestCase):
         mock_oauth_client.return_value.get.assert_called_with(
             f'http://enterprise-catalog.example.com/api/v1/enterprise-catalogs/{ent_uuid}/contains_content_items/',
             params={'course_run_ids': ['AB+CD101']},
+        )
+
+    @mock.patch('enterprise_access.apps.api_client.base_oauth.OAuthAPIClient')
+    def test_catalog_content_metadata(self, mock_oauth_client):
+        content_keys = ['course+A', 'course+B']
+        mock_response_json = {
+            'next': None,
+            'results': [
+                {
+                    'key': content_keys[0],
+                    'other_metadata': 'foo',
+                },
+                {
+                    'key': content_keys[1],
+                    'other_metadata': 'bar',
+                }
+            ]
+        }
+
+        request_response = Response()
+        request_response.status_code = 200
+        mock_oauth_client.return_value.get.return_value.json.return_value = mock_response_json
+
+        customer_uuid = uuid4()
+        client = EnterpriseCatalogApiClient()
+        fetched_metadata = client.catalog_content_metadata(customer_uuid, content_keys)
+
+        self.assertEqual(fetched_metadata['results'], mock_response_json['results'])
+        mock_oauth_client.return_value.get.assert_called_with(
+            f'http://enterprise-catalog.example.com/api/v1/enterprise-catalogs/{customer_uuid}/get_content_metadata/',
+            params={
+                'content_keys': content_keys,
+                'traverse_pagination': True,
+            },
+        )
+
+    @mock.patch('enterprise_access.apps.api_client.base_oauth.OAuthAPIClient')
+    def test_catalog_content_metadata_raises_http_error(self, mock_oauth_client):
+        content_keys = ['course+A', 'course+B']
+        request_response = Response()
+        request_response.status_code = 400
+
+        mock_oauth_client.return_value.get.return_value = request_response
+
+        customer_uuid = uuid4()
+        client = EnterpriseCatalogApiClient()
+
+        with self.assertRaises(HTTPError):
+            client.catalog_content_metadata(customer_uuid, content_keys)
+
+        mock_oauth_client.return_value.get.assert_called_with(
+            f'http://enterprise-catalog.example.com/api/v1/enterprise-catalogs/{customer_uuid}/get_content_metadata/',
+            params={
+                'content_keys': content_keys,
+                'traverse_pagination': True,
+            },
         )

--- a/enterprise_access/apps/content_assignments/api.py
+++ b/enterprise_access/apps/content_assignments/api.py
@@ -12,6 +12,7 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator
 
+from enterprise_access.apps.content_metadata.api import get_and_cache_catalog_content_metadata
 from enterprise_access.apps.core.models import User
 from enterprise_access.apps.subsidy_access_policy.content_metadata_api import get_and_cache_content_metadata
 
@@ -436,4 +437,26 @@ def cancel_assignments(assignments: Iterable[LearnerContentAssignment]) -> dict:
     return {
         'cancelled': list(set(cancelled_assignments) | already_cancelled_assignments),
         'non_cancelable': list(non_cancelable_assignments),
+    }
+
+
+def get_content_metadata_for_assignments(enterprise_catalog_uuid, assignments):
+    """
+    Fetches (from cache or enterprise-catalog API call) content metadata
+    in bulk for the `content_keys` of the given assignments, provided
+    such metadata is related to the given `enterprise_catalog_uuid`.
+
+    Returns:
+        A dict mapping every content key of the provided assignments
+        to a content metadata dictionary, or null if no such dictionary
+        could be found for a given key.
+    """
+    content_keys = sorted({assignment.content_key for assignment in assignments})
+    content_metadata_list = get_and_cache_catalog_content_metadata(enterprise_catalog_uuid, content_keys)
+    metadata_by_key = {
+        record['key']: record for record in content_metadata_list
+    }
+    return {
+        assignment.content_key: metadata_by_key.get(assignment.content_key)
+        for assignment in assignments
     }

--- a/enterprise_access/apps/content_metadata/api.py
+++ b/enterprise_access/apps/content_metadata/api.py
@@ -1,0 +1,110 @@
+"""
+Python API for interacting with content metadata.
+TODO: refactor subsidy_access_policy/content_metadata_api.py
+into this module.
+"""
+import logging
+
+from django.conf import settings
+from django.core.cache import cache
+from requests.exceptions import HTTPError
+
+from enterprise_access.cache_utils import versioned_cache_key
+
+from ..api_client.enterprise_catalog_client import EnterpriseCatalogApiClient
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CACHE_TIMEOUT = getattr(settings, 'CONTENT_METADATA_CACHE_TIMEOUT', 60 * 5)
+
+
+def get_and_cache_catalog_content_metadata(enterprise_catalog_uuid, content_keys, timeout=None):
+    """
+    Returns the metadata corresponding to the requested
+    ``content_keys`` within the provided ``enterprise_catalog_uuid``,
+    as told by the enterprise-access service.  Utilizes a cache per-content-record,
+    that is, each combination of (enterprise_catalog_uuid, key) for key in content_keys
+    is cached independently.
+
+    Returns: A list of dictionaries containing content metadata for the given keys.
+    Raises: An HTTPError if there's a problem getting the content metadata
+      via the enterprise-catalog service.
+    """
+    # List of content metadata dicts we'll ultimately return
+    metadata_results_list = []
+
+    # We'll start with the assumption that we need to fetch every key
+    # from the catalog service, and then prune down as we find records
+    # in the cache
+    keys_to_fetch = set(content_keys)
+
+    # Maintains a mapping of cache keys for each content key
+    cache_keys_by_content_key = {}
+    for content_key in content_keys:
+        cache_key = versioned_cache_key(
+            'get_catalog_content_metadata',
+            enterprise_catalog_uuid,
+            content_key,
+        )
+        cache_keys_by_content_key[content_key] = cache_key
+
+    # Use our computed cache keys to do a bulk get from the Django cache
+    cached_content_metadata = cache.get_many(cache_keys_by_content_key.values())
+
+    # Go through our cache hits, append data to results and prune
+    # from the list of keys to fetch from the catalog service.
+    for content_key, cache_key in cache_keys_by_content_key.items():
+        if cache_key in cached_content_metadata:
+            logger.info(f'cache hit for catalog {enterprise_catalog_uuid} and content {content_key}')
+            metadata_results_list.append(cached_content_metadata[cache_key])
+            keys_to_fetch.remove(content_key)
+
+    # Here's the list of results fetched from the catalog service
+    fetched_metadata = []
+    if keys_to_fetch:
+        fetched_metadata = _fetch_metadata_with_client(enterprise_catalog_uuid, keys_to_fetch)
+
+    # Do a bulk set into the cache of everything we just had to fetch from the catalog service
+    content_metadata_to_cache = {}
+    for fetched_record in fetched_metadata:
+        cache_key = cache_keys_by_content_key.get(fetched_record.get('key'))
+        content_metadata_to_cache[cache_key] = fetched_record
+
+    cache.set_many(content_metadata_to_cache, timeout or DEFAULT_CACHE_TIMEOUT)
+
+    # Add to our results list everything we just had to fetch
+    metadata_results_list.extend(fetched_metadata)
+
+    # Log a warning for any content key that the caller asked for metadata about,
+    # but which was not found in cache OR from the catalog service.
+    missing_keys = set(content_keys) - {record.get('key') for record in metadata_results_list}
+    if missing_keys:
+        logger.warning(
+            'Could not fetch content keys %s from catalog %s',
+            missing_keys,
+            enterprise_catalog_uuid,
+        )
+
+    # Return our results list
+    return metadata_results_list
+
+
+def _fetch_metadata_with_client(enterprise_catalog_uuid, content_keys):
+    """
+    Helper to isolate the task of fetching content metadata via our client.
+    """
+    client = EnterpriseCatalogApiClient()
+    try:
+        response_payload = client.catalog_content_metadata(
+            enterprise_catalog_uuid,
+            list(content_keys),
+        )
+        results = response_payload['results']
+        logger.info(
+            'Fetched content metadata in catalog %s for the following content keys: %s',
+            enterprise_catalog_uuid,
+            [record.get('key') for record in results],
+        )
+        return results
+    except HTTPError as exc:
+        raise exc

--- a/enterprise_access/apps/content_metadata/tests/test_api.py
+++ b/enterprise_access/apps/content_metadata/tests/test_api.py
@@ -1,0 +1,94 @@
+"""
+Tests for the content_metadata/api.py functions.
+"""
+
+from unittest import mock
+from uuid import uuid4
+
+from django.test import TestCase
+from requests.exceptions import HTTPError
+
+from enterprise_access.apps.content_metadata import api
+
+
+class TestContentMetadataApi(TestCase):
+    """
+    Tests the content_metadata/api.py functions.
+    """
+    @mock.patch('enterprise_access.apps.content_metadata.api.EnterpriseCatalogApiClient', autospec=True)
+    def test_get_and_cache_metadata_happy_path(self, mock_client_class):
+        content_keys = ['course+A', 'course+B']
+        customer_uuid = uuid4()
+        # Mock results from the catalog content metadata API endpoint.
+        mock_result = {
+            'count': 2,
+            'results': [
+                {'key': 'course+A', 'data': 'things'}, {'key': 'course+B', 'data': 'stuff'},
+            ],
+        }
+        mock_client = mock_client_class.return_value
+        mock_client.catalog_content_metadata.return_value = mock_result
+
+        metadata_list = api.get_and_cache_catalog_content_metadata(customer_uuid, content_keys)
+
+        self.assertEqual(mock_client.catalog_content_metadata.call_count, 1)
+        # tease apart the call args, because the client is passed a set() of content keys to fetch
+        call_args, _ = mock_client.catalog_content_metadata.call_args_list[0]
+        self.assertEqual(call_args[0], customer_uuid)
+        self.assertEqual(sorted(call_args[1]), sorted(content_keys))
+        self.assertEqual(metadata_list, mock_result['results'])
+
+        # ask again to hit the cache, ensure that we're still at only one client fetch
+        metadata_list = api.get_and_cache_catalog_content_metadata(customer_uuid, content_keys)
+
+        self.assertEqual(mock_client.catalog_content_metadata.call_count, 1)
+        self.assertEqual(metadata_list, mock_result['results'])
+
+        # Now get-and-cache again, but this time request keys that meet the following criteria:
+        # 1. One key that should already be in the cache.
+        # 2. One key that's not cached, and that the mock client will return data about.
+        # 3. One key that's not cached, and for which the mock client won't return any data.
+        # one of which the mock server doesn't know about
+
+        new_content_keys = ['course+B', 'course+C', 'course+D']
+
+        # first, setup the mock client to give us data on one of the requested keys
+        mock_client.catalog_content_metadata.return_value = {
+            'count': 1,
+            'results': [
+                {'key': 'course+C', 'data': 'etc'},
+            ],
+        }
+
+        new_metadata_list = api.get_and_cache_catalog_content_metadata(customer_uuid, new_content_keys)
+
+        # Should only have requested courses C and D via the client
+        # tease apart the call args, because the client is passed a set() of content keys to fetch
+        self.assertEqual(mock_client.catalog_content_metadata.call_count, 2)
+        call_args, _ = mock_client.catalog_content_metadata.call_args_list[1]
+        self.assertEqual(call_args[0], customer_uuid)
+        self.assertEqual(sorted(call_args[1]), ['course+C', 'course+D'])
+
+        # And there will be results for courses B and C, but no result for course D
+        self.assertEqual(
+            sorted(new_metadata_list, key=lambda record: record['key']),
+            [
+                {'key': 'course+B', 'data': 'stuff'},
+                {'key': 'course+C', 'data': 'etc'}
+            ]
+        )
+
+    @mock.patch('enterprise_access.apps.content_metadata.api.EnterpriseCatalogApiClient', autospec=True)
+    def test_get_and_cache_metadata_http_error(self, mock_client_class):
+        content_keys = ['course+A', 'course+B']
+        customer_uuid = uuid4()
+        mock_client = mock_client_class.return_value
+        mock_client.catalog_content_metadata.side_effect = HTTPError('oh barnacles')
+
+        with self.assertRaisesRegex(HTTPError, 'oh barnacles'):
+            api.get_and_cache_catalog_content_metadata(customer_uuid, content_keys)
+
+        # tease apart the call args, because the client is passed a set() of content keys to fetch
+        call_args, _ = mock_client.catalog_content_metadata.call_args_list[0]
+        self.assertEqual(call_args[0], customer_uuid)
+        self.assertEqual(sorted(call_args[1]), sorted(content_keys))

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -232,6 +232,13 @@ class SubsidyAccessPolicy(TimeStampedModel):
                 return policy_class
         return None
 
+    @property
+    def is_assignable(self):
+        """
+        Convenience property to determine if this policy is assignable.
+        """
+        return self.access_method == AccessMethods.ASSIGNED
+
     def clean(self):
         """
         Used to help validate field values before saving this model instance.

--- a/enterprise_access/settings/devstack.py
+++ b/enterprise_access/settings/devstack.py
@@ -98,6 +98,7 @@ ENTERPRISE_ACCESS_URL = 'http://localhost:18270'
 
 # shell_plus
 SHELL_PLUS_IMPORTS = [
+    'from enterprise_access.apps.api_client import *',
     'from enterprise_access.apps.subsidy_request.utils import localized_utcnow',
     'from enterprise_access.apps.content_assignments import api as assignments_api',
     'from pprint import pprint',


### PR DESCRIPTION
This change allows us to pull-through content metadata from the enteprise-catalog `get_content_metadata` endpoint into serialized assignments contained within responses of the `credits_available` view.  
For example, in response to
```
curl --location 'http://localhost:18270/api/v1/policy-redemption/credits_available/?enterprise_customer_uuid=70699d54-7504-4429-8295-e1c0ec68dbc7&lms_user_id=8' \
```
you'd get 
```
[
    {
        "uuid": "3cc0ad2c-ede1-476c-8271-97683855e41d",
        "policy_redemption_url": "http://localhost:18270/api/v1/policy-redemption/3cc0ad2c-ede1-476c-8271-97683855e41d/redeem/",
        "remaining_balance_per_user": null,
        "remaining_balance": 482847,
        "subsidy_expiration_date": "2024-03-15T18:48:26Z",
        "learner_content_assignments": [
            {
                "uuid": "a7e12cd7-4c9a-41ef-82a6-bea4c9be0521",
                "assignment_configuration": "a9f97992-4894-4b80-9dde-b08ce3d7bff3",
                "learner_email": "verified@example.com",
                "lms_user_id": 8,
                "content_key": "course-v1:edX+DemoX+Demo_Course2",
                "content_title": null,
                "content_quantity": -200,
                "state": "allocated",
                "transaction_uuid": null,
                "last_notification_at": null,
                "actions": [],
                "content_metadata": null
            },
            {
                "uuid": "84cf3f51-2cd9-4632-9c93-809744e75fed",
                "assignment_configuration": "a9f97992-4894-4b80-9dde-b08ce3d7bff3",
                "learner_email": "verified@example.com",
                "lms_user_id": 8,
                "content_key": "edX+DemoX",
                "content_title": null,
                "content_quantity": -100,
                "state": "allocated",
                "transaction_uuid": null,
                "last_notification_at": null,
                "actions": [
                    {
                        "uuid": "d0f29825-c4d6-48f6-8f1b-4d456939e61c",
                        "action_type": "notified",
                        "completed_at": "2023-11-01T14:12:41Z",
                        "error_reason": null
                    }
                ],
                "content_metadata": {
                    "start_date": "2013-02-05T05:00:00Z",
                    "end_date": null,
                    "enroll_by_date": "2020-01-30T19:14:45.240399Z",
                    "content_price": 149,
                    "partners": [
                        {
                            "name": "edX",
                            "logo_image_url": "https://www.edx.org/images/logos/edx-logo-elm.svg"
                        }
                    ]
                }
            }
        ],
        "policy_type": "AssignedLearnerCreditAccessPolicy",
        "enterprise_customer_uuid": "70699d54-7504-4429-8295-e1c0ec68dbc7",
        "display_name": "test assignment policy",
        "description": "Assignment-based policy against Alex's third test subsidy.\r\nhttp://localhost:18280/admin/subsidy/subsidy/4c53f616-5ea0-42a0-9430-ba165cb2c916/change/\r\n\r\nCatalog record points at Test Enterprise's catalog:\r\nhttp://localhost:18000/admin/enterprise/enterprisecustomercatalog/482a8a38-f60d-4250-8f93-402cd5f69d3b/change/",
        "active": true,
        "catalog_uuid": "7467c9d2-433c-4f7e-ba2e-c5c7798527b2",
        "subsidy_uuid": "4c53f616-5ea0-42a0-9430-ba165cb2c916",
        "access_method": "assigned",
        "spend_limit": 1000000,
        "per_learner_enrollment_limit": null,
        "per_learner_spend_limit": null,
        "assignment_configuration": "a9f97992-4894-4b80-9dde-b08ce3d7bff3"
    }
]
```
Has good drf-spec docs at http://localhost:18270/api/schema/redoc/#tag/Subsidy-Access-Policy-Redemption/operation/api_v1_policy_redemption_credits_available_list

This PR built on top of some serialization changes in https://github.com/openedx/enterprise-access/pull/307