### PR TITLE
perf: cache policy aggregates

### DIFF
--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -4,7 +4,7 @@ Tests for Enterprise Access Subsidy Access Policy app API v1 views.
 from datetime import datetime, timedelta
 from operator import itemgetter
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import call, patch
 from uuid import UUID, uuid4
 
 import ddt
@@ -425,6 +425,19 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
         response_json = response.json()
         self.assertEqual(response_json['count'], 0)
         self.assertEqual(response_json['results'], [])
+
+        # Assert that we only call the subsidy service to list transaction
+        # aggregates once per policy
+        self.mock_subsidy_client.list_subsidy_transactions.assert_has_calls([
+            call(
+                subsidy_uuid=self.redeemable_policy.subsidy_uuid,
+                subsidy_access_policy_uuid=self.redeemable_policy.uuid
+            ),
+            call(
+                subsidy_uuid=self.non_redeemable_policy.subsidy_uuid,
+                subsidy_access_policy_uuid=self.non_redeemable_policy.uuid,
+            )
+        ])
 
     @ddt.data(
         {

--- a/enterprise_access/apps/subsidy_access_policy/tests/test_models.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/test_models.py
@@ -125,6 +125,13 @@ class SubsidyAccessPolicyTests(MockPolicyDependenciesMixin, TestCase):
             active=False,
         )
 
+    def tearDown(self):
+        """
+        Clears any cached data for the test policy instances between test runs.
+        """
+        super().tearDown()
+        request_cache(namespace=REQUEST_CACHE_NAMESPACE).clear()
+
     def test_can_not_create_parent_model_object(self, *args):
         """
         Verify that correct exception raised when we try to create object of SubsidyAccessPolicy


### PR DESCRIPTION
Store policy aggregates in the request cache, so that the policy list view isn't ridiculously slow.  It used to make lots of calls to subsidy for a single list call - 4 calls to the subsidy service per single policy, all to compute the aggregates, which won't change in the scope of our list request.

Before (4 calls per policy)
```
enterprise_access.app  | 2023-12-07 14:36:11,673 DEBUG 972 [urllib3.connectionpool] [user 1] [ip 172.20.0.1] [request_id None] connectionpool.py:547 - http://enterprise-subsidy.app:18280 "GET /api/v2/subsidies/4c53f616-5ea0-42a0-9430-ba165cb2c916/admin/transactions/?state=committed&state=pending&state=created&include_aggregates=True&subsidy_access_policy_uuid=3cc0ad2c-ede1-476c-8271-97683855e41d HTTP/1.1" 200 962
enterprise_access.app  | 2023-12-07 14:36:11,749 DEBUG 972 [urllib3.connectionpool] [user 1] [ip 172.20.0.1] [request_id None] connectionpool.py:547 - http://enterprise-subsidy.app:18280 "GET /api/v2/subsidies/4c53f616-5ea0-42a0-9430-ba165cb2c916/admin/transactions/?state=committed&state=pending&state=created&include_aggregates=True&subsidy_access_policy_uuid=3cc0ad2c-ede1-476c-8271-97683855e41d HTTP/1.1" 200 962
enterprise_access.app  | 2023-12-07 14:36:11,861 DEBUG 972 [urllib3.connectionpool] [user 1] [ip 172.20.0.1] [request_id None] connectionpool.py:547 - http://enterprise-subsidy.app:18280 "GET /api/v2/subsidies/4c53f616-5ea0-42a0-9430-ba165cb2c916/admin/transactions/?state=committed&state=pending&state=created&include_aggregates=True&subsidy_access_policy_uuid=3cc0ad2c-ede1-476c-8271-97683855e41d HTTP/1.1" 200 962
enterprise_access.app  | 2023-12-07 14:36:11,951 DEBUG 972 [urllib3.connectionpool] [user 1] [ip 172.20.0.1] [request_id None] connectionpool.py:547 - http://enterprise-subsidy.app:18280 "GET /api/v2/subsidies/4c53f616-5ea0-42a0-9430-ba165cb2c916/admin/transactions/?state=committed&state=pending&state=created&include_aggregates=True&subsidy_access_policy_uuid=3cc0ad2c-ede1-476c-8271-97683855e41d HTTP/1.1" 200 962
enterprise_access.app  | 2023-12-07 14:36:12,061 DEBUG 972 [urllib3.connectionpool] [user 1] [ip 172.20.0.1] [request_id None] connectionpool.py:547 - http://enterprise-subsidy.app:18280 "GET /api/v2/subsidies/77fa11d3-ac40-431f-94cb-4db769257469/admin/transactions/?state=committed&state=pending&state=created&include_aggregates=True&subsidy_access_policy_uuid=50dd1967-9a41-4c22-a04b-5dbeab6a031b HTTP/1.1" 200 143
enterprise_access.app  | 2023-12-07 14:36:12,114 DEBUG 972 [urllib3.connectionpool] [user 1] [ip 172.20.0.1] [request_id None] connectionpool.py:547 - http://enterprise-subsidy.app:18280 "GET /api/v2/subsidies/77fa11d3-ac40-431f-94cb-4db769257469/admin/transactions/?state=committed&state=pending&state=created&include_aggregates=True&subsidy_access_policy_uuid=50dd1967-9a41-4c22-a04b-5dbeab6a031b HTTP/1.1" 200 143
enterprise_access.app  | 2023-12-07 14:36:12,165 DEBUG 972 [urllib3.connectionpool] [user 1] [ip 172.20.0.1] [request_id None] connectionpool.py:547 - http://enterprise-subsidy.app:18280 "GET /api/v2/subsidies/77fa11d3-ac40-431f-94cb-4db769257469/admin/transactions/?state=committed&state=pending&state=created&include_aggregates=True&subsidy_access_policy_uuid=50dd1967-9a41-4c22-a04b-5dbeab6a031b HTTP/1.1" 200 143
enterprise_access.app  | 2023-12-07 14:36:12,214 DEBUG 972 [urllib3.connectionpool] [user 1] [ip 172.20.0.1] [request_id None] connectionpool.py:547 - http://enterprise-subsidy.app:18280 "GET /api/v2/subsidies/77fa11d3-ac40-431f-94cb-4db769257469/admin/transactions/?state=committed&state=pending&state=created&include_aggregates=True&subsidy_access_policy_uuid=50dd1967-9a41-4c22-a04b-5dbeab6a031b HTTP/1.1" 200 143
enterprise_access.app  | 2023-12-07 14:36:12,277 DEBUG 972 [urllib3.connectionpool] [user 1] [ip 172.20.0.1] [request_id None] connectionpool.py:547 - http://enterprise-subsidy.app:18280 "GET /api/v2/subsidies/4c53f616-5ea0-42a0-9430-ba165cb2c916/admin/transactions/?state=committed&state=pending&state=created&include_aggregates=True&subsidy_access_policy_uuid=c9064ee0-ea37-4b63-92bd-f507d39d5993 HTTP/1.1" 200 2481
enterprise_access.app  | 2023-12-07 14:36:12,360 DEBUG 972 [urllib3.connectionpool] [user 1] [ip 172.20.0.1] [request_id None] connectionpool.py:547 - http://enterprise-subsidy.app:18280 "GET /api/v2/subsidies/4c53f616-5ea0-42a0-9430-ba165cb2c916/admin/transactions/?state=committed&state=pending&state=created&include_aggregates=True&subsidy_access_policy_uuid=c9064ee0-ea37-4b63-92bd-f507d39d5993 HTTP/1.1" 200 2481
enterprise_access.app  | 2023-12-07 14:36:12,419 DEBUG 972 [urllib3.connectionpool] [user 1] [ip 172.20.0.1] [request_id None] connectionpool.py:547 - http://enterprise-subsidy.app:18280 "GET /api/v2/subsidies/4c53f616-5ea0-42a0-9430-ba165cb2c916/admin/transactions/?state=committed&state=pending&state=created&include_aggregates=True&subsidy_access_policy_uuid=c9064ee0-ea37-4b63-92bd-f507d39d5993 HTTP/1.1" 200 2481
enterprise_access.app  | 2023-12-07 14:36:12,472 DEBUG 972 [urllib3.connectionpool] [user 1] [ip 172.20.0.1] [request_id None] connectionpool.py:547 - http://enterprise-subsidy.app:18280 "GET /api/v2/subsidies/4c53f616-5ea0-42a0-9430-ba165cb2c916/admin/transactions/?state=committed&state=pending&state=created&include_aggregates=True&subsidy_access_policy_uuid=c9064ee0-ea37-4b63-92bd-f507d39d5993 HTTP/1.1" 200 2481
```

After (1 call per policy)
```
enterprise_access.app  | 2023-12-07 14:43:27,257 DEBUG 1001 [urllib3.connectionpool] [user 1] [ip 172.20.0.1] [request_id None] connectionpool.py:547 - http://enterprise-subsidy.app:18280 "GET /api/v2/subsidies/4c53f616-5ea0-42a0-9430-ba165cb2c916/admin/transactions/?state=committed&state=pending&state=created&include_aggregates=True&subsidy_access_policy_uuid=3cc0ad2c-ede1-476c-8271-97683855e41d HTTP/1.1" 200 962
enterprise_access.app  | 2023-12-07 14:43:27,357 DEBUG 1001 [urllib3.connectionpool] [user 1] [ip 172.20.0.1] [request_id None] connectionpool.py:547 - http://enterprise-subsidy.app:18280 "GET /api/v2/subsidies/77fa11d3-ac40-431f-94cb-4db769257469/admin/transactions/?state=committed&state=pending&state=created&include_aggregates=True&subsidy_access_policy_uuid=50dd1967-9a41-4c22-a04b-5dbeab6a031b HTTP/1.1" 200 143
enterprise_access.app  | 2023-12-07 14:43:27,438 DEBUG 1001 [urllib3.connectionpool] [user 1] [ip 172.20.0.1] [request_id None] connectionpool.py:547 - http://enterprise-subsidy.app:18280 "GET /api/v2/subsidies/4c53f616-5ea0-42a0-9430-ba165cb2c916/admin/transactions/?state=committed&state=pending&state=created&include_aggregates=True&subsidy_access_policy_uuid=c9064ee0-ea37-4b63-92bd-f507d39d5993 HTTP/1.1" 200 2481
```

...and we see the cache behavior we'd expect on each request to the list endpoint now: one cache miss, followed by 3 cache hits, per policy:
```
enterprise_access.app  | 2023-12-07 14:43:27,258 INFO 1001 [enterprise_access.apps.subsidy_access_policy.models] [user 1] [ip 172.20.0.1] [request_id None] models.py:462 - aggregates_for_policy cache miss: subsidy 4c53f616-5ea0-42a0-9430-ba165cb2c916, policy 3cc0ad2c-ede1-476c-8271-97683855e41d
enterprise_access.app  | 2023-12-07 14:43:27,259 INFO 1001 [enterprise_access.apps.subsidy_access_policy.models] [user 1] [ip 172.20.0.1] [request_id None] models.py:451 - aggregates_for_policy cache hit: subsidy 4c53f616-5ea0-42a0-9430-ba165cb2c916, policy 3cc0ad2c-ede1-476c-8271-97683855e41d
enterprise_access.app  | 2023-12-07 14:43:27,273 INFO 1001 [enterprise_access.apps.subsidy_access_policy.models] [user 1] [ip 172.20.0.1] [request_id None] models.py:451 - aggregates_for_policy cache hit: subsidy 4c53f616-5ea0-42a0-9430-ba165cb2c916, policy 3cc0ad2c-ede1-476c-8271-97683855e41d
enterprise_access.app  | 2023-12-07 14:43:27,275 INFO 1001 [enterprise_access.apps.subsidy_access_policy.models] [user 1] [ip 172.20.0.1] [request_id None] models.py:451 - aggregates_for_policy cache hit: subsidy 4c53f616-5ea0-42a0-9430-ba165cb2c916, policy 3cc0ad2c-ede1-476c-8271-97683855e41d
enterprise_access.app  | 2023-12-07 14:43:27,358 INFO 1001 [enterprise_access.apps.subsidy_access_policy.models] [user 1] [ip 172.20.0.1] [request_id None] models.py:462 - aggregates_for_policy cache miss: subsidy 77fa11d3-ac40-431f-94cb-4db769257469, policy 50dd1967-9a41-4c22-a04b-5dbeab6a031b
enterprise_access.app  | 2023-12-07 14:43:27,358 INFO 1001 [enterprise_access.apps.subsidy_access_policy.models] [user 1] [ip 172.20.0.1] [request_id None] models.py:451 - aggregates_for_policy cache hit: subsidy 77fa11d3-ac40-431f-94cb-4db769257469, policy 50dd1967-9a41-4c22-a04b-5dbeab6a031b
enterprise_access.app  | 2023-12-07 14:43:27,367 INFO 1001 [enterprise_access.apps.subsidy_access_policy.models] [user 1] [ip 172.20.0.1] [request_id None] models.py:451 - aggregates_for_policy cache hit: subsidy 77fa11d3-ac40-431f-94cb-4db769257469, policy 50dd1967-9a41-4c22-a04b-5dbeab6a031b
enterprise_access.app  | 2023-12-07 14:43:27,370 INFO 1001 [enterprise_access.apps.subsidy_access_policy.models] [user 1] [ip 172.20.0.1] [request_id None] models.py:451 - aggregates_for_policy cache hit: subsidy 77fa11d3-ac40-431f-94cb-4db769257469, policy 50dd1967-9a41-4c22-a04b-5dbeab6a031b
enterprise_access.app  | 2023-12-07 14:43:27,438 INFO 1001 [enterprise_access.apps.subsidy_access_policy.models] [user 1] [ip 172.20.0.1] [request_id None] models.py:462 - aggregates_for_policy cache miss: subsidy 4c53f616-5ea0-42a0-9430-ba165cb2c916, policy c9064ee0-ea37-4b63-92bd-f507d39d5993
enterprise_access.app  | 2023-12-07 14:43:27,439 INFO 1001 [enterprise_access.apps.subsidy_access_policy.models] [user 1] [ip 172.20.0.1] [request_id None] models.py:451 - aggregates_for_policy cache hit: subsidy 4c53f616-5ea0-42a0-9430-ba165cb2c916, policy c9064ee0-ea37-4b63-92bd-f507d39d5993
enterprise_access.app  | 2023-12-07 14:43:27,439 INFO 1001 [enterprise_access.apps.subsidy_access_policy.models] [user 1] [ip 172.20.0.1] [request_id None] models.py:451 - aggregates_for_policy cache hit: subsidy 4c53f616-5ea0-42a0-9430-ba165cb2c916, policy c9064ee0-ea37-4b63-92bd-f507d39d5993
enterprise_access.app  | 2023-12-07 14:43:27,440 INFO 1001 [enterprise_access.apps.subsidy_access_policy.models] [user 1] [ip 172.20.0.1] [request_id None] models.py:451 - aggregates_for_policy cache hit: subsidy 4c53f616-5ea0-42a0-9430-ba165cb2c916, policy c9064ee0-ea37-4b63-92bd-f507d39d5993
```