### PR TITLE
fix: braze alias stuff and other fixes

### DIFF
--- a/enterprise_access/apps/api_client/braze_client.py
+++ b/enterprise_access/apps/api_client/braze_client.py
@@ -76,3 +76,15 @@ class BrazeApiClient(BrazeClient):
             'send_to_existing_only': False,
             'trigger_properties': trigger_properties or {},
         }
+
+    def create_recipient_no_external_id(self, user_email):
+        """
+        Create a Braze recipient dict identified only by an alias based on their email.
+        """
+        return {
+            'attributes': {'email': user_email},
+            'user_alias': {
+                'alias_label': ENTERPRISE_BRAZE_ALIAS_LABEL,
+                'alias_name': user_email,
+            },
+        }

--- a/enterprise_access/apps/content_assignments/content_metadata_api.py
+++ b/enterprise_access/apps/content_assignments/content_metadata_api.py
@@ -8,7 +8,9 @@ from enterprise_access.apps.content_metadata.api import get_and_cache_catalog_co
 
 DATE_INPUT_PATTERNS = [
     '%Y-%m-%dT%H:%M:%SZ',
+    '%Y-%m-%dT%H:%M:%S.%fZ',
     '%Y-%m-%d %H:%M:%SZ',
+    '%Y-%m-%d %H:%M:%S.%fZ',
 ]
 
 

--- a/enterprise_access/apps/content_assignments/models.py
+++ b/enterprise_access/apps/content_assignments/models.py
@@ -294,6 +294,17 @@ class LearnerContentAssignment(TimeStampedModel):
         )
         return record, was_created
 
