### PR TITLE
feat: can-redeem user message for no/cancelled/errored assignments

### DIFF
--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -35,8 +35,11 @@ from enterprise_access.apps.events.signals import SUBSIDY_REDEEMED
 from enterprise_access.apps.events.utils import send_subsidy_redemption_event_to_event_bus
 from enterprise_access.apps.subsidy_access_policy.constants import (
     REASON_CONTENT_NOT_IN_CATALOG,
+    REASON_LEARNER_ASSIGNMENT_CANCELLED,
+    REASON_LEARNER_ASSIGNMENT_FAILED,
     REASON_LEARNER_MAX_ENROLLMENTS_REACHED,
     REASON_LEARNER_MAX_SPEND_REACHED,
+    REASON_LEARNER_NOT_ASSIGNED_CONTENT,
     REASON_LEARNER_NOT_IN_ENTERPRISE,
     REASON_NOT_ENOUGH_VALUE_IN_SUBSIDY,
     REASON_POLICY_EXPIRED,
@@ -138,6 +141,9 @@ def _get_user_message_for_reason(reason_slug, enterprise_admin_users):
         REASON_LEARNER_MAX_SPEND_REACHED: MissingSubsidyAccessReasonUserMessages.LEARNER_LIMITS_REACHED,
         REASON_LEARNER_MAX_ENROLLMENTS_REACHED: MissingSubsidyAccessReasonUserMessages.LEARNER_LIMITS_REACHED,
         REASON_CONTENT_NOT_IN_CATALOG: MissingSubsidyAccessReasonUserMessages.CONTENT_NOT_IN_CATALOG,
+        REASON_LEARNER_NOT_ASSIGNED_CONTENT: MissingSubsidyAccessReasonUserMessages.LEARNER_NOT_ASSIGNED_CONTENT,
+        REASON_LEARNER_ASSIGNMENT_CANCELLED: MissingSubsidyAccessReasonUserMessages.LEARNER_ASSIGNMENT_CANCELED,
+        REASON_LEARNER_ASSIGNMENT_FAILED: MissingSubsidyAccessReasonUserMessages.LEARNER_NOT_ASSIGNED_CONTENT,
     }
 
     if reason_slug not in MISSING_SUBSIDY_ACCESS_POLICY_REASONS:

--- a/enterprise_access/apps/subsidy_access_policy/constants.py
+++ b/enterprise_access/apps/subsidy_access_policy/constants.py
@@ -95,6 +95,10 @@ class MissingSubsidyAccessReasonUserMessages:
         "You can't enroll right now because this course is no longer available in your organization's catalog."
     LEARNER_NOT_IN_ENTERPRISE = \
         "You can't enroll right now because your account is no longer associated with the organization."
+    LEARNER_NOT_ASSIGNED_CONTENT = \
+        "You can't enroll right now because this course is not assigned to you."
+    LEARNER_ASSIGNMENT_CANCELED = \
+        "You can't enroll right now right now because your administrator canceled your course assignment."
 
 
 REASON_POLICY_EXPIRED = "policy_expired"


### PR DESCRIPTION
ENT-8114 | The can-redeem endpoint now returns a reason and user message related to policies that are unredeemable due to a lack of allocated `LearnerContentAssignment` record for the requesting user, or the existence of an assignment in a `CANCELLED` or `ERRORED` state.

Sample response payload for my local policy that does *not* have an assignment for the requesting test user:
```
[
    {
        "content_key": "course-v1:edX+DemoX+Demo_Course",
        "list_price": null,
        "redemptions": [],
        "has_successful_redemption": false,
        "redeemable_subsidy_access_policy": null,
        "can_redeem": false,
        "reasons": [
            {
                "reason": "reason_learner_not_assigned_content",
                "user_message": "You can't enroll right now because this course is not assigned to you.",
                "policy_uuids": [
                    "3cc0ad2c-ede1-476c-8271-97683855e41d"
                ],
                "metadata": {
                    "enterprise_administrators": [
                        {
                            "email": "enterprise_admin_test-enterprise@example.com",
                            "lms_user_id": 145
                        }
                    ]
                }
            }
        ]
    }
]
```

### Assignment does not exist:
![image](https://github.com/openedx/enterprise-access/assets/2307986/14b8d008-e8d0-4491-a42b-8adc2d26098a)

### Assignment exists but canceled
![image](https://github.com/openedx/enterprise-access/assets/2307986/e6dd7b37-120b-4343-9565-6fa073a912e8)

### Errored assignment
I re-used the "no assignment exists" message here, since there was no pre-defined spec for the message to show in this case.  This is still better than the current state of things, where we'd show a message about a missing code if the requesting learner had an errored assignment for the requested content.
![image](https://github.com/openedx/enterprise-access/assets/2307986/7faa424d-dd79-4334-83d7-1e0e7570fd83)
