### PR TITLE
fix: missing content titles on assignments

### DIFF
--- a/enterprise_access/apps/api/v1/tests/test_allocation_view.py
+++ b/enterprise_access/apps/api/v1/tests/test_allocation_view.py
@@ -435,7 +435,7 @@ class TestSubsidyAccessPolicyAllocationEndToEnd(APITestWithMocks):
         assignment records as we'd expect.
         """
         mock_get_and_cache_content_metadata.return_value = {
-            'title': self.content_title,
+            'content_title': self.content_title,
         }
         mock_aggregates_for_policy.return_value = {
             'total_quantity': -100 * 100,

--- a/enterprise_access/apps/content_assignments/api.py
+++ b/enterprise_access/apps/content_assignments/api.py
@@ -291,7 +291,7 @@ def _get_content_title(assignment_configuration, content_key):
         assignment_configuration.enterprise_customer_uuid,
         content_key,
     )
-    return content_metadata.get('title')
+    return content_metadata.get('content_title')
 
 
 def _create_new_assignments(assignment_configuration, learner_emails, content_key, content_quantity):

--- a/enterprise_access/apps/content_assignments/tests/test_api.py
+++ b/enterprise_access/apps/content_assignments/tests/test_api.py
@@ -225,7 +225,7 @@ class TestContentAssignmentApi(TestCase):
             f'{name}@foo.com' for name in ('alice', 'bob', 'carol', 'david', 'eugene')
         ]
         mock_get_and_cache_content_metadata.return_value = {
-            'title': content_title,
+            'content_title': content_title,
         }
 
         allocated_assignment = LearnerContentAssignmentFactory.create(


### PR DESCRIPTION
## Description

- @adamstankiewicz was integration testing and noticed missing content titles on new assignments
- i realized i had [the wrong summary key](https://github.com/openedx/enterprise-subsidy/blob/main/enterprise_subsidy/apps/content_metadata/api.py#L110)