### PR TITLE
fix: be defensive in content metadata fetching for assignment expiration

### DIFF
--- a/enterprise_access/apps/content_assignments/management/commands/automatically_expire_assignments.py
+++ b/enterprise_access/apps/content_assignments/management/commands/automatically_expire_assignments.py
@@ -91,9 +91,20 @@ class Command(BaseCommand):
                 )
 
                 for assignment in assignments:
+                    enrollment_end_date = None
                     content_metadata = content_metadata_for_assignments.get(assignment.content_key, {})
-                    enrollment_end_date_str = content_metadata.get('normalized_metadata', {}).get('enroll_by_date')
-                    enrollment_end_date = self.to_datetime(enrollment_end_date_str)
+                    if content_metadata is not None:
+                        normalized_metadata = content_metadata.get('normalized_metadata') or {}
+                        enrollment_end_date_str = normalized_metadata.get('enroll_by_date')
+                        try:
+                            enrollment_end_date = self.to_datetime(enrollment_end_date_str)
+                        except ValueError:
+                            logger.warning(
+                                '%s Bad datetime format for %s, value: %s',
+                                log_prefix,
+                                assignment.content_key,
+                                enrollment_end_date_str,
+                            )
 
                     logger.info(
                         '%s AssignmentUUID: [%s], ContentKey: [%s], AssignmentExpiry: [%s], EnrollmentEnd: [%s], SubsidyExpiry: [%s]',  # nopep8 pylint: disable=line-too-long

--- a/enterprise_access/apps/content_assignments/management/commands/tests/test_automatically_expire_assignments.py
+++ b/enterprise_access/apps/content_assignments/management/commands/tests/test_automatically_expire_assignments.py
@@ -197,6 +197,12 @@ class TesAutomaticallyExpireAssignmentCommand(TestCase):
                     'content_price': 123,
                 },
             },
+            'edX+edXPrivacy101': {
+                'normalized_metadata': {
+                    # test that some other datetime format is handled gracefully
+                    'enroll_by_date': enrollment_end.strftime("%Y-%m-%d %H:%M"),
+                }
+            }
         }
         mock_path = COMMAND_PATH + '.logger.info'
 


### PR DESCRIPTION
The `automatically_expire_assignments` command is now more defensive about fetching content metadata for assignment records.
https://2u-internal.atlassian.net/browse/ENT-8205