### PR TITLE
fix: case-insensitive email matching for existing assignments

### DIFF
--- a/enterprise_access/apps/content_assignments/tests/test_api.py
+++ b/enterprise_access/apps/content_assignments/tests/test_api.py
@@ -234,8 +234,10 @@ class TestContentAssignmentApi(TestCase):
         content_price_cents = 100
         # add a duplicate email to the input list to ensure only one
         # allocation occurs.
+        # We throw a couple ALL UPPER CASE emails into the requested emails to allocate
+        # to verify that we filter for pre-existing assignments in a case-insensitive manner.
         learners_to_assign = [
-            f'{name}@foo.com' for name in ('alice', 'bob', 'carol', 'david', 'eugene', 'eugene', 'bob', 'eugene')
+            f'{name}@foo.com' for name in ('ALICE', 'bob', 'CAROL', 'david', 'eugene', 'eugene', 'bob', 'eugene')
         ]
         mock_get_and_cache_content_metadata.return_value = {
             'content_title': content_title,
@@ -251,7 +253,7 @@ class TestContentAssignmentApi(TestCase):
         )
         accepted_assignment = LearnerContentAssignmentFactory.create(
             assignment_configuration=self.assignment_configuration,
-            learner_email='bob@foo.com',
+            learner_email='BOB@foo.com',
             content_key=content_key,
             content_title=content_title,
             content_quantity=-content_price_cents,


### PR DESCRIPTION
ENT-8129 | Also do filters for existing assignments against a batch of emails to allocate in a case-insensitive manner.  Helps in the case where a client allocates to `foo@bar.com` at time t1 and against attempts to allocate to `FOO@bar.com` at time t2.  No second assignment record will be written for `FOO@bar.com`.