### PR TITLE
fix: assignment auto-expiration date

### DIFF
--- a/enterprise_access/apps/content_assignments/models.py
+++ b/enterprise_access/apps/content_assignments/models.py
@@ -245,9 +245,14 @@ class LearnerContentAssignment(TimeStampedModel):
         reset the auto-expiration date.
         """
         last_notification = self.get_last_successful_notified_action()
+        # If we're currently sending the first notification message,
+        # we won't yet have a successful action, so use the creation time of
+        # the assignment as the starting_point
         if not last_notification:
-            return None
-        return last_notification.completed_at + timezone.timedelta(days=NUM_DAYS_BEFORE_AUTO_CANCELLATION)
+            starting_point = self.created
+        else:
+            starting_point = last_notification.completed_at
+        return starting_point + timezone.timedelta(days=NUM_DAYS_BEFORE_AUTO_CANCELLATION)
 
     def get_last_successful_linked_action(self):
         """

--- a/enterprise_access/apps/content_assignments/tests/test_models.py
+++ b/enterprise_access/apps/content_assignments/tests/test_models.py
@@ -141,14 +141,20 @@ class TestAssignmentActions(TestCase):
 
     def test_get_auto_expiration_date_no_action(self):
         """
-        Test that this method returns None if there is no last successful
+        Test that this method returns a date 90 days from the assignment
+        creation time if there is no last successful
         notified action.
         """
-        self.assertIsNone(self.assignment.get_auto_expiration_date())
-
+        self.assertEqual(
+            self.assignment.get_auto_expiration_date(),
+            self.assignment.created + timezone.timedelta(days=NUM_DAYS_BEFORE_AUTO_CANCELLATION),
+        )
         self.assignment.add_errored_notified_action(Exception('foo'))
 
-        self.assertIsNone(self.assignment.get_auto_expiration_date())
+        self.assertEqual(
+            self.assignment.get_auto_expiration_date(),
+            self.assignment.created + timezone.timedelta(days=NUM_DAYS_BEFORE_AUTO_CANCELLATION),
+        )
 
     def test_get_auto_expiration_date(self):
         """


### PR DESCRIPTION
ENT-8146 | Use the assignment.created time as the starting point for assignment auto-expiration if a successful notification action does not yet exist.