### PR TITLE
feat: pass the special keyword during forced redemption

### DIFF
--- a/enterprise_access/apps/subsidy_access_policy/constants.py
+++ b/enterprise_access/apps/subsidy_access_policy/constants.py
@@ -113,3 +113,7 @@ REASON_LEARNER_MAX_ENROLLMENTS_REACHED = "learner_max_enrollments_reached"
 REASON_LEARNER_NOT_ASSIGNED_CONTENT = "reason_learner_not_assigned_content"
 REASON_LEARNER_ASSIGNMENT_CANCELLED = "reason_learner_assignment_cancelled"
 REASON_LEARNER_ASSIGNMENT_FAILED = "reason_learner_assignment_failed"
+
+# Redeem metadata keyword that
+# forces enrollment to take place, regardless of course state.
+FORCE_ENROLLMENT_KEYWORD = 'allow_late_enrollment'

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -25,6 +25,7 @@ from enterprise_access.utils import format_traceback, is_none, is_not_none, loca
 from ..content_assignments.models import AssignmentConfiguration
 from .constants import (
     CREDIT_POLICY_TYPE_PRIORITY,
+    FORCE_ENROLLMENT_KEYWORD,
     REASON_CONTENT_NOT_IN_CATALOG,
     REASON_LEARNER_ASSIGNMENT_CANCELLED,
     REASON_LEARNER_ASSIGNMENT_FAILED,
@@ -1642,6 +1643,9 @@ class ForcedPolicyRedemption(TimeStampedModel):
                         self.lms_user_id,
                         self.course_run_key,
                         existing_transactions,
+                        metadata={
+                            FORCE_ENROLLMENT_KEYWORD: True,
+                        },
                     )
                     self.transaction_uuid = result['uuid']
                     self.redeemed_at = result['modified']


### PR DESCRIPTION
Keyword required by the subsidy service: https://github.com/openedx/enterprise-subsidy/pull/219 `allow_late_enrollment`
This is the thing that will allow us to not only force redemption, but to force it for courses that are otherwise _closed_ to new enrollments.