### PR TITLE
fix: SubsidyAPIHTTPError should not drop the HTTP response error

### DIFF
--- a/enterprise_access/apps/subsidy_access_policy/exceptions.py
+++ b/enterprise_access/apps/subsidy_access_policy/exceptions.py
@@ -42,12 +42,24 @@ class SubsidyAPIHTTPError(requests.exceptions.HTTPError):
     """
     @property
     def error_response(self):
-        """ Fetch the response object from the HTTPError that caused this exception. """
+        """
+        Fetch the response object from the HTTPError that caused this exception.
+
+        Returns:
+            requests.models.Response or None.
+        """
         return self.__cause__.response  # pylint: disable=no-member
 
     def error_payload(self):
-        if self.error_response:
-            return self.error_response.json()
+        """
+        Generate a useful error payload for logging purposes.
+        """
+        # requests.models.Response is falsey for HTTP status codes greater than or equal to 400!  We must explicitly
+        # check if the response object is not None before giving up on it.
+        if self.error_response is not None:
+            error_payload = self.error_response.json()
+            error_payload['subsidy_status_code'] = self.error_response.status_code
+            return error_payload
         return {
             'detail': str(self),
         }


### PR DESCRIPTION
Before this change, the SubsidyAPIHTTPError source code assumed that we can test the truthiness of requests.models.Response as a proxy for existence.  This is a fatal assumption because the Response objects overrides __bool__() in a way that all error codes are falsey. This resulted in completely dropping the error information from the response object.

After this change, error codes will actually be propagated up into error logging tools (New Relic, Splunk, etc.).

requests.models.Response implementation: https://docs.python-requests.org/en/latest/_modules/requests/models/#Response