### PR TITLE
build: fixes for native deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ validation_requirements: ## sync to requirements for testing & code quality chec
 doc_requirements:
 	pip-sync -q requirements/doc.txt
 
-production-requirements: ## install requirements for production
+production-requirements: piptools ## install requirements for production
 	pip-sync -q requirements/production.txt
 
 static: ## generate static files

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -29,6 +29,7 @@ edx-rest-api-client
 jsonfield2
 mysqlclient
 openedx-events
+pygments
 pymemcache
 pytz
 redis

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -111,7 +111,7 @@ django-filter==23.5
     # via -r requirements/base.in
 django-log-request-id==2.1.0
     # via -r requirements/base.in
-django-model-utils==4.3.1
+django-model-utils==4.4.0
     # via
     #   edx-celeryutils
     #   edx-rbac
@@ -156,6 +156,7 @@ edx-django-utils==5.10.1
     #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   openedx-events
 edx-drf-extensions==10.2.0
     # via
     #   -r requirements/base.in
@@ -172,7 +173,7 @@ edx-rest-api-client==5.6.1
     # via
     #   -r requirements/base.in
     #   edx-enterprise-subsidy-client
-fastavro==1.9.3
+fastavro==1.9.4
     # via
     #   -r requirements/base.in
     #   openedx-events
@@ -204,7 +205,7 @@ markupsafe==2.1.5
     # via jinja2
 monotonic==1.6
     # via analytics-python
-mysqlclient==2.2.3
+mysqlclient==2.2.4
     # via -r requirements/base.in
 newrelic==9.6.0
     # via edx-django-utils
@@ -214,7 +215,7 @@ oauthlib==3.2.2
     #   social-auth-core
 openapi-codec==1.3.2
     # via django-rest-swagger
-openedx-events==9.4.0
+openedx-events==9.5.1
     # via -r requirements/base.in
 packaging==23.2
     # via drf-yasg
@@ -230,6 +231,8 @@ psutil==5.9.8
     # via edx-django-utils
 pycparser==2.21
     # via cffi
+pygments==2.17.2
+    # via -r requirements/base.in
 pyjwt[crypto]==2.8.0
     # via
     #   drf-jwt
@@ -277,7 +280,7 @@ requests==2.31.0
     #   social-auth-core
 requests-oauthlib==1.3.1
     # via social-auth-core
-rpds-py==0.17.1
+rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
@@ -298,7 +301,7 @@ slumber==0.7.1
     # via edx-rest-api-client
 social-auth-app-django==5.4.0
     # via edx-auth-backends
-social-auth-core==4.5.2
+social-auth-core==4.5.3
     # via
     #   edx-auth-backends
     #   social-auth-app-django
@@ -314,7 +317,7 @@ typing-extensions==4.9.0
     #   drf-spectacular
     #   edx-opaque-keys
     #   kombu
-tzdata==2023.4
+tzdata==2024.1
     # via
     #   backports-zoneinfo
     #   celery

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -199,7 +199,7 @@ django-filter==23.5
     # via -r requirements/validation.txt
 django-log-request-id==2.1.0
     # via -r requirements/validation.txt
-django-model-utils==4.3.1
+django-model-utils==4.4.0
     # via
     #   -r requirements/validation.txt
     #   edx-celeryutils
@@ -253,6 +253,7 @@ edx-django-utils==5.10.1
     #   -r requirements/validation.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   openedx-events
 edx-drf-extensions==10.2.0
     # via
     #   -r requirements/validation.txt
@@ -281,11 +282,11 @@ exceptiongroup==1.2.0
     #   pytest
 factory-boy==3.3.0
     # via -r requirements/validation.txt
-faker==22.7.0
+faker==23.2.0
     # via
     #   -r requirements/validation.txt
     #   factory-boy
-fastavro==1.9.3
+fastavro==1.9.4
     # via
     #   -r requirements/validation.txt
     #   openedx-events
@@ -328,7 +329,7 @@ itypes==1.2.0
     # via
     #   -r requirements/validation.txt
     #   coreapi
-jaraco-classes==3.3.0
+jaraco-classes==3.3.1
     # via
     #   -r requirements/validation.txt
     #   keyring
@@ -391,7 +392,7 @@ more-itertools==10.2.0
     # via
     #   -r requirements/validation.txt
     #   jaraco-classes
-mysqlclient==2.2.3
+mysqlclient==2.2.4
     # via -r requirements/validation.txt
 newrelic==9.6.0
     # via
@@ -410,7 +411,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/validation.txt
     #   django-rest-swagger
