### PR TITLE
fix: serialized data should not include querysets

### DIFF
--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -180,7 +180,7 @@ class SubsidyAccessPolicyResponseSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
     def get_group_associations(self, obj):
-        return obj.groups.values_list("enterprise_group_uuid", flat=True)
+        return list(obj.groups.values_list("enterprise_group_uuid", flat=True))
 
 
 class SubsidyAccessPolicyCRUDSerializer(serializers.ModelSerializer):
@@ -275,7 +275,7 @@ class SubsidyAccessPolicyCRUDSerializer(serializers.ModelSerializer):
         return self.context['view']
 
     def get_group_associations(self, obj):
-        return obj.groups.values_list("enterprise_group_uuid", flat=True)
+        return list(obj.groups.values_list("enterprise_group_uuid", flat=True))
 
     def create(self, validated_data):
         policy_type = validated_data.get('policy_type')

--- a/enterprise_access/apps/subsidy_access_policy/admin.py
+++ b/enterprise_access/apps/subsidy_access_policy/admin.py
@@ -79,20 +79,23 @@ class BaseSubsidyAccessPolicyMixin(SimpleHistoryAdmin):
         https://daniel.feldroy.com/posts/pretty-formatting-json-django-admin
         for this styling idea.
         """
-        data = SubsidyAccessPolicyResponseSerializer(obj).data
-        json_string = json.dumps(data, indent=4, sort_keys=True)
+        try:
+            data = SubsidyAccessPolicyResponseSerializer(obj).data
+            json_string = json.dumps(data, indent=4, sort_keys=True)
 
-        # Get the Pygments formatter
-        formatter = HtmlFormatter(style='default')
+            # Get the Pygments formatter
+            formatter = HtmlFormatter(style='default')
 
-        # Highlight the data
-        response = highlight(json_string, JsonLexer(), formatter)
+            # Highlight the data
+            response = highlight(json_string, JsonLexer(), formatter)
 
-        # Get the stylesheet
-        style = "<style>" + formatter.get_style_defs() + "</style><br>"
+            # Get the stylesheet
+            style = "<style>" + formatter.get_style_defs() + "</style><br>"
 
-        # Safe the output
-        return mark_safe(style + response)
+            # Safe the output
+            return mark_safe(style + response)
+        except Exception:  # pylint: disable=broad-except
+            return ''
 
     def _short_description(self, obj):
         return Truncator(str(obj.description)).chars(255)


### PR DESCRIPTION
also, broadly try/except the django admin API repr of serialized subsidy access policy records.