### PR TITLE
refactor: assignment expiration

### DIFF
--- a/enterprise_access/apps/content_assignments/content_metadata_api.py
+++ b/enterprise_access/apps/content_assignments/content_metadata_api.py
@@ -53,14 +53,24 @@ def get_human_readable_date(datetime_string, output_pattern='%b %d, %Y'):
     Given a datetime string value from some content metadata record,
     convert it to the provided pattern.
     """
+    datetime_obj = parse_datetime_string(datetime_string)
+    if datetime_obj:
+        return datetime_obj.strftime(output_pattern)
+    return None
+
+
+def parse_datetime_string(datetime_string):
+    """
+    Given a datetime string value from some content metadata record,
+    parse it into a datetime object.
+    """
     if not datetime_string:
         return None
 
     last_exception = None
     for input_pattern in DATE_INPUT_PATTERNS:
         try:
-            datetime_obj = datetime.strptime(datetime_string, input_pattern)
-            return datetime_obj.strftime(output_pattern)
+            return datetime.strptime(datetime_string, input_pattern)
         except ValueError as exc:
             last_exception = exc
 

--- a/enterprise_access/apps/content_assignments/management/commands/automatically_expire_assignments.py
+++ b/enterprise_access/apps/content_assignments/management/commands/automatically_expire_assignments.py
@@ -7,16 +7,11 @@ import logging
 
 from django.core.management.base import BaseCommand
 from django.core.paginator import Paginator
-from django.utils.timezone import now, timedelta
 
-from enterprise_access.apps.content_assignments.constants import (
-    NUM_DAYS_BEFORE_AUTO_CANCELLATION,
-    AssignmentAutomaticExpiredReason,
-    LearnerContentAssignmentStateChoices
-)
+from enterprise_access.apps.content_assignments.api import expire_assignment
+from enterprise_access.apps.content_assignments.constants import LearnerContentAssignmentStateChoices
 from enterprise_access.apps.content_assignments.content_metadata_api import get_content_metadata_for_assignments
 from enterprise_access.apps.content_assignments.models import AssignmentConfiguration
-from enterprise_access.apps.content_assignments.tasks import send_assignment_automatically_expired_email
 
 logger = logging.getLogger(__name__)
 
@@ -59,22 +54,21 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         dry_run = options['dry_run']
 
-        log_prefix = '[AUTOMATICALLY_EXPIRE_ASSIGNMENTS]'
-        if dry_run:
-            log_prefix = '[DRY_RUN]'
-
         for assignment_configuration in AssignmentConfiguration.objects.filter(active=True):
             subsidy_access_policy = assignment_configuration.subsidy_access_policy
             enterprise_catalog_uuid = subsidy_access_policy.catalog_uuid
-            subsidy_expiration_datetime = self.to_datetime(subsidy_access_policy.subsidy_expiration_datetime)
 
+            message = (
+                '[AUTOMATICALLY_EXPIRE_ASSIGNMENTS] Assignment Configuration. UUID: [%s], '
+                'Policy: [%s], Catalog: [%s], Enterprise: [%s], dry_run [%s]',
+            )
             logger.info(
-                '%s Processing Assignment Configuration. UUID: [%s], Policy: [%s], Catalog: [%s], Enterprise: [%s]',
-                log_prefix,
+                message,
                 assignment_configuration.uuid,
                 subsidy_access_policy.uuid,
                 enterprise_catalog_uuid,
-                assignment_configuration.enterprise_customer_uuid
+                assignment_configuration.enterprise_customer_uuid,
+                dry_run,
             )
 
             allocated_assignments = assignment_configuration.assignments.filter(
@@ -91,55 +85,10 @@ class Command(BaseCommand):
                 )
 
                 for assignment in assignments:
-                    enrollment_end_date = None
                     content_metadata = content_metadata_for_assignments.get(assignment.content_key, {})
-                    if content_metadata is not None:
-                        normalized_metadata = content_metadata.get('normalized_metadata') or {}
-                        enrollment_end_date_str = normalized_metadata.get('enroll_by_date')
-                        try:
-                            enrollment_end_date = self.to_datetime(enrollment_end_date_str)
-                        except ValueError:
-                            logger.warning(
-                                '%s Bad datetime format for %s, value: %s',
-                                log_prefix,
-                                assignment.content_key,
-                                enrollment_end_date_str,
-                            )
-
-                    logger.info(
-                        '%s AssignmentUUID: [%s], ContentKey: [%s], AssignmentExpiry: [%s], EnrollmentEnd: [%s], SubsidyExpiry: [%s]',  # nopep8 pylint: disable=line-too-long
-                        log_prefix,
-                        assignment.uuid,
-                        assignment.content_key,
-                        assignment.created + timedelta(days=NUM_DAYS_BEFORE_AUTO_CANCELLATION),
-                        enrollment_end_date,
-                        subsidy_expiration_datetime
+                    expire_assignment(
+                        assignment_configuration,
+                        assignment,
+                        content_metadata,
+                        modify_assignment=not dry_run,
                     )
-
-                    expired_assignment_uuid = None
-                    assignment_expiry_reason = None
-                    current_date = now()
-
-                    if current_date > (assignment.created + timedelta(days=NUM_DAYS_BEFORE_AUTO_CANCELLATION)):
-                        expired_assignment_uuid = assignment.uuid
-                        assignment_expiry_reason = AssignmentAutomaticExpiredReason.NIENTY_DAYS_PASSED
-                    elif enrollment_end_date and enrollment_end_date < current_date:
-                        expired_assignment_uuid = assignment.uuid
-                        assignment_expiry_reason = AssignmentAutomaticExpiredReason.ENROLLMENT_DATE_PASSED
-                    elif subsidy_expiration_datetime and subsidy_expiration_datetime < current_date:
-                        expired_assignment_uuid = assignment.uuid
-                        assignment_expiry_reason = AssignmentAutomaticExpiredReason.SUBSIDY_EXPIRED
-
-                    if expired_assignment_uuid:
-                        logger.info(
-                            '%s Assignment Expired. AssignmentConfigUUID: [%s], AssignmentUUID: [%s], Reason: [%s]',
-                            log_prefix,
-                            assignment_configuration.uuid,
-                            expired_assignment_uuid,
-                            assignment_expiry_reason
-                        )
-
-                        if not dry_run:
-                            assignment.state = LearnerContentAssignmentStateChoices.CANCELLED
-                            assignment.save()
-                            send_assignment_automatically_expired_email.delay(expired_assignment_uuid)


### PR DESCRIPTION
Part of ENT-7557, refactors expiration business logic into the `content_assignments.api` module, so its
clearer where to find the logic that determines whether and when an assignment is expired.