### PR TITLE
fix: uniquify retired email addresses

### DIFF
--- a/enterprise_access/apps/content_assignments/api.py
+++ b/enterprise_access/apps/content_assignments/api.py
@@ -756,7 +756,6 @@ def expire_assignment(
 
         if automatic_expiration_reason == AssignmentAutomaticExpiredReason.NINETY_DAYS_PASSED:
             assignment.clear_pii()
-            assignment.clear_historical_pii()
 
         assignment.save()
         send_assignment_automatically_expired_email.delay(assignment.uuid)

--- a/enterprise_access/apps/content_assignments/constants.py
+++ b/enterprise_access/apps/content_assignments/constants.py
@@ -120,4 +120,4 @@ class AssignmentAutomaticExpiredReason:
 
 NUM_DAYS_BEFORE_AUTO_EXPIRATION = 90
 
-RETIRED_EMAIL_ADDRESS = 'retired_user@retired.invalid'
+RETIRED_EMAIL_ADDRESS_FORMAT = 'retired_user{}@retired.invalid'

--- a/enterprise_access/apps/content_assignments/tests/test_models.py
+++ b/enterprise_access/apps/content_assignments/tests/test_models.py
@@ -1,13 +1,14 @@
 """
 Tests for the ``api.py`` module of the content_assignments app.
 """
+import re
 
 from django.test import TestCase
 from django.utils import timezone
 
 from enterprise_access.apps.subsidy_access_policy.tests.factories import AssignedLearnerCreditAccessPolicyFactory
 
-from ..constants import RETIRED_EMAIL_ADDRESS, AssignmentActions
+from ..constants import RETIRED_EMAIL_ADDRESS_FORMAT, AssignmentActions
 from ..models import AssignmentConfiguration
 from .factories import LearnerContentAssignmentFactory
 
@@ -155,12 +156,12 @@ class TestAssignmentActions(TestCase):
 
         self.assignment.clear_pii()
         self.assignment.save()
-        self.assignment.clear_historical_pii()
 
         self.assignment.refresh_from_db()
 
         self.assertEqual(12345, self.assignment.lms_user_id)
-        self.assertEqual(self.assignment.learner_email, RETIRED_EMAIL_ADDRESS)
+        pattern = RETIRED_EMAIL_ADDRESS_FORMAT.format('[a-f0-9]{16}')
+        self.assertIsNotNone(re.match(pattern, self.assignment.learner_email))
 
         for historical_record in self.assignment.history.all():
-            self.assertEqual(historical_record.learner_email, RETIRED_EMAIL_ADDRESS)
+            self.assertIsNotNone(re.match(pattern, historical_record.learner_email))


### PR DESCRIPTION
Prior to this change, the `LearnerContentAssignment.clear_pii()` method set a retired email address to the same static value.  This means that if two different learners (by email) in the same assignment configuration (i.e. budget) have the same course assigned, and then those records are expired, the second record to be expired will fail on the unique constraint violation of the model.
This change adds a random hex-string to each retired email address value to help resolve this issue. ENT-8574

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
