### PR TITLE
fix: record error action when learner-linking task fails.

### DIFF
--- a/enterprise_access/apps/content_assignments/models.py
+++ b/enterprise_access/apps/content_assignments/models.py
@@ -20,6 +20,7 @@ from .constants import (
     AssignmentRecentActionTypes,
     LearnerContentAssignmentStateChoices
 )
+from .utils import format_traceback
 
 BULK_OPERATION_BATCH_SIZE = 50
 
@@ -257,6 +258,16 @@ class LearnerContentAssignment(TimeStampedModel):
             },
         )
         return record, was_created
+
+    def add_errored_linked_action(self, exc):
+        """
+        Adds an errored "linked" action for this assignment record, given an exception instance.
+        """
+        return self.actions.create(
+            action_type=AssignmentActions.LEARNER_LINKED,
+            error_reason=AssignmentActionErrors.INTERNAL_API_ERROR,
+            traceback=format_traceback(exc),
+        )
 
     def get_successful_notified_action(self):
         """

--- a/enterprise_access/apps/content_assignments/tests/test_tasks.py
+++ b/enterprise_access/apps/content_assignments/tests/test_tasks.py
@@ -11,7 +11,11 @@ from requests.exceptions import HTTPError
 from rest_framework import status
 
 from enterprise_access.apps.api_client.tests.test_utils import MockResponse
-from enterprise_access.apps.content_assignments.constants import LearnerContentAssignmentStateChoices
+from enterprise_access.apps.content_assignments.constants import (
+    AssignmentActionErrors,
+    AssignmentActions,
+    LearnerContentAssignmentStateChoices
+)
 from enterprise_access.apps.content_assignments.tasks import (
     create_pending_enterprise_learner_for_assignment_task,
     send_cancel_email_for_pending_assignment
@@ -141,6 +145,9 @@ class TestCreatePendingEnterpriseLearnerForAssignmentTask(APITestWithMocks):
         # Finally, make sure the on_failure() handler successfully updated assignment state to errored.
         self.assignment.refresh_from_db()
         assert self.assignment.state == LearnerContentAssignmentStateChoices.ERRORED
+        action = self.assignment.actions.filter(action_type=AssignmentActions.LEARNER_LINKED).first()
+        self.assertIn('HTTPError', action.traceback)
+        self.assertEqual(action.error_reason, AssignmentActionErrors.INTERNAL_API_ERROR)
 
     @mock.patch('enterprise_access.apps.api_client.base_oauth.OAuthAPIClient')
     def test_last_retry_success(self, mock_oauth_client):

--- a/enterprise_access/apps/content_assignments/utils.py
+++ b/enterprise_access/apps/content_assignments/utils.py
@@ -1,6 +1,7 @@
 """
 Utility functions for the content_assignments app.
 """
+import traceback
 
 
 def chunks(a_list, chunk_size):
@@ -9,3 +10,7 @@ def chunks(a_list, chunk_size):
     """
     for i in range(0, len(a_list), chunk_size):
         yield a_list[i:i + chunk_size]
+
+
+def format_traceback(exception):
+    return ''.join(traceback.format_tb(exception.__traceback__))


### PR DESCRIPTION
ENT-7981 | Records an errored learner-linking action when the call to link pending learners fails during assignment allocation.

Locally, I forced my lms client method to raise an HTTPError on the pending learners call.
![image](https://github.com/openedx/enterprise-access/assets/2307986/af21812f-42d3-4f55-8d90-27e588ad3ea5)
