### PR TITLE
feat: create assigned policy configuration on save

### DIFF
--- a/enterprise_access/apps/content_assignments/api.py
+++ b/enterprise_access/apps/content_assignments/api.py
@@ -43,6 +43,16 @@ class AllocationException(Exception):
     user_message = 'An error occurred during allocation'
 
 
+def create_assignment_configuration(enterprise_customer_uuid, **kwargs):
+    """
+    Create a new ``AssignmentConfiguration`` for the given customer identifier.
+    """
+    return AssignmentConfiguration.objects.create(
+        enterprise_customer_uuid=enterprise_customer_uuid,
+        **kwargs,
+    )
+
+
 def get_assignment_configuration(uuid):
     """
     Returns an `AssignmentConfiguration` record with the given uuid,

--- a/enterprise_access/apps/subsidy_access_policy/admin.py
+++ b/enterprise_access/apps/subsidy_access_policy/admin.py
@@ -229,6 +229,12 @@ class LearnerContentAssignmentAccessPolicy(DjangoQLSearchMixin, BaseSubsidyAcces
         'subsidy_uuid',
     )
 
+    readonly_fields = BaseSubsidyAccessPolicyMixin.readonly_fields + (
+        'assignment_configuration',
+        'per_learner_spend_limit',
+        'per_learner_enrollment_limit',
+    )
+
     fieldsets = [
         (
             'Base configuration',
@@ -243,7 +249,7 @@ class LearnerContentAssignmentAccessPolicy(DjangoQLSearchMixin, BaseSubsidyAcces
                     'assignment_configuration',
                     'created',
                     'modified',
-                ]
+                ],
             }
         ),
         (


### PR DESCRIPTION
ENT-7988 | Create an assigned policy's `assignment_configuration` on save() if none is present. Clean up django admin form for assigned policies.