### PR TITLE
feat: allow cancel/remind-all assignments views to be filterable

### DIFF
--- a/enterprise_access/apps/api/filters/content_assignments.py
+++ b/enterprise_access/apps/api/filters/content_assignments.py
@@ -3,8 +3,14 @@ API Filters for resources defined in the ``assignment_policy`` app.
 """
 from django_filters import CharFilter
 
+from ...content_assignments.constants import AssignmentLearnerStates
 from ...content_assignments.models import AssignmentConfiguration, LearnerContentAssignment
 from .base import CharInFilter, HelpfulFilterSet
+
+LEARNER_STATE_HELP_TEXT = (
+    'Choose from the following valid learner states: ' +
+    ', '.join([choice for choice, _ in AssignmentLearnerStates.CHOICES])
+)
 
 
 class AssignmentConfigurationFilter(HelpfulFilterSet):
@@ -20,8 +26,16 @@ class LearnerContentAssignmentAdminFilter(HelpfulFilterSet):
     """
     Base filter for LearnerContentAssignment views.
     """
-    learner_state = CharFilter(field_name='learner_state', lookup_expr='exact')
-    learner_state__in = CharInFilter(field_name='learner_state', lookup_expr='in')
+    learner_state = CharFilter(
+        field_name='learner_state',
+        lookup_expr='exact',
+        help_text=LEARNER_STATE_HELP_TEXT,
+    )
+    learner_state__in = CharInFilter(
+        field_name='learner_state',
+        lookup_expr='in',
+        help_text=LEARNER_STATE_HELP_TEXT,
+    )
 
     class Meta:
         model = LearnerContentAssignment


### PR DESCRIPTION
ENT-8156 | The remind-all and cancel-all views for content assignments
are now filterable by anything the list view can be filtered by,
included the `learner_state` attribute.