### PR TITLE
fix: new approach to generate `learner_state_count` in admin assignments list API; add addtl ordering and filtering support

### DIFF
--- a/enterprise_access/apps/api/filters/base.py
+++ b/enterprise_access/apps/api/filters/base.py
@@ -1,7 +1,12 @@
 """
 Base FilterSet utility classes.
 """
+from django_filters import BaseInFilter, CharFilter
 from django_filters import rest_framework as drf_filters
+
+
+class CharInFilter(BaseInFilter, CharFilter):
+    pass
 
 
 class HelpfulFilterSet(drf_filters.FilterSet):

--- a/enterprise_access/apps/api/filters/content_assignments.py
+++ b/enterprise_access/apps/api/filters/content_assignments.py
@@ -2,7 +2,7 @@
 API Filters for resources defined in the ``assignment_policy`` app.
 """
 from ...content_assignments.models import AssignmentConfiguration, LearnerContentAssignment
-from .base import HelpfulFilterSet
+from .base import CharInFilter, HelpfulFilterSet
 
 
 class AssignmentConfigurationFilter(HelpfulFilterSet):
@@ -18,6 +18,8 @@ class LearnerContentAssignmentAdminFilter(HelpfulFilterSet):
     """
     Base filter for LearnerContentAssignment views.
     """
+    learner_state = CharInFilter(field_name='learner_state', lookup_expr='in')
+
     class Meta:
         model = LearnerContentAssignment
         fields = [
@@ -25,4 +27,5 @@ class LearnerContentAssignmentAdminFilter(HelpfulFilterSet):
             'learner_email',
             'lms_user_id',
             'state',
+            'learner_state',
         ]

--- a/enterprise_access/apps/api/v1/tests/test_assignment_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_assignment_views.py
@@ -388,8 +388,8 @@ class TestAdminAssignmentAuthorizedCRUD(CRUDViewTestMixin, APITest):
         assert actual_assignment_uuids == expected_assignment_uuids
 
         expected_learner_state_counts = [
-            {'count': 1, 'learner_state': 'waiting'},
             {'count': 1, 'learner_state': 'notifying'},
+            {'count': 1, 'learner_state': 'waiting'},
             {'count': 1, 'learner_state': 'failed'},
         ]
         assert response_json['learner_state_counts'] == expected_learner_state_counts

--- a/enterprise_access/apps/api/v1/tests/test_assignment_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_assignment_views.py
@@ -580,7 +580,6 @@ class TestAdminAssignmentAuthorizedCRUD(CRUDViewTestMixin, APITest):
         for assignment in response.json().get('results'):
             assert assignment.get('learner_state') in learner_states_to_query
 
-
     def test_assignment_search_query_param(self):
         """
         Test that the list view follows the default Django API filtering with the usage of the ``search`` query param.

--- a/enterprise_access/apps/api/v1/tests/test_assignment_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_assignment_views.py
@@ -388,9 +388,9 @@ class TestAdminAssignmentAuthorizedCRUD(CRUDViewTestMixin, APITest):
         assert actual_assignment_uuids == expected_assignment_uuids
 
         expected_learner_state_counts = [
-            {'count': 1, 'learner_state': 'notifying'},
-            {'count': 1, 'learner_state': 'waiting'},
             {'count': 1, 'learner_state': 'failed'},
+            {'count': 1, 'learner_state': 'waiting'},
+            {'count': 1, 'learner_state': 'notifying'},
         ]
         assert response_json['learner_state_counts'] == expected_learner_state_counts
 

--- a/enterprise_access/apps/api/v1/views/content_assignments/assignments_admin.py
+++ b/enterprise_access/apps/api/v1/views/content_assignments/assignments_admin.py
@@ -1,8 +1,8 @@
 """
 Admin-facing REST API views for LearnerContentAssignments in the content_assignments app.
 """
-from collections import Counter
 import logging
+from collections import Counter
 
 from drf_spectacular.utils import extend_schema
 from edx_rbac.decorators import permission_required

--- a/enterprise_access/apps/api/v1/views/content_assignments/assignments_admin.py
+++ b/enterprise_access/apps/api/v1/views/content_assignments/assignments_admin.py
@@ -3,7 +3,6 @@ Admin-facing REST API views for LearnerContentAssignments in the content_assignm
 """
 import logging
 
-from django.db.models import Count, F, OuterRef, Subquery, Value
 from drf_spectacular.utils import extend_schema
 from edx_rbac.decorators import permission_required
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication


### PR DESCRIPTION
* Ensures `content_quantity` can be used with `?ordering`.
* Ensures `learner_state` ("Status" column) can be filtered by one or more values at a time (e.g., `learner_state=waiting`, `learner_state=notifying,failed`).
* Refactors how `learner_state_counts` is generated to no longer rely on `.values('learner_state').annotation(count=Count('uuid', distinct=True))`, which seems to be causing the exception seen in the following screenshot locally (not in stage/prod, though?). API now relies on `Counter` to determine the counts of each `learner_state`. It also now ensures `self.filter_queryset()` is called before generating these counts.

![image](https://github.com/openedx/enterprise-access/assets/2828721/56748385-4d00-43f7-9008-b382440c8988)