### PR TITLE
feat!: allow in expr filtering for assignment view fields

### DIFF
--- a/enterprise_access/apps/api/filters/content_assignments.py
+++ b/enterprise_access/apps/api/filters/content_assignments.py
@@ -1,6 +1,8 @@
 """
 API Filters for resources defined in the ``assignment_policy`` app.
 """
+from django_filters import CharFilter
+
 from ...content_assignments.models import AssignmentConfiguration, LearnerContentAssignment
 from .base import CharInFilter, HelpfulFilterSet
 
@@ -18,14 +20,14 @@ class LearnerContentAssignmentAdminFilter(HelpfulFilterSet):
     """
     Base filter for LearnerContentAssignment views.
     """
-    learner_state = CharInFilter(field_name='learner_state', lookup_expr='in')
+    learner_state = CharFilter(field_name='learner_state', lookup_expr='exact')
+    learner_state__in = CharInFilter(field_name='learner_state', lookup_expr='in')
 
     class Meta:
         model = LearnerContentAssignment
-        fields = [
-            'content_key',
-            'learner_email',
-            'lms_user_id',
-            'state',
-            'learner_state',
-        ]
+        fields = {
+            'content_key': ['exact', 'in'],
+            'learner_email': ['exact', 'in'],
+            'lms_user_id': ['exact', 'in'],
+            'state': ['exact', 'in'],
+        }


### PR DESCRIPTION
ENT-7809 | Allow all fields that we filter assignments by to accept either exact filtering or "in" filtering.  This slightly changes the current usage of filtering on "learner_state" to remain consistent. Callers must now request filters on this field as "learner_state__in=state1,state2" instead of "learner_state=state1,state2".