### PR TITLE
feat: remove some timing logs, add allocation logs

### DIFF
--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -3,7 +3,6 @@ REST API views for the subsidy_access_policy app.
 """
 import logging
 import os
-import time
 from collections import defaultdict
 from contextlib import suppress
 
@@ -802,29 +801,21 @@ class SubsidyAccessPolicyAllocateViewset(UserDetailsFromJwtMixin, PermissionRequ
         content_price_cents = serializer.data['content_price_cents']
 
         try:
-            # TODO: remove the timing calls after slowness is identified
-            start_time = time.process_time()
             with policy.lock():
                 can_allocate, reason = policy.can_allocate(
                     len(learner_emails),
                     content_key,
                     content_price_cents,
                 )
-                can_allocate_time = time.process_time() - start_time
-                logger.info('allocate timing: can_allocate() %s', can_allocate_time)
                 if can_allocate:
                     allocation_result = policy.allocate(
                         learner_emails,
                         content_key,
                         content_price_cents,
                     )
-                    do_allocate_time = time.process_time() - can_allocate_time
-                    logger.info('allocate timing: do allocate() %s', do_allocate_time)
                     response_serializer = serializers.SubsidyAccessPolicyAllocationResponseSerializer(
                         allocation_result,
                     )
-                    serialization_time = time.process_time() - do_allocate_time
-                    logger.info('allocate timing: serialization %s', serialization_time)
                     return Response(response_serializer.data, status=status.HTTP_202_ACCEPTED)
                 else:
                     non_allocatable_reason_list = _get_reasons_for_no_redeemable_policies(
@@ -833,11 +824,6 @@ class SubsidyAccessPolicyAllocateViewset(UserDetailsFromJwtMixin, PermissionRequ
                     )
                     raise AllocationRequestException(detail=non_allocatable_reason_list)
 
-            # we may not have hit the `if` block, so just get a time on the
-            # entire policy lock context.  We can infer the difference between
-            # that value and `serialization_time` if the latter is available in logs.
-            lock_release_time = time.process_time() - start_time
-            logger.info('allocate timing: policy lock release %s', lock_release_time)
         except SubsidyAccessPolicyLockAttemptFailed as exc:
             logger.exception(exc)
             raise SubsidyAccessPolicyLockedException() from exc

--- a/enterprise_access/apps/content_assignments/api.py
+++ b/enterprise_access/apps/content_assignments/api.py
@@ -251,6 +251,18 @@ def allocate_assignments(assignment_configuration, learner_emails, content_key, 
       ```
 
     """
+    # Set a batch ID to track assignments updated and/or created together.
+    allocation_batch_id = uuid4()
+
+    message = (
+        'Allocating assignments: assignment_configuration=%s, batch_id=%s, '
+        'learner_emails=%s, content_key=%s, content_price_cents=%s'
+    )
+    logger.info(
+        message, assignment_configuration.uuid, allocation_batch_id,
+        learner_emails, content_key, content_price_cents
+    )
+
     if content_price_cents < 0:
         raise AllocationException('Allocation price must be >= 0')
 
@@ -280,9 +292,6 @@ def allocate_assignments(assignment_configuration, learner_emails, content_key, 
     # assignments (when they were created in a prior request), but time has passed since then so the outcome might be
     # different this time. It's technically possible some learners have registered since the last request.
     assignments_with_updated_lms_user_id = _try_populate_assignments_lms_user_id(existing_assignments)
-
-    # Set a batch ID to track assignments updated and/or created together.
-    allocation_batch_id = uuid4()
 
     # Split up the existing assignment records by state
     for assignment in existing_assignments:
@@ -457,6 +466,15 @@ def _create_new_assignments(
     """
     Helper to bulk save new LearnerContentAssignment instances.
     """
+    message = (
+        'Allocation starting to create records: assignment_configuration=%s, batch_id=%s, '
+        'learner_emails=%s, content_key=%s'
+    )
+    logger.info(
+        message, assignment_configuration.uuid, allocation_batch_id,
+        learner_emails, content_key,
+    )
+
     # First, prepare assignment objects using data available in-memory only.
     content_title = _get_content_title(assignment_configuration, content_key)
     assignments_to_create = []


### PR DESCRIPTION
[new PR b/c of weird failing test in github but not local]

* Strips out some logging that was manually timing the allocate endpoint (the endpoint is now performant enough, and we have better tools for this anyway)
* Adds logging around the main function that allocates assignments.