### PR TITLE
feat: scrub assignment pii on auto-expiration

### DIFF
--- a/docs/decisions/0016_automatic_expiration.rst
+++ b/docs/decisions/0016_automatic_expiration.rst
@@ -1,0 +1,57 @@
+0016 Automatic Cancellation (Expiration)
+****************************************
+
+Status
+======
+Accepted - January 2024
+
+Context
+=======
+
+How expiration currently works
+------------------------------
+There's currently a management command (run via a cron) named ``automatically_exire_assignments.py``
+that toggles the state of ``LearnerContentAssignment`` records ("Assignments")
+to ``CANCELLED`` under any of the following conditions, as long as the current state
+of the assignment is ``ALLOCATED``:
+
+1. The current date is more than 90 days after the most recent notification action - this action
+   time is used as a proxy for understanding *when* the assignment *was last allocated*. This helps
+   deal with the edge case where an assignment is allocated, cancelled, and re-allocated later. Note
+   that a reminder action on an assignment record *does not* reset this specific expiry time.
+2. The current date is greater than the inferred enrollment deadline for the assigned course.
+3. The current date is greater than the expiration date of the subsidy associated with the Assignment's
+   access policy record.
+
+Decision
+========
+The above management command will now remove Personally-Identifiable Information ("PII") from assignments
+that are automatically moved from ``ALLOCATED`` to ``CANCELLED`` under condition (1) above - that is, only
+for such assignments whose last notification time was more than 90 days ago.
+This PII includes the learner email address.
+
+Scrubbing the learner email
+---------------------------
+Note that, to remove learner email PII, we change the value to a "tombstone" - ``retired_user@retired.invalid``.
+This is done so that the ``learner_email`` database column can continue to have a non-null constraint.
+
+Consequences
+============
+* Assignments that were cancelled by the admin or that fell into an ``ERRORED`` state will not
+  currently have PII cleared by this cron-based management command.
+* The Assignment data schema does not yet fully support the improvements proposed in
+  `<0015-expiration-improvements.rst>`_. The implementation of these improvements will
+  allow us to also take a more nuanced approach about automatically expiring assignment records
+  in non-allocated states, or to retire PII fields in other ways.
+
+Alternatives Considered
+=======================
+
+Hook into the edX User Retirement Pipeline
+------------------------------------------
+We have not yet rejected, but not yet committed to, integrating ``LearnerContentAssignment``
+record retirement with the edX User Retirement Pipeline. This would involve exposing
+some API view to scrub PII from certain assignment records associated with a
+registered edX user who has requested that their account be retired. This is mostly relevant
+in the case of ``ACCEPTED`` assignments, or assignments that have fallen into an ``ERRORED``
+state prior to being automatically expired.

--- a/enterprise_access/apps/api/v1/tests/test_assignment_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_assignment_views.py
@@ -156,7 +156,7 @@ class CRUDViewTestMixin:
             error_reason='Phony error reason.',
             traceback=None,
         )
-        linked_action, _ = self.assignment_cancelled.add_successful_linked_action()
+        linked_action = self.assignment_cancelled.add_successful_linked_action()
         linked_action.error_reason = 'Phony error reason.'
         linked_action.save()
 

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -1419,7 +1419,7 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
             content_quantity=-content_price_cents,
             state=LearnerContentAssignmentStateChoices.ALLOCATED,
         )