+    def add_errored_notified_action(self, exc):
+        """
+        Adds an errored action about the notification of the allocation of this assignment record,
+        given an exception instance.
+        """
+        return self.actions.create(
+            action_type=AssignmentActions.NOTIFIED,
+            error_reason=AssignmentActionErrors.EMAIL_ERROR,
+            traceback=format_traceback(exc),
+        )
+
     def get_last_successful_reminded_action(self):
         """
         Returns all successful "reminded" LearnerContentAssignmentActions for this assignment,
@@ -311,6 +322,54 @@ class LearnerContentAssignment(TimeStampedModel):
         return self.actions.create(
             action_type=AssignmentActions.REMINDED,
             completed_at=timezone.now(),
+        )
+
+    def add_errored_reminded_action(self, exc):
+        """
+        Adds an errored "reminded" LearnerContentAssignmentAction for this assignment record.
+        """
+        return self.actions.create(
+            action_type=AssignmentActions.REMINDED,
+            error_reason=AssignmentActionErrors.EMAIL_ERROR,
+            traceback=format_traceback(exc),
+        )
+
+    def add_successful_cancel_action(self):
+        """
+        Adds a successful "cancel" LearnerContentAssignmentAction for this assignment record.
+        """
+        return self.actions.create(
+            action_type=AssignmentActions.CANCELLED_NOTIFICATION,
+            completed_at=timezone.now(),
+        )
+
+    def add_errored_cancel_action(self, exc):
+        """
+        Adds an errored "cancel" LearnerContentAssignmentAction for this assignment record.
+        """
+        return self.actions.create(
+            action_type=AssignmentActions.CANCELLED_NOTIFICATION,
+            error_reason=AssignmentActionErrors.EMAIL_ERROR,
+            traceback=format_traceback(exc),
+        )
+
+    def add_successful_expiration_action(self):
+        """
+        Adds a successful expiration LearnerContentAssignmentAction for this assignment record.
+        """
+        return self.actions.create(
+            action_type=AssignmentActions.AUTOMATIC_CANCELLATION_NOTIFICATION,
+            completed_at=timezone.now(),
+        )
+
+    def add_errored_expiration_action(self, exc):
+        """
+        Adds an errored expiration LearnerContentAssignmentAction for this assignment record.
+        """
+        return self.actions.create(
+            action_type=AssignmentActions.AUTOMATIC_CANCELLATION_NOTIFICATION,
+            error_reason=AssignmentActionErrors.EMAIL_ERROR,
+            traceback=format_traceback(exc),
         )
 
     @classmethod

--- a/enterprise_access/apps/content_assignments/tests/test_content_metadata_api.py
+++ b/enterprise_access/apps/content_assignments/tests/test_content_metadata_api.py
@@ -1,0 +1,79 @@
+"""
+Tests for the ``content_metadata_api.py`` module of the content_assignments app.
+"""
+import ddt
+from django.test import TestCase
+
+from ..content_metadata_api import get_card_image_url, get_course_partners, get_human_readable_date
+
+
+@ddt.ddt
+class TestContentMetadataApi(TestCase):
+    """
+    Tests functions of the ``content_assignment_api.py`` file.
+    """
+
+    @ddt.data(
+        (
+            {'card_image_url': 'my-card-image', 'image_url': 'my-image-url'},
+            'my-card-image',
+        ),
+        (
+            {'card_image_url': 'my-card-image', 'image_url': None},
+            'my-card-image',
+        ),
+        (
+            {'card_image_url': 'my-card-image'},
+            'my-card-image',
+        ),
+        (
+            {'card_image_url': None, 'image_url': 'my-image-url'},
+            'my-image-url',
+        ),
+        (
+            {},
+            None,
+        )
+    )
+    @ddt.unpack
+    def test_get_card_image_url(self, content_metadata, expected_output):
+        self.assertEqual(expected_output, get_card_image_url(content_metadata))
+
+    @ddt.data(
+        ('2023-01-01T00:00:00.000000Z', 'Jan 01, 2023'),
+        ('2023-01-01T00:00:00Z', 'Jan 01, 2023'),
+        ('2023-01-01 00:00:00.000000Z', 'Jan 01, 2023'),
+        ('2023-01-01 00:00:00Z', 'Jan 01, 2023'),
+    )
+    @ddt.unpack
+    def test_get_human_readable_date(self, datetime_string, expected_output):
+        self.assertEqual(expected_output, get_human_readable_date(datetime_string))
+
+    def test_get_human_readable_date_exception(self):
+        with self.assertRaisesRegex(ValueError, 'does not match format'):
+            get_human_readable_date('2023-01-01')
+
+    @ddt.data(
+        (
+            {'owners': [
+                {'name': 'bob', 'id': 1}, {'name': 'sam', 'id': 2},
+                {'name': 'dave', 'id': 3}, {'name': 'jill', 'id': 4}
+            ]},
+            'bob, sam, dave, and jill',
+        ),
+        (
+            {'owners': [{'name': 'bob', 'id': 1}, {'name': 'sam', 'id': 2}]},
+            'bob and sam',
+        ),
+        (
+            {'owners': [{'name': 'bob', 'id': 1}]},
+            'bob',
+        ),
+    )
+    @ddt.unpack
+    def test_get_course_partners(self, content_metadata, expected_output):
+        self.assertEqual(expected_output, get_course_partners(content_metadata))
+
+    def test_get_course_partners_exception(self):
+        with self.assertRaisesRegex(Exception, 'must have a partner'):
+            get_course_partners({'foo': 'bar'})

--- a/enterprise_access/apps/content_assignments/tests/test_tasks.py
+++ b/enterprise_access/apps/content_assignments/tests/test_tasks.py
@@ -269,17 +269,17 @@ class TestBrazeEmailTasks(APITestWithMocks):
     @mock.patch('enterprise_access.apps.content_assignments.tasks.BrazeApiClient')
     @ddt.data(True, False)
     def test_send_reminder_email_for_pending_assignment(
-        self, is_logistrated, mock_braze_client, mock_lms_client, mock_get_metadata,
+        self, is_logistrated, mock_braze_client_class, mock_lms_client, mock_get_metadata,
         mock_policy_model,  # pylint: disable=unused-argument
     ):
         """
         Verify send_reminder_email_for_pending_assignment hits braze client with expected args
         """
+        mock_braze_client = mock_braze_client_class.return_value
         if not is_logistrated:
             self.assignment.lms_user_id = None
             self.assignment.save()
 
-        content_key = 'demoX'
         admin_email = 'test@admin.com'
         mock_lms_client.return_value.get_enterprise_customer_data.return_value = {
             'uuid': TEST_ENTERPRISE_UUID,
@@ -290,11 +290,8 @@ class TestBrazeEmailTasks(APITestWithMocks):
             }],
             'name': self.enterprise_customer_name,
         }
-        mock_recipient = {
-            'external_user_id': 1
-        }
-        mock_get_metadata.return_value = {
-            'key': content_key,
+        mock_metadata = {
+            'key': self.assignment.content_key,
             'normalized_metadata': {
                 'start_date': '2020-01-01 12:00:00Z',
                 'end_date': '2022-01-01 12:00:00Z',
@@ -308,10 +305,9 @@ class TestBrazeEmailTasks(APITestWithMocks):
             ],
             'card_image_url': 'https://itsanimage.com'
         }
+        mock_get_metadata.return_value = {self.assignment.content_key: mock_metadata}
+        mock_braze_client.generate_mailto_link.return_value = f'mailto:{admin_email}'
 
-        mock_admin_mailto = f'mailto:{admin_email}'
-        mock_braze_client.return_value.create_recipient.return_value = mock_recipient
-        mock_braze_client.return_value.generate_mailto_link.return_value = mock_admin_mailto
         send_reminder_email_for_pending_assignment(self.assignment.uuid)
 
         # Make sure our LMS client got called correct times and with what we expected
@@ -319,15 +315,16 @@ class TestBrazeEmailTasks(APITestWithMocks):
             self.assignment_configuration.enterprise_customer_uuid
         )
 
-        assert mock_braze_client.return_value.send_campaign_message.call_count == 1
         expected_campaign_identifier = 'test-assignment-remind-campaign'
+        expected_recipient = mock_braze_client.create_recipient_no_external_id.return_value
         if is_logistrated:
             expected_campaign_identifier = 'test-assignment-remind-post-logistration-campaign'
-        mock_braze_client.return_value.send_campaign_message.assert_called_once_with(
+            expected_recipient = mock_braze_client.create_recipient.return_value
+        mock_braze_client.send_campaign_message.assert_called_once_with(
             expected_campaign_identifier,
-            recipients=[mock_recipient],
+            recipients=[expected_recipient],
             trigger_properties={
-                'contact_admin_link': mock_admin_mailto,
+                'contact_admin_link': f'mailto:{admin_email}',
                 'organization': self.enterprise_customer_name,
                 'course_title': self.assignment.content_title,
                 'enrollment_deadline': 'Jan 01, 2021',
@@ -352,7 +349,6 @@ class TestBrazeEmailTasks(APITestWithMocks):
         """
         Verify send_email_for_new_assignment hits braze client with expected args
         """
-        content_key = 'demoX'
         admin_email = 'test@admin.com'
         mock_lms_client.return_value.get_enterprise_customer_data.return_value = {
             'uuid': TEST_ENTERPRISE_UUID,
@@ -366,8 +362,8 @@ class TestBrazeEmailTasks(APITestWithMocks):
         mock_recipient = {
             'external_user_id': 1
         }
-        mock_get_metadata.return_value = {
-            'key': content_key,
+        mock_metadata = {
+            'key': self.assignment.content_key,
             'normalized_metadata': {
                 'start_date': '2020-01-01T12:00:00Z',
                 'end_date': '2022-01-01 12:00:00Z',
@@ -380,6 +376,7 @@ class TestBrazeEmailTasks(APITestWithMocks):
             ],
             'card_image_url': 'https://itsanimage.com',
         }
+        mock_get_metadata.return_value = {self.assignment.content_key: mock_metadata}
 
         mock_admin_mailto = f'mailto:{admin_email}'
         mock_braze_client.return_value.create_recipient.return_value = mock_recipient


### PR DESCRIPTION
* Send aliased recipient when no lms_user_id on assignment (Braze API won't accept request otherwise).
* Task retries should result in only 1 errored action.
* Even safer date parsing (account for possible microseconds).
* Fetch course metadata record inside assignment tasks properly.
ENT-8066