### PR TITLE
fix: avoid race condition during assignment allocation

### DIFF
--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -9,7 +9,6 @@ from contextlib import suppress
 import requests
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.db import transaction
 from django.utils.functional import cached_property
 from drf_spectacular.utils import extend_schema
 from edx_enterprise_subsidy_client import EnterpriseSubsidyAPIClient
@@ -798,7 +797,7 @@ class SubsidyAccessPolicyAllocateViewset(UserDetailsFromJwtMixin, PermissionRequ
         content_price_cents = serializer.data['content_price_cents']
 
         try:
-            with policy.lock(), transaction.atomic():
+            with policy.lock():
                 can_allocate, reason = policy.can_allocate(
                     len(learner_emails),
                     content_key,

--- a/enterprise_access/apps/content_assignments/tasks.py
+++ b/enterprise_access/apps/content_assignments/tasks.py
@@ -48,7 +48,7 @@ class CreatePendingEnterpriseLearnerForAssignmentTaskBase(LoggedTaskWithRetry): 
                     'The task failure resulted from exceeding the locally defined max number of retries '
                     '(settings.TASK_MAX_RETRIES).'
                 )
-        except assignment.DoesNotExist:
+        except learner_content_assignment_model.DoesNotExist:
             logger.error(f'LearnerContentAssignment not found with UUID: {learner_content_assignment_uuid}')
 
 


### PR DESCRIPTION
...in which we re-learn the lesson of invoking async celery tasks _outside_ of `transaction.atomic()` blocks.

The race condition occurs like so:
```
[MAIN PROC] DB TRANSACTION STARTS
[MAIN PROC] ASSIGNMENT ALPHA CREATED
[MAIN PROC] ASYNC TASK TO LINK LEARNERS INVOKED
[MAIN PROC] ...OTHER ASSIGNMENTS CREATED.
[CELERY WORKER PROC] TASK STARTS, GIVEN ALPHA UUID ARG
[CELERY WORKER PROC] TASK READS ASSIGNMENT TABLE FOR ALPHA UUID
[CELERY WORKER PROC] NO ASSIGNMENT WITH ALPHA UUID EXISTS, RAISE
[MAIN PROC] TRANSACTION COMMITTED
```