### PR TITLE
fix: compare emails case-insensitively when setting assignment lms_user_ids

### DIFF
--- a/enterprise_access/apps/content_assignments/signals.py
+++ b/enterprise_access/apps/content_assignments/signals.py
@@ -20,7 +20,7 @@ def update_assignment_lms_user_id_from_user_email(sender, **kwargs):  # pylint: 
     user = kwargs['instance']
     if user.lms_user_id:
         assignments_to_update = LearnerContentAssignment.objects.filter(
-            learner_email=user.email,
+            learner_email__iexact=user.email,
             lms_user_id=None,
         )
 

--- a/enterprise_access/apps/content_assignments/tests/test_api.py
+++ b/enterprise_access/apps/content_assignments/tests/test_api.py
@@ -467,7 +467,7 @@ class TestContentAssignmentApi(TestCase):
         }
 
         if user_exists:
-            UserFactory(username='alice', email=learner_email, lms_user_id=lms_user_id)
+            UserFactory(username='alice', email=learner_email.upper(), lms_user_id=lms_user_id)
 
         assignment = None
         if existing_assignment_state:

--- a/enterprise_access/apps/content_assignments/tests/test_signals.py
+++ b/enterprise_access/apps/content_assignments/tests/test_signals.py
@@ -41,8 +41,8 @@ class SignalsTests(TestCase):
         test_user = UserFactory(email=TEST_EMAIL)
         # Simulate creating asignments for the test learner AFTER user creation.
         assignments_post_register = [
-            LearnerContentAssignmentFactory(learner_email=TEST_EMAIL, lms_user_id=None),
-            LearnerContentAssignmentFactory(learner_email=TEST_EMAIL, lms_user_id=None),
+            LearnerContentAssignmentFactory(learner_email=TEST_EMAIL.upper(), lms_user_id=None),
+            LearnerContentAssignmentFactory(learner_email=TEST_EMAIL.upper(), lms_user_id=None),
         ]
         # Simulate the learner logging in.
         test_user.last_login = timezone.now()


### PR DESCRIPTION
ENT-8129 | The email stored on assignment records might be only a case-insensitive match to the corresponding email in the core.User records, so do case-insensitive matching during the assignment flow and during the post-user-save signal that updates assignment ``lms_user_ids``.