### PR TITLE
fix: adds type to cron job argument

### DIFF
--- a/enterprise_access/apps/content_assignments/management/commands/automatically_nudge_assignments.py
+++ b/enterprise_access/apps/content_assignments/management/commands/automatically_nudge_assignments.py
@@ -44,9 +44,10 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             '--days_before_course_start_date',
-            action='store_true',
+            type=int,
             dest='days_before_course_start_date',
             default=30,
+            metavar='NUM_DAYS',
             help='The amount of days before the course start date to send a nudge email through braze',
         )
 


### PR DESCRIPTION
Failing cron job does not recognize the type of argument passed. Defining a type of the value for the argument