-openedx-events==9.4.0
+openedx-events==9.5.1
     # via -r requirements/validation.txt
 packaging==23.2
     # via
@@ -539,7 +540,7 @@ python-dateutil==2.8.2
     #   analytics-python
     #   celery
     #   faker
-python-slugify==8.0.3
+python-slugify==8.0.4
     # via
     #   -r requirements/validation.txt
     #   code-annotations
@@ -599,7 +600,7 @@ rich==13.7.0
     # via
     #   -r requirements/validation.txt
     #   twine
-rpds-py==0.17.1
+rpds-py==0.18.0
     # via
     #   -r requirements/validation.txt
     #   jsonschema
@@ -639,7 +640,7 @@ social-auth-app-django==5.4.0
     # via
     #   -r requirements/validation.txt
     #   edx-auth-backends
-social-auth-core==4.5.2
+social-auth-core==4.5.3
     # via
     #   -r requirements/validation.txt
     #   edx-auth-backends
@@ -677,7 +678,7 @@ tomlkit==0.12.3
     #   pylint
 tox==4.12.1
     # via -r requirements/validation.txt
-twine==4.0.2
+twine==5.0.0
     # via -r requirements/validation.txt
 typing-extensions==4.9.0
     # via
@@ -690,7 +691,7 @@ typing-extensions==4.9.0
     #   kombu
     #   pylint
     #   rich
-tzdata==2023.4
+tzdata==2024.1
     # via
     #   -r requirements/validation.txt
     #   backports-zoneinfo

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -195,7 +195,7 @@ django-filter==23.5
     # via -r requirements/test.txt
 django-log-request-id==2.1.0
     # via -r requirements/test.txt
-django-model-utils==4.3.1
+django-model-utils==4.4.0
     # via
     #   -r requirements/test.txt
     #   edx-celeryutils
@@ -254,6 +254,7 @@ edx-django-utils==5.10.1
     #   -r requirements/test.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   openedx-events
 edx-drf-extensions==10.2.0
     # via
     #   -r requirements/test.txt
@@ -280,11 +281,11 @@ exceptiongroup==1.2.0
     #   pytest
 factory-boy==3.3.0
     # via -r requirements/test.txt
-faker==22.7.0
+faker==23.2.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
-fastavro==1.9.3
+fastavro==1.9.4
     # via
     #   -r requirements/test.txt
     #   openedx-events
@@ -359,7 +360,7 @@ monotonic==1.6
     # via
     #   -r requirements/test.txt
     #   analytics-python
-mysqlclient==2.2.3
+mysqlclient==2.2.4
     # via -r requirements/test.txt
 newrelic==9.6.0
     # via
@@ -376,7 +377,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
-openedx-events==9.4.0
+openedx-events==9.5.1
     # via -r requirements/test.txt
 packaging==23.2
     # via
@@ -426,6 +427,7 @@ pydata-sphinx-theme==0.14.4
     # via sphinx-book-theme
 pygments==2.17.2
     # via
+    #   -r requirements/test.txt
     #   accessible-pygments
     #   doc8
     #   pydata-sphinx-theme
@@ -489,7 +491,7 @@ python-dateutil==2.8.2
     #   analytics-python
     #   celery
     #   faker
-python-slugify==8.0.3
+python-slugify==8.0.4
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -536,7 +538,7 @@ requests-oauthlib==1.3.1
     #   social-auth-core
 restructuredtext-lint==1.4.0
     # via doc8
-rpds-py==0.17.1
+rpds-py==0.18.0
     # via
     #   -r requirements/test.txt
     #   jsonschema
@@ -570,7 +572,7 @@ social-auth-app-django==5.4.0
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.5.2
+social-auth-core==4.5.3
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
@@ -637,7 +639,7 @@ typing-extensions==4.9.0
     #   kombu
     #   pydata-sphinx-theme
     #   pylint
-tzdata==2023.4
+tzdata==2024.1
     # via
     #   -r requirements/test.txt
     #   backports-zoneinfo

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.42.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.0
     # via -r requirements/pip.in
-setuptools==69.0.3
+setuptools==69.1.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -140,7 +140,7 @@ django-filter==23.5
     # via -r requirements/base.txt
 django-log-request-id==2.1.0
     # via -r requirements/base.txt
-django-model-utils==4.3.1
+django-model-utils==4.4.0
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
@@ -190,6 +190,7 @@ edx-django-utils==5.10.1
     #   -r requirements/base.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   openedx-events
 edx-drf-extensions==10.2.0
     # via
     #   -r requirements/base.txt
@@ -208,11 +209,11 @@ edx-rest-api-client==5.6.1
     # via
     #   -r requirements/base.txt
     #   edx-enterprise-subsidy-client
