### PR TITLE
feat: return `learner_state_counts` as part of the admin assignments list API response

### DIFF
--- a/enterprise_access/apps/api/serializers/content_assignments/assignment.py
+++ b/enterprise_access/apps/api/serializers/content_assignments/assignment.py
@@ -215,6 +215,9 @@ class LearnerContentAssignmentWithContentMetadataResponseSerializer(LearnerConte
 
     @extend_schema_field(ContentMetadataForAssignmentSerializer)
     def get_content_metadata(self, obj):
+        """
+        Serializers content metadata for the assignment, if available.
+        """
         metadata_lookup = self.context.get('content_metadata')
         if metadata_lookup and (assignment_content_metadata := metadata_lookup.get(obj.content_key)):
             return ContentMetadataForAssignmentSerializer(assignment_content_metadata).data

--- a/enterprise_access/apps/api/v1/tests/test_assignment_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_assignment_views.py
@@ -388,9 +388,9 @@ class TestAdminAssignmentAuthorizedCRUD(CRUDViewTestMixin, APITest):
         assert actual_assignment_uuids == expected_assignment_uuids
 
         expected_learner_state_counts = [
-            { 'count': 1, 'learner_state': 'waiting' },
-            { 'count': 1, 'learner_state': 'notifying' },
-            { 'count': 1, 'learner_state': 'failed' },
+            {'count': 1, 'learner_state': 'waiting'},
+            {'count': 1, 'learner_state': 'notifying'},
+            {'count': 1, 'learner_state': 'failed'},
         ]
         assert response_json['learner_state_counts'] == expected_learner_state_counts
 

--- a/enterprise_access/apps/api/v1/tests/test_assignment_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_assignment_views.py
@@ -367,8 +367,8 @@ class TestAdminAssignmentAuthorizedCRUD(CRUDViewTestMixin, APITest):
     )
     def test_list(self, role_context_dict):
         """
-        Test that the list view returns a 200 response code and the expected (list) results of serialization.  It should
-        also allow system-wide admins and operators.
+        Test that the list view returns a 200 response code and the expected (list) results of serialization, including
+        the `learner_state_counts` overview metadata. It should also allow system-wide admins and operators.
 
         This also tests that only Assignment in the requested AssignmentConfiguration are returned.
         """
@@ -377,14 +377,22 @@ class TestAdminAssignmentAuthorizedCRUD(CRUDViewTestMixin, APITest):
 
         # Send a list request for all Assignments for the main test customer.
         response = self.client.get(ADMIN_ASSIGNMENTS_LIST_ENDPOINT)
+        response_json = response.json()
 
         # Only the Assignments for the main customer is returned, and not that of the other customer.
         expected_assignments_for_enterprise_customer = LearnerContentAssignment.objects.filter(
             assignment_configuration__enterprise_customer_uuid=TEST_ENTERPRISE_UUID
         )
         expected_assignment_uuids = {assignment.uuid for assignment in expected_assignments_for_enterprise_customer}
-        actual_assignment_uuids = {UUID(assignment['uuid']) for assignment in response.json()['results']}
+        actual_assignment_uuids = {UUID(assignment['uuid']) for assignment in response_json['results']}
         assert actual_assignment_uuids == expected_assignment_uuids
