### PR TITLE
fix: safely access dictionary

### DIFF
--- a/enterprise_access/apps/content_assignments/tasks.py
+++ b/enterprise_access/apps/content_assignments/tasks.py
@@ -187,8 +187,10 @@ def send_reminder_email_for_pending_assignment(assignment_uuid):
         )
         braze_trigger_properties["organization"] = enterprise_customer_data['name']
         braze_trigger_properties["course_title"] = assignment.content_title
-        braze_trigger_properties["enrollment_deadline"] = course_metadata['normalized_metadata']['enroll_by_date']
-        braze_trigger_properties["start_date"] = course_metadata['normalized_metadata']['start_date']
+        enrollment_deadline = course_metadata.get('normalized_metadata', {}).get('enroll_by_date')
+        braze_trigger_properties["enrollment_deadline"] = enrollment_deadline
+        start_date = course_metadata.get('normalized_metadata', {}).get('start_date')
+        braze_trigger_properties["start_date"] = start_date
         braze_trigger_properties["course_partner"] = course_metadata['owners'][0]['name']
         braze_trigger_properties["course_card_image"] = course_metadata['card_image_url']
         braze_trigger_properties["learner_portal_link"] = learner_portal_url
@@ -275,8 +277,10 @@ def send_email_for_new_assignment(new_assignment_uuid):
         )
         braze_trigger_properties["organization"] = enterprise_customer_data['name']
         braze_trigger_properties["course_title"] = assignment.content_title
-        braze_trigger_properties["enrollment_deadline"] = course_metadata['normalized_metadata']['enroll_by_date']
-        braze_trigger_properties["start_date"] = course_metadata['normalized_metadata']['start_date']
+        enrollment_deadline = course_metadata.get('normalized_metadata', {}).get('enroll_by_date')
+        braze_trigger_properties["enrollment_deadline"] = enrollment_deadline
+        start_date = course_metadata.get('normalized_metadata', {}).get('start_date')
+        braze_trigger_properties["start_date"] = start_date
         braze_trigger_properties["course_partner"] = _get_course_partners(course_metadata)
         braze_trigger_properties["course_card_image"] = course_metadata['card_image_url']
         braze_trigger_properties["learner_portal_link"] = learner_portal_url


### PR DESCRIPTION
## Description
- https://2u-internal.atlassian.net/browse/ENT-8031
- new relic alert paged me
- everywhere else in the code `normalized_metadata` is accessed its via `.get()` as if its not always there
- applying same pattern here

```
ubuntu@ip-172-31-34-253:~/edx-repos/enterprise-access$ grep -r normalized_metadata
grep: .git/objects/pack/pack-a6d5c57132f9f5afaa6c97138e5aea61488639e9.pack: binary file matches
enterprise_access/apps/content_assignments/tasks.py:        braze_trigger_properties["enrollment_deadline"] = course_metadata['normalized_metadata']['enroll_by_date']
enterprise_access/apps/content_assignments/tasks.py:        braze_trigger_properties["start_date"] = course_metadata['normalized_metadata']['start_date']
enterprise_access/apps/content_assignments/tasks.py:        braze_trigger_properties["enrollment_deadline"] = course_metadata['normalized_metadata']['enroll_by_date']
enterprise_access/apps/content_assignments/tasks.py:        braze_trigger_properties["start_date"] = course_metadata['normalized_metadata']['start_date']
grep: enterprise_access/apps/content_assignments/__pycache__/tasks.cpython-38.pyc: binary file matches
enterprise_access/apps/content_assignments/management/commands/automatically_expire_assignments.py:                    enrollment_end_date = content_metadata.get('normalized_metadata', {}).get('enroll_by_date')
enterprise_access/apps/content_assignments/management/commands/tests/test_automatically_expire_assignments.py:                'normalized_metadata': {
enterprise_access/apps/content_assignments/management/commands/tests/test_automatically_expire_assignments.py:                'normalized_metadata': {
enterprise_access/apps/content_assignments/tests/test_tasks.py:            'normalized_metadata': {
enterprise_access/apps/content_assignments/tests/test_tasks.py:            'normalized_metadata': {
enterprise_access/apps/api/serializers/content_assignments/assignment.py:        return obj.get('normalized_metadata', {}).get('start_date')
enterprise_access/apps/api/serializers/content_assignments/assignment.py:        return obj.get('normalized_metadata', {}).get('end_date')
enterprise_access/apps/api/serializers/content_assignments/assignment.py:        return obj.get('normalized_metadata', {}).get('enroll_by_date')
enterprise_access/apps/api/serializers/content_assignments/assignment.py:        return obj.get('normalized_metadata', {}).get('content_price')
grep: enterprise_access/apps/api/serializers/content_assignments/__pycache__/assignment.cpython-38.pyc: binary file matches
enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py:                'normalized_metadata': {
```