-fastavro==1.9.3
+fastavro==1.9.4
     # via
     #   -r requirements/base.txt
     #   openedx-events
-gevent==23.9.1
+gevent==24.2.1
     # via -r requirements/production.in
 greenlet==3.0.3
     # via gevent
@@ -266,7 +267,7 @@ monotonic==1.6
     # via
     #   -r requirements/base.txt
     #   analytics-python
-mysqlclient==2.2.3
+mysqlclient==2.2.4
     # via
     #   -r requirements/base.txt
     #   -r requirements/production.in
@@ -283,7 +284,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-openedx-events==9.4.0
+openedx-events==9.5.1
     # via -r requirements/base.txt
 packaging==23.2
     # via
@@ -314,6 +315,8 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
+pygments==2.17.2
+    # via -r requirements/base.txt
 pyjwt[crypto]==2.8.0
     # via
     #   -r requirements/base.txt
@@ -377,7 +380,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-rpds-py==0.17.1
+rpds-py==0.18.0
     # via
     #   -r requirements/base.txt
     #   jsonschema
@@ -408,7 +411,7 @@ social-auth-app-django==5.4.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.5.2
+social-auth-core==4.5.3
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -429,7 +432,7 @@ typing-extensions==4.9.0
     #   drf-spectacular
     #   edx-opaque-keys
     #   kombu
-tzdata==2023.4
+tzdata==2024.1
     # via
     #   -r requirements/base.txt
     #   backports-zoneinfo

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -186,7 +186,7 @@ django-filter==23.5
     # via -r requirements/test.txt
 django-log-request-id==2.1.0
     # via -r requirements/test.txt
-django-model-utils==4.3.1
+django-model-utils==4.4.0
     # via
     #   -r requirements/test.txt
     #   edx-celeryutils
@@ -238,6 +238,7 @@ edx-django-utils==5.10.1
     #   -r requirements/test.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   openedx-events
 edx-drf-extensions==10.2.0
     # via
     #   -r requirements/test.txt
@@ -266,11 +267,11 @@ exceptiongroup==1.2.0
     #   pytest
 factory-boy==3.3.0
     # via -r requirements/test.txt
-faker==22.7.0
+faker==23.2.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
-fastavro==1.9.3
+fastavro==1.9.4
     # via
     #   -r requirements/test.txt
     #   openedx-events
@@ -311,7 +312,7 @@ itypes==1.2.0
     # via
     #   -r requirements/test.txt
     #   coreapi
-jaraco-classes==3.3.0
+jaraco-classes==3.3.1
     # via keyring
 jeepney==0.8.0
     # via
@@ -360,7 +361,7 @@ monotonic==1.6
     #   analytics-python
 more-itertools==10.2.0
     # via jaraco-classes
-mysqlclient==2.2.3
+mysqlclient==2.2.4
     # via -r requirements/test.txt
 newrelic==9.6.0
     # via
@@ -377,7 +378,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
-openedx-events==9.4.0
+openedx-events==9.5.1
     # via -r requirements/test.txt
 packaging==23.2
     # via
@@ -429,6 +430,7 @@ pydocstyle==6.3.0
     # via -r requirements/quality.in
 pygments==2.17.2
     # via
+    #   -r requirements/test.txt
     #   readme-renderer
     #   rich
 pyjwt[crypto]==2.8.0
@@ -489,7 +491,7 @@ python-dateutil==2.8.2
     #   analytics-python
     #   celery
     #   faker
-python-slugify==8.0.3
+python-slugify==8.0.4
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -540,7 +542,7 @@ rfc3986==2.0.0
     # via twine
 rich==13.7.0
     # via twine
-rpds-py==0.17.1
+rpds-py==0.18.0
     # via
     #   -r requirements/test.txt
     #   jsonschema
@@ -576,7 +578,7 @@ social-auth-app-django==5.4.0
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.5.2
+social-auth-core==4.5.3
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
@@ -609,7 +611,7 @@ tomlkit==0.12.3
     #   pylint
 tox==4.12.1
     # via -r requirements/test.txt
-twine==4.0.2
+twine==5.0.0
     # via -r requirements/quality.in
 typing-extensions==4.9.0
     # via
@@ -622,7 +624,7 @@ typing-extensions==4.9.0
     #   kombu
     #   pylint
     #   rich
-tzdata==2023.4
+tzdata==2024.1
     # via
     #   -r requirements/test.txt
     #   backports-zoneinfo

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -170,7 +170,7 @@ django-filter==23.5
     # via -r requirements/base.txt
 django-log-request-id==2.1.0
     # via -r requirements/base.txt