+
+        expected_learner_state_counts = [
+            { 'count': 1, 'learner_state': 'waiting' },
+            { 'count': 1, 'learner_state': 'notifying' },
+            { 'count': 1, 'learner_state': 'failed' },
+        ]
+        assert response_json['learner_state_counts'] == expected_learner_state_counts
 
     @ddt.data(
         None,

--- a/enterprise_access/apps/api/v1/views/content_assignments/assignments_admin.py
+++ b/enterprise_access/apps/api/v1/views/content_assignments/assignments_admin.py
@@ -4,14 +4,10 @@ Admin-facing REST API views for LearnerContentAssignments in the content_assignm
 import logging
 
 from django.db.models import Count
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, extend_schema, inline_serializer
+from drf_spectacular.utils import extend_schema
 from edx_rbac.decorators import permission_required
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
-from rest_framework import authentication, mixins, permissions
-from rest_framework import serializers as drf_serializers
-from rest_framework import status, viewsets
-from rest_framework.compat import coreapi
+from rest_framework import authentication, mixins, permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.response import Response

--- a/enterprise_access/apps/api/v1/views/content_assignments/assignments_admin.py
+++ b/enterprise_access/apps/api/v1/views/content_assignments/assignments_admin.py
@@ -157,7 +157,9 @@ class LearnerContentAssignmentAdminViewSet(
         response = super().list(request, *args, **kwargs)
         queryset = self.get_queryset()
         learner_state_counts = queryset.values('learner_state') \
-            .annotate(count=Count('uuid', distinct=True)).order_by('-count')
+            .exclude(learner_state__isnull=True) \
+            .annotate(count=Count('uuid', distinct=True)) \
+            .order_by('-count')
 
         # Add the learner_state_overview to the default response.
         response.data['learner_state_counts'] = learner_state_counts

--- a/enterprise_access/apps/api/v1/views/content_assignments/assignments_admin.py
+++ b/enterprise_access/apps/api/v1/views/content_assignments/assignments_admin.py
@@ -8,7 +8,9 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, inline_serializer
 from edx_rbac.decorators import permission_required
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
-from rest_framework import authentication, mixins, permissions, status, viewsets, serializers as drf_serializers
+from rest_framework import authentication, mixins, permissions
+from rest_framework import serializers as drf_serializers
+from rest_framework import status, viewsets
 from rest_framework.compat import coreapi
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter, SearchFilter

--- a/enterprise_access/apps/api/v1/views/utils.py
+++ b/enterprise_access/apps/api/v1/views/utils.py
@@ -17,3 +17,48 @@ class PaginationWithPageCount(DefaultPagination):
     # backwards compatibility with existing API clients.
     page_size = settings.REST_FRAMEWORK.get('PAGE_SIZE')
     max_page_size = 500
+
+    def get_paginated_response_schema(self, schema):
+        """
+        Annotate the paginated response schema with the extra fields provided by edx_rest_framework_extensions'
+        DefaultPagination class (e.g., `page_count`), ensuring these extra fields show up in the DRF Spectacular
+        generated docs.
+        """
+        return {
+            'type': 'object',
+            'properties': {
+                'count': {
+                    'type': 'integer',
+                    'description': 'The total number of items across all pages',
+                    'example': 123,
+                },
+                'page_count': {
+                    'type': 'integer',
+                    'description': 'The total number of pages',
+                    'example': 3,
+                },
+                'page_size': {
+                    'type': 'integer',
+                    'description': 'The number of items per page',
+                    'example': 50,
+                },
+                'current_page': {
+                    'type': 'integer',
+                    'description': 'The current page number',
+                    'example': 1,
+                },
+                'next': {
+                    'type': 'string',
+                    'description': 'Link to the next page of results',
+                    'nullable': True,
+                    'format': 'uri',
+                },
+                'previous': {
+                    'type': 'string',
+                    'description': 'Link to the previous page of results',
+                    'nullable': True,
+                    'format': 'uri',
+                },
+                'results': schema,
+            },
+        }


### PR DESCRIPTION
In order to support the default behavior of `DataTable` filtering with checkboxes on the "Status" column of the "Assigned" table in the Learner Credit Management's budget detail page, the paginated response of the admin content assignments list API now returns a `learner_state_counts` field that will adhere to any queryset filters, etc.

Allows the frontend UI to iterate over `learner_state_counts` to display the following:

<img width="1434" alt="image" src="https://github.com/openedx/enterprise-access/assets/2828721/52905841-9eb6-4499-91fe-ba7106ee729c">

### Example API response

```python
{
    "next": null,
    "previous": null,
    "count": 21,
    "num_pages": 1,
    "current_page": 1,
    "start": 0,
    "results": [
        {
            "uuid": "b8cf11f9-8589-42d0-83d7-0e938636a8d8",
            "assignment_configuration": "d17b7d66-8289-404e-90a5-d534ead459f6",
            "learner_email": "[edx+018@example.com](mailto:edx+018@example.com)",
            "lms_user_id": null,
            "content_key": "ColumbiaX+CSMM.104x",
            "content_title": null,
            "content_quantity": -10000,
            "state": "allocated",
            "transaction_uuid": null,
            "last_notification_at": null,
            "actions": [],
            "recent_action": {
                "action_type": "assigned",
                "timestamp": "2023-11-07T13:29:44.086890Z"
            },
            "learner_state": "notifying",
            "error_reason": null
        },
       # ...
    ],
    "learner_state_counts": [
        {
            "learner_state": "notifying",
            "count": 20
        },
        {
            "learner_state": "waiting",
            "count": 1
        }
    ]
}
```

### Updated DRF Spectacular docs

The Redoc page now includes the extra pagination fields that were not currently depicted as well as the new `learner_state_counts` field.

<img width="1502" alt="image" src="https://github.com/openedx/enterprise-access/assets/2828721/646c1125-1f80-4b41-99b9-db67b9c9c6bf">