-        action, _ = assignment1.add_successful_linked_action()
+        action = assignment1.add_successful_linked_action()
 
         # Implicitly tests that this response only includes allocated assignments
         LearnerContentAssignmentFactory.create(

--- a/enterprise_access/apps/content_assignments/constants.py
+++ b/enterprise_access/apps/content_assignments/constants.py
@@ -28,6 +28,9 @@ class LearnerContentAssignmentStateChoices:
     # States which allow reminders by an admin.
     REMINDABLE_STATES = (ALLOCATED,)
 
+    # States from which an assignment can be expired
+    EXPIRABLE_STATES = (ALLOCATED,)
+
 
 class AssignmentActions:
     """
@@ -107,3 +110,5 @@ class AssignmentAutomaticExpiredReason:
 
 
 NUM_DAYS_BEFORE_AUTO_CANCELLATION = 90
+
+RETIRED_EMAIL_ADDRESS = 'retired_user@retired.invalid'

--- a/enterprise_access/apps/content_assignments/tests/test_models.py
+++ b/enterprise_access/apps/content_assignments/tests/test_models.py
@@ -4,7 +4,7 @@ Tests for the ``api.py`` module of the content_assignments app.
 from django.test import TestCase
 from django.utils import timezone
 
-from ..constants import AssignmentActions
+from ..constants import NUM_DAYS_BEFORE_AUTO_CANCELLATION, RETIRED_EMAIL_ADDRESS, AssignmentActions
 from ..models import AssignmentConfiguration
 from .factories import LearnerContentAssignmentFactory
 
@@ -37,12 +37,11 @@ class TestAssignmentActions(TestCase):
         Tests that we can idempotently get/set the linked action for an assignment.
         """
         # Start with no linked actions
-        self.assertIsNone(self.assignment.get_successful_linked_action())
+        self.assertIsNone(self.assignment.get_last_successful_linked_action())
 
         # now create one
-        linked_action, was_created = self.assignment.add_successful_linked_action()
+        linked_action = self.assignment.add_successful_linked_action()
 
-        self.assertTrue(was_created)
         self.assertEqual(linked_action.action_type, AssignmentActions.LEARNER_LINKED)
         self.assertIsNone(linked_action.error_reason)
         self.assertAlmostEqual(
@@ -54,26 +53,28 @@ class TestAssignmentActions(TestCase):
         # now if we fetch the linked action for this assignment, we'll
         # get the thing we just created
         self.assertEqual(
-            self.assignment.get_successful_linked_action(),
+            self.assignment.get_last_successful_linked_action(),
             linked_action,
         )
 
-        # ...and adding a linked action through this method is idempotent
-        linked_action_again, was_created_again = self.assignment.add_successful_linked_action()
-        self.assertEqual(linked_action_again, linked_action)
-        self.assertFalse(was_created_again)
+        # ...and adding a linked action through this method will create a new action record
+        linked_action_again = self.assignment.add_successful_linked_action()
+        self.assertNotEqual(linked_action_again, linked_action)
+        self.assertEqual(
+            self.assignment.get_last_successful_linked_action(),
+            linked_action_again,
+        )
 
     def test_get_set_notified_action(self):
         """
         Tests that we can idempotently get/set the notified action for an assignment.
         """
         # Start with no notified actions
-        self.assertIsNone(self.assignment.get_successful_notified_action())
+        self.assertIsNone(self.assignment.get_last_successful_notified_action())
 
         # now create one
-        notified_action, was_created = self.assignment.add_successful_notified_action()
+        notified_action = self.assignment.add_successful_notified_action()
 
-        self.assertTrue(was_created)
         self.assertEqual(notified_action.action_type, AssignmentActions.NOTIFIED)
         self.assertIsNone(notified_action.error_reason)
         self.assertAlmostEqual(
@@ -85,14 +86,17 @@ class TestAssignmentActions(TestCase):
         # now if we fetch the notified action for this assignment, we'll
         # get the thing we just created
         self.assertEqual(
-            self.assignment.get_successful_notified_action(),
+            self.assignment.get_last_successful_notified_action(),
             notified_action,
         )
 
-        # ...and adding a notified action through this method is idempotent
-        notified_action_again, was_created_again = self.assignment.add_successful_notified_action()
-        self.assertEqual(notified_action_again, notified_action)
-        self.assertFalse(was_created_again)
+        # ...and adding a notified action through this method creates a new action record
+        notified_action_again = self.assignment.add_successful_notified_action()
+        self.assertNotEqual(notified_action_again, notified_action)
+        self.assertEqual(
+            self.assignment.get_last_successful_notified_action(),
+            notified_action_again,
+        )
 
     def test_get_set_reminded_actions(self):
         """
@@ -134,3 +138,53 @@ class TestAssignmentActions(TestCase):
             self.assignment.get_last_successful_reminded_action(),
             reminded_action_again,
         )
+
+    def test_get_auto_expiration_date_no_action(self):
+        """
+        Test that this method returns None if there is no last successful
+        notified action.
+        """
+        self.assertIsNone(self.assignment.get_auto_expiration_date())
+
+        self.assignment.add_errored_notified_action(Exception('foo'))
+
+        self.assertIsNone(self.assignment.get_auto_expiration_date())
+
+    def test_get_auto_expiration_date(self):
+        """
+        Test that this method returns None if there is no last successful
+        notified action.
+        """
+        first_notification = self.assignment.add_successful_notified_action()
+
+        self.assertEqual(
+            self.assignment.get_auto_expiration_date(),
+            first_notification.completed_at + timezone.timedelta(days=NUM_DAYS_BEFORE_AUTO_CANCELLATION),
+        )
+
+        second_notification = self.assignment.add_successful_notified_action()
+
+        self.assertEqual(
+            self.assignment.get_auto_expiration_date(),
+            second_notification.completed_at + timezone.timedelta(days=NUM_DAYS_BEFORE_AUTO_CANCELLATION),
+        )
+
+    def test_clear_pii(self):
+        """
+        Tests that we can clear pii on an assignment.
+        """
+        self.assignment.learner_email = 'foo@bar.com'
+        self.assignment.lms_user_id = 12345
+        self.assignment.save()
+
+        self.assignment.clear_pii()
+        self.assignment.save()
+        self.assignment.clear_historical_pii()
+
+        self.assignment.refresh_from_db()
+
+        self.assertEqual(12345, self.assignment.lms_user_id)
+        self.assertEqual(self.assignment.learner_email, RETIRED_EMAIL_ADDRESS)
+
+        for historical_record in self.assignment.history.all():
+            self.assertEqual(historical_record.learner_email, RETIRED_EMAIL_ADDRESS)


### PR DESCRIPTION
ENT-7557 | Removes PII on assignment records (and related history) when the record has been in an expirable state for long enough.

# How expiration currently works
There's currently a management command (run via a cron) named ``automatically_exire_assignments.py``
that toggles the state of ``LearnerContentAssignment`` records ("Assignments")
to ``CANCELLED`` under any of the following conditions:

1. The current state of the assignment is ``ALLOCATED``.
2. The current date is more than 90 days after the most recent notification action - this action
   time is used as a proxy for understanding *when* the assignment *was last allocated*. This helps
   deal with the edge case where an assignment is allocated, cancelled, and re-allocated later.
3. The current date is greater than the inferred enrollment deadline for the assigned course.
4. The current date is greater than the expiration date of the subsidy associated with the Assignment's
   access policy record.

# Decision
The above management command will now remove Personally-Identifiable Information ("PII") from assignments
that are automatically moved from ``ALLOCATED`` to ``CANCELLED`` under condition (1) above - that is, only
for such assignments whose last notification time was more than 90 days ago.
This PII includes the learner email address and their ``lms_user_id``.

## Scrubbing the learner email
Note that, to remove learner email PII, we change the value to a "tombstone" - ``retired_user@retired.invalid``.
This is done so that the ``learner_email`` database column can continue to have a non-null constraint.

# Consequences
* Assignments that were cancelled by the admin or that fell into an ``ERRORED`` state will not
  currently have PII cleared by this cron-based management command.
* The Assignment data schema does not yet fully support the improvements proposed in
  `<0015-expiration-improvements.rst>`_. The implementation of these improvements will
  allow us to also take a more nuanced approach about automatically expiring assignment records
  in non-allocated states, or to retire PII fields in other ways.

# Alternatives Considered

## Hook into the edX User Retirement Pipeline
We have not yet rejected, but not yet committed to, integrating ``LearnerContentAssignment``
record retirement with the edX User Retirement Pipeline. This would involve exposing
some API view to scrub PII from certain assignment records associated with a
registered edX user who has requested that their account be retired.

(Above copied from ADR)