### PR TITLE
feat: adds optional filtering by active subsidy access policies

### DIFF
--- a/enterprise_access/apps/api/filters/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/filters/subsidy_access_policy.py
@@ -15,6 +15,10 @@ class SubsidyAccessPolicyFilter(HelpfulFilterSet):
         required=True,
         help_text=SubsidyAccessPolicy._meta.get_field('enterprise_customer_uuid').help_text,
     )
+    active = drf_filters.BooleanFilter(
+        required=False,
+        help_text=SubsidyAccessPolicy._meta.get_field('active').help_text,
+    )
 
     class Meta:
         model = SubsidyAccessPolicy

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -347,7 +347,8 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
         # Test the retrieve endpoint
         response = self.client.get(
             reverse('api:v1:subsidy-access-policies-list'),
-            {'enterprise_customer_uuid': str(self.enterprise_uuid)},
+            {'enterprise_customer_uuid': str(self.enterprise_uuid),
+             'active': True},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_json = response.json()
@@ -407,6 +408,24 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
                 'assignment_configuration': None,
             },
         ]
+
+        sort_key = itemgetter('spend_limit')
+        self.assertEqual(
+            sorted(expected_results, key=sort_key),
+            sorted(response_json['results'], key=sort_key),
+        )
+
+        # Test the retrieve endpoint for inactive policies
+        response = self.client.get(
+            reverse('api:v1:subsidy-access-policies-list'),
+            {'enterprise_customer_uuid': str(self.enterprise_uuid),
+             'active': False},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_json = response.json()
+        self.assertEqual(response_json['count'], 0)
+
+        expected_results = []
 
         sort_key = itemgetter('spend_limit')
         self.assertEqual(

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -424,7 +424,6 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_json = response.json()
         self.assertEqual(response_json['count'], 0)
-        
         self.assertEqual(response_json['results'], [])
 
     @ddt.data(

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -424,14 +424,8 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_json = response.json()
         self.assertEqual(response_json['count'], 0)
-
-        expected_results = []
-
-        sort_key = itemgetter('spend_limit')
-        self.assertEqual(
-            sorted(expected_results, key=sort_key),
-            sorted(response_json['results'], key=sort_key),
-        )
+        
+        self.assertEqual(response_json['results'], [])
 
     @ddt.data(
         {


### PR DESCRIPTION
Adds optional filtering by `active` policies to the the subsidy-access-policy filter file.