### PR TITLE
perf: faster base API Test case

### DIFF
--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -38,14 +38,19 @@ class APITest(APITestCase):
     """
     Base class for API Tests.
     """
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user = UserFactory(username=TEST_USERNAME, email=TEST_EMAIL, is_active=True, password=TEST_PASSWORD)
+        cls.user.save()
+
+        cls.client = APIClient()
 
     def setUp(self):
         """
         Perform operations common to all tests.
         """
         super().setUp()
-        self.create_user(username=TEST_USERNAME, email=TEST_EMAIL, password=TEST_PASSWORD)
-        self.client = APIClient()
         self.client.login(username=TEST_USERNAME, password=TEST_PASSWORD)
 
     def tearDown(self):


### PR DESCRIPTION
I noticed that the base API test case was re-creating a user to use for the test client for every single test of an API view.  And the same user. With the same username/email/password.  This seemed costly on my machine, so I moved it to setUpClass().