### PR TITLE
feat: log redeemability logical outputs

### DIFF
--- a/enterprise_access/utils.py
+++ b/enterprise_access/utils.py
@@ -103,7 +103,8 @@ def get_automatic_expiration_date_and_reason(
             fetched and subsequently cached from the content metadata API.
     """
     assignment_configuration = assignment.assignment_configuration
-    subsidy_access_policy = assignment_configuration.subsidy_access_policy  # pylint: disable=no-member
+    # pylint: disable=no-member,useless-suppression
+    subsidy_access_policy = assignment_configuration.subsidy_access_policy
 
     # subsidy expiration
     subsidy_expiration_datetime = _get_subsidy_expiration(assignment)


### PR DESCRIPTION
This is to help investigate a call to the `redeem` view that fails because the underlying `can_redeem()` check fails.  There's currently nothing in our logs that ties together the policy, the reason for irredeemability, the lms_user_id, and content_key.