### PR TITLE
feat: reminder failures no longer fail assignments

### DIFF
--- a/enterprise_access/apps/api/v1/views/content_assignments/assignments_admin.py
+++ b/enterprise_access/apps/api/v1/views/content_assignments/assignments_admin.py
@@ -188,7 +188,7 @@ class LearnerContentAssignmentAdminViewSet(
     @extend_schema(
         tags=[CONTENT_ASSIGNMENT_ADMIN_CRUD_API_TAG],
         summary='Cancel assignments by UUID.',
-        parameters=[LearnerContentAssignmentActionRequestSerializer],
+        request=LearnerContentAssignmentActionRequestSerializer,
         responses={
             status.HTTP_200_OK: None,
             status.HTTP_404_NOT_FOUND: None,
@@ -270,7 +270,7 @@ class LearnerContentAssignmentAdminViewSet(
     @extend_schema(
         tags=[CONTENT_ASSIGNMENT_ADMIN_CRUD_API_TAG],
         summary='Remind assignments by UUID.',
-        parameters=[LearnerContentAssignmentActionRequestSerializer],
+        request=LearnerContentAssignmentActionRequestSerializer,
         responses={
             status.HTTP_200_OK: None,
             status.HTTP_404_NOT_FOUND: None,


### PR DESCRIPTION
This is a stop-the-bleeding approach to solving the problem where reminder failures cause the assignment to become inadvertently non-redeemable. This commit results in the remind and remind-all endpoints no longer progressing the assignment lifecycle state to `errored` when the reminder fails for any reason.

Before this PR, clicking remind would cause admins to see the following table cells change:

* Reminder failure:
  - Status column: "Waiting for learner" -> "Failed: Reminder"
  - Recent action column: "Assigned: \<date\>" -> NO CHANGE
* Reminder success:
  - Status column: "Waiting for learner" -> NO CHANGE
  - Recent action column: "Assigned: \<date\>" -> "Reminded: \<date\>"

but now they will see:

* Reminder failure:
  - Status column: "Waiting for learner" -> NO CHANGE
  - Recent action column: "Assigned: \<date\>" -> NO CHANGE
* Reminder success:
  - Status column: "Waiting for learner" -> NO CHANGE
  - Recent action column: "Assigned: \<date\>" -> "Reminded: \<date\>"

This is obviously not ideal because the failure case causes no visual change in the admin UI whatsoever. Absence of a POSITIVE change in the recent action column implies a NEGATIVE reminder outcome, so reminder failures are *indirectly* inferrable. However, this is likely not the preferred long-term UX because reminder failures are not *directly* inferrable.

ENT-8362

Screenshots
===

Assignment just created:
<img width="783" alt="Screenshot 2024-04-18 at 16 57 29" src="https://github.com/openedx/enterprise-access/assets/85151/5a0afddf-b0fe-4d66-82ef-2a1ffd5d1ccf">

"Failed" reminder action added with `completed_at` = null and `error_reason` = `email_error`:
<img width="783" alt="Screenshot 2024-04-18 at 16 57 29" src="https://github.com/openedx/enterprise-access/assets/85151/5a0afddf-b0fe-4d66-82ef-2a1ffd5d1ccf">

"Successful" reminder action added with `completed_at` = now and `error_reason` = null:
<img width="786" alt="Screenshot 2024-04-18 at 17 01 41" src="https://github.com/openedx/enterprise-access/assets/85151/50aa0302-caf3-4a66-aea5-70d6de1e3682">
