### PR TITLE
fix: content summary course key normalization

### DIFF
--- a/enterprise_access/apps/subsidy_access_policy/tests/test_models.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/test_models.py
@@ -764,7 +764,14 @@ class AssignedLearnerCreditAccessPolicyTests(MockPolicyDependenciesMixin, TestCa
             autospec=True,
         )
         self.mock_assignments_api = self.assignments_api_patcher.start()
+
+        assign_get_content_metadata_patcher = patch(
+            'enterprise_access.apps.content_assignments.api.get_and_cache_content_metadata'
+        )
+        self.mock_assign_get_content_metadata = assign_get_content_metadata_patcher.start()
+
         self.addCleanup(self.assignments_api_patcher.stop)
+        self.addCleanup(assign_get_content_metadata_patcher.stop)
 
     @classmethod
     def setUpClass(cls):
@@ -879,6 +886,11 @@ class AssignedLearnerCreditAccessPolicyTests(MockPolicyDependenciesMixin, TestCa
         self.mock_get_content_metadata.return_value = {
             'content_price': 200,
         }
+        self.mock_assign_get_content_metadata.return_value = {
+            'content_price': 200,
+            'content_key': self.course_key,
+            'course_run_key': self.course_run_key,
+        }
         self.mock_subsidy_client.can_redeem.return_value = {'can_redeem': True, 'active': True}
         self.mock_transactions_cache_for_learner.return_value = {
             'transactions': [],
@@ -969,6 +981,11 @@ class AssignedLearnerCreditAccessPolicyTests(MockPolicyDependenciesMixin, TestCa
         self.mock_catalog_contains_content_key.return_value = True
         self.mock_get_content_metadata.return_value = {
             'content_price': 200,
+        }
+        self.mock_assign_get_content_metadata.return_value = {
+            'content_price': 200,
+            'content_key': self.course_key,
+            'course_run_key': self.course_run_key,
         }
         self.mock_subsidy_client.can_redeem.return_value = {'can_redeem': True, 'active': True}
         self.mock_transactions_cache_for_learner.return_value = {


### PR DESCRIPTION
## Description

Content Assignments need to be able to figure out the canonical `course_key` from a `course_run_key`. Previously this was done via the syntax/structure of the key itself. This fails in situations where the `course_run_key` is not properly formed. Example provided in the ticket.

This new implementation leverages the content summary data provided by enterprise-subsidy service. The content summary utilizes the enterprise-catalog data which stores the course-key/run-key relationships as it unpacks the content metadata from discovery - regardless of how keys are structured within that document. In other words, it doesn't need to evaluate the key syntax/structure so it is tolerate of non-conforming keys.

- https://2u-internal.atlassian.net/browse/ENT-8125