-django-model-utils==4.3.1
+django-model-utils==4.4.0
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
@@ -220,6 +220,7 @@ edx-django-utils==5.10.1
     #   -r requirements/base.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   openedx-events
 edx-drf-extensions==10.2.0
     # via
     #   -r requirements/base.txt
@@ -244,9 +245,9 @@ exceptiongroup==1.2.0
     # via pytest
 factory-boy==3.3.0
     # via -r requirements/test.in
-faker==22.7.0
+faker==23.2.0
     # via factory-boy
-fastavro==1.9.3
+fastavro==1.9.4
     # via
     #   -r requirements/base.txt
     #   openedx-events
@@ -309,7 +310,7 @@ monotonic==1.6
     # via
     #   -r requirements/base.txt
     #   analytics-python
-mysqlclient==2.2.3
+mysqlclient==2.2.4
     # via -r requirements/base.txt
 newrelic==9.6.0
     # via
@@ -324,7 +325,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-openedx-events==9.4.0
+openedx-events==9.5.1
     # via -r requirements/base.txt
 packaging==23.2
     # via
@@ -366,6 +367,8 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
+pygments==2.17.2
+    # via -r requirements/base.txt
 pyjwt[crypto]==2.8.0
     # via
     #   -r requirements/base.txt
@@ -415,7 +418,7 @@ python-dateutil==2.8.2
     #   analytics-python
     #   celery
     #   faker
-python-slugify==8.0.3
+python-slugify==8.0.4
     # via code-annotations
 python3-openid==3.2.0
     # via
@@ -454,7 +457,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-rpds-py==0.17.1
+rpds-py==0.18.0
     # via
     #   -r requirements/base.txt
     #   jsonschema
@@ -486,7 +489,7 @@ social-auth-app-django==5.4.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.5.2
+social-auth-core==4.5.3
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -524,7 +527,7 @@ typing-extensions==4.9.0
     #   faker
     #   kombu
     #   pylint
-tzdata==2023.4
+tzdata==2024.1
     # via
     #   -r requirements/base.txt
     #   backports-zoneinfo

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -234,7 +234,7 @@ django-log-request-id==2.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-django-model-utils==4.3.1
+django-model-utils==4.4.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -312,6 +312,7 @@ edx-django-utils==5.10.1
     #   -r requirements/test.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   openedx-events
 edx-drf-extensions==10.2.0
     # via
     #   -r requirements/quality.txt
@@ -350,12 +351,12 @@ factory-boy==3.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-faker==22.7.0
+faker==23.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   factory-boy
-fastavro==1.9.3
+fastavro==1.9.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -404,7 +405,7 @@ itypes==1.2.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   coreapi
-jaraco-classes==3.3.0
+jaraco-classes==3.3.1
     # via
     #   -r requirements/quality.txt
     #   keyring
@@ -474,7 +475,7 @@ more-itertools==10.2.0
     # via
     #   -r requirements/quality.txt
     #   jaraco-classes
-mysqlclient==2.2.3
+mysqlclient==2.2.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -498,7 +499,7 @@ openapi-codec==1.3.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django-rest-swagger
-openedx-events==9.4.0
+openedx-events==9.5.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -564,6 +565,7 @@ pydocstyle==6.3.0
 pygments==2.17.2
     # via
     #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   readme-renderer
     #   rich
 pyjwt[crypto]==2.8.0
@@ -640,7 +642,7 @@ python-dateutil==2.8.2
     #   analytics-python
     #   celery
     #   faker
-python-slugify==8.0.3
+python-slugify==8.0.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -708,7 +710,7 @@ rich==13.7.0
     # via
     #   -r requirements/quality.txt
     #   twine
-rpds-py==0.17.1
+rpds-py==0.18.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -756,7 +758,7 @@ social-auth-app-django==5.4.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.5.2
+social-auth-core==4.5.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -797,7 +799,7 @@ tox==4.12.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-twine==4.0.2
+twine==5.0.0
     # via -r requirements/quality.txt
 typing-extensions==4.9.0
     # via
@@ -811,7 +813,7 @@ typing-extensions==4.9.0
     #   kombu
     #   pylint
     #   rich
-tzdata==2023.4
+tzdata==2024.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
While creating the Ansible playbooks and roles for deploying enterprise-access - https://github.com/openedx/configuration/pull/7107, a couple of issues were discovered with the `production-requirements` make command and the requirements.

This PR includes the following changes:
1. Make the `production-requriements` command depend on the `piptools` command so that it can be run without explicitly running the `piptools` beforehand.
2. Add `pygments` as an explicit requirement.