### PR TITLE
fix: django admin search on FK field

### DIFF
--- a/enterprise_access/apps/content_assignments/admin.py
+++ b/enterprise_access/apps/content_assignments/admin.py
@@ -80,7 +80,7 @@ class LearnerContentAssignmentAdmin(DjangoQLSearchMixin, SimpleHistoryAdmin):
         'uuid',
         'learner_email',
         'lms_user_id',
-        'assignment_configuration',
+        'assignment_configuration__uuid',
         'assignment_configuration__enterprise_customer_uuid',
     )
     list_filter = ('state',)
@@ -124,7 +124,7 @@ class LearnerContentAssignmentActionAdmin(DjangoQLSearchMixin, SimpleHistoryAdmi
     ordering = ['-modified']
     search_fields = (
         'uuid',
-        'assignment',
+        'assignment__uuid',
         'traceback',
     )
     list_filter = ('action_type', 'error_reason')

--- a/enterprise_access/apps/subsidy_access_policy/admin/__init__.py
+++ b/enterprise_access/apps/subsidy_access_policy/admin/__init__.py
@@ -330,7 +330,7 @@ class PolicyGroupAssociationAdmin(admin.ModelAdmin):
     Admin configuration for PolicyGroupAssociation
     """
     search_fields = (
-        'subsidy_access_policy',
+        'subsidy_access_policy__uuid',
         'enterprise_group_uuid',
     )
 


### PR DESCRIPTION
In Django Admin, you can't search directly on a Foreign Key model - you have to specify which _field_ of the related model is searchable, even if it's the PK.