### PR TITLE
perf: improve allocate view latency

### DIFF
--- a/enterprise_access/apps/api/v1/tests/test_allocation_view.py
+++ b/enterprise_access/apps/api/v1/tests/test_allocation_view.py
@@ -765,7 +765,7 @@ class TestSubsidyAccessPolicyAllocationEndToEnd(APITestWithMocks):
     )
     @mock.patch(
         'enterprise_access.apps.content_assignments.api.get_and_cache_content_metadata',
-        return_value=mock.MagicMock(),
+        return_value={'content_title': 'the-title'},
     )
     @mock.patch(
         'enterprise_access.apps.content_assignments.api.create_pending_enterprise_learner_for_assignment_task'


### PR DESCRIPTION
1. `full_clean()` actually runs queries to validate uniqueness, and we don't need that here. switch to `clean()` instead. https://docs.djangoproject.com/en/4.2/ref/models/instances/#django.db.models.Model.full_clean
2. We only need to fetch the content title once, outside of the loop to create assignments.
3. Prefetch updated/created assignments at the tail end of allocation, so that any downstream serializers don't need to do N queries for actions.