### PR TITLE
feat: update contact email logic in can_redeem

### DIFF
--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -95,19 +95,31 @@ def _get_reasons_for_no_redeemable_policies(enterprise_customer_uuid, non_redeem
     reasons = []
     lms_client = LmsApiClient()
     enterprise_customer_data = lms_client.get_enterprise_customer_data(enterprise_customer_uuid)
-    enterprise_admin_users = enterprise_customer_data.get('admin_users')
+    admin_contact = _get_admin_contact_email(enterprise_customer_data)
 
     for reason, policies in non_redeemable_policies_by_reason.items():
         reasons.append({
             "reason": reason,
-            "user_message": _get_user_message_for_reason(reason, enterprise_admin_users),
+            "user_message": _get_user_message_for_reason(reason, admin_contact),
             "metadata": {
-                "enterprise_administrators": enterprise_admin_users,
+                "enterprise_administrators": admin_contact,
             },
             "policy_uuids": [policy.uuid for policy in policies],
         })
 
     return reasons
+
+
+def _get_admin_contact_email(enterprise_customer_data):
+    """
+    Return the point of contact email for an enterprise customer.
+    """
+    if admin_contact_email := enterprise_customer_data.get('contact_email'):
+        return [{
+            "email": admin_contact_email,
+            "lms_user_id": None,
+        }]
+    return enterprise_customer_data.get('admin_users', [])
 
 
 def _get_user_message_for_reason(reason_slug, enterprise_admin_users):


### PR DESCRIPTION
# Description
Update the `enterprise_administrators` contact information to the enterprise customer's `contact_email` since we want to prioritize this over the list of `admin_users`. Fall back on the list of `admin_users` if a `contact_email` is not set.

https://2u-internal.atlassian.net/browse/ENT-8418