### PR TITLE
fix: slightly better braze exception handling

### DIFF
--- a/enterprise_access/apps/content_assignments/utils.py
+++ b/enterprise_access/apps/content_assignments/utils.py
@@ -13,4 +13,5 @@ def chunks(a_list, chunk_size):
 
 
 def format_traceback(exception):
-    return ''.join(traceback.format_tb(exception.__traceback__))
+    trace = ''.join(traceback.format_tb(exception.__traceback__))
+    return f'{exception}\n{trace}'

--- a/enterprise_access/settings/devstack.py
+++ b/enterprise_access/settings/devstack.py
@@ -103,6 +103,7 @@ SHELL_PLUS_IMPORTS = [
     'from enterprise_access.apps.subsidy_request.utils import localized_utcnow',
     'from enterprise_access.apps.content_assignments import api as assignments_api',
     'from pprint import pprint',
+    'from enterprise_access.apps.content_assignments import tasks as assignments_tasks',
 ]
 
 


### PR DESCRIPTION
Pluck the response content from the underlying HTTPError when handling `BrazeBadRequestError`.