### PR TITLE
fix: create braze alias when sending assignment emails

### DIFF
--- a/enterprise_access/apps/api_client/braze_client.py
+++ b/enterprise_access/apps/api_client/braze_client.py
@@ -49,6 +49,8 @@ class BrazeApiClient(BrazeClient):
     ):
         """
         Create a recipient object using the given user_email and lms_user_id.
+        Identifies the given email address with any existing Braze alias records
+        via the provided ``lms_user_id``.
         """
 
         user_alias = {

--- a/enterprise_access/apps/content_assignments/tasks.py
+++ b/enterprise_access/apps/content_assignments/tasks.py
@@ -9,7 +9,7 @@ from celery import shared_task
 from django.apps import apps
 from django.conf import settings
 
-from enterprise_access.apps.api_client.braze_client import BrazeApiClient
+from enterprise_access.apps.api_client.braze_client import ENTERPRISE_BRAZE_ALIAS_LABEL, BrazeApiClient
 from enterprise_access.apps.api_client.lms_client import LmsApiClient
 from enterprise_access.apps.content_assignments.content_metadata_api import (
     get_card_image_url,
@@ -86,6 +86,12 @@ class BrazeCampaignSender:
         if self.assignment.lms_user_id is None:
             recipient = self.braze_client.create_recipient_no_external_id(
                 self.assignment.learner_email,
+            )
+            # We need an alias record to exist in Braze before
+            # sending to any previously-unidentified users.
+            self.braze_client.create_braze_alias(
+                [self.assignment.learner_email],
+                ENTERPRISE_BRAZE_ALIAS_LABEL,
             )
         else:
             recipient = self.braze_client.create_recipient(

--- a/enterprise_access/apps/content_assignments/tests/test_tasks.py
+++ b/enterprise_access/apps/content_assignments/tests/test_tasks.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from requests.exceptions import HTTPError
 from rest_framework import status
 
+from enterprise_access.apps.api_client.braze_client import ENTERPRISE_BRAZE_ALIAS_LABEL
 from enterprise_access.apps.api_client.tests.test_utils import MockResponse
 from enterprise_access.apps.content_assignments.constants import (
     AssignmentActionErrors,
@@ -320,6 +321,12 @@ class TestBrazeEmailTasks(APITestWithMocks):
         if is_logistrated:
             expected_campaign_identifier = 'test-assignment-remind-post-logistration-campaign'
             expected_recipient = mock_braze_client.create_recipient.return_value
+            self.assertFalse(mock_braze_client.create_braze_alias.called)
+        else:
+            mock_braze_client.create_braze_alias.assert_called_once_with(
+                [self.assignment.learner_email],
+                ENTERPRISE_BRAZE_ALIAS_LABEL,
+            )
         mock_braze_client.send_campaign_message.assert_called_once_with(
             expected_campaign_identifier,
             recipients=[expected_recipient],


### PR DESCRIPTION
We have to create an alias record in Braze before sending campaign messages to emails that aren't currently identified in braze.  e.g.
![image](https://github.com/openedx/enterprise-access/assets/2307986/23b1850e-f3b8-4ca6-9aa8-b5f0aba305ae)
this works now.