### PR TITLE
feat: Updates groups learner record check to cached learner record

### DIFF
--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -1095,6 +1095,7 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
             SubsidyAccessPolicy, 'enterprise_user_record'
         )
         self.mock_enterprise_user_record = enterprise_user_record_patcher.start()
+        self.mock_enterprise_user_record.return_value = TEST_USER_RECORD
 
         self.addCleanup(lms_client_patcher.stop)
         self.addCleanup(subsidy_client_patcher.stop)
@@ -1413,6 +1414,7 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
             'is_active': is_subsidy_active,
         }
         self.lms_client_instance.get_enterprise_user.return_value = get_enterprise_user
+        self.mock_enterprise_user_record.return_value = get_enterprise_user
 
         query_params = {
             'enterprise_customer_uuid': str(self.enterprise_uuid),

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -1091,17 +1091,16 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
         self.lms_client_instance = lms_client.return_value
         self.lms_client_instance.get_enterprise_user.return_value = TEST_USER_RECORD
 
-        includes_user_patcher = patch.object(
-            SubsidyAccessPolicy, 'includes_user'
+        enterprise_user_record_patcher = patch.object(
+            SubsidyAccessPolicy, 'enterprise_user_record'
         )
-        self.mock_includes_user = includes_user_patcher.start()
-        self.mock_includes_user.return_value = True
+        self.mock_enterprise_user_record = enterprise_user_record_patcher.start()
 
         self.addCleanup(lms_client_patcher.stop)
         self.addCleanup(subsidy_client_patcher.stop)
         self.addCleanup(contains_key_patcher.stop)
         self.addCleanup(get_content_metadata_patcher.stop)
-        self.addCleanup(includes_user_patcher.stop)
+        self.addCleanup(enterprise_user_record_patcher.stop)
 
     @mock.patch('enterprise_access.apps.api_client.base_oauth.OAuthAPIClient')
     @mock.patch('enterprise_access.apps.subsidy_access_policy.models.get_and_cache_transactions_for_learner')

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -387,7 +387,7 @@ class SubsidyAccessPolicy(TimeStampedModel):
 
     def enterprise_user_record(self, lms_user_id):
         """
-        Determines if the user is included in the SubsidyAccessPolicy's customer.
+        Returns the enterprise_user_record.
         Retrieves it from TieredCache if available, otherwise, it will retrieve and initialize the cache.
         """
         enterprise_user_record = get_and_cache_enterprise_learner_record(

--- a/enterprise_access/apps/subsidy_access_policy/tests/mixins.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/mixins.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 
 from django.core.cache import cache as django_cache
 
+from test_utils import TEST_USER_RECORD
+
 from ..models import SubsidyAccessPolicy
 
 
@@ -49,6 +51,7 @@ class MockPolicyDependenciesMixin:
         )
 
         self.mock_enterprise_user_record = enterprise_user_record_patcher.start()
+        self.mock_enterprise_user_record.return_value = TEST_USER_RECORD
 
         self.addCleanup(subsidy_client_patcher.stop)
         self.addCleanup(transactions_cache_for_learner_patcher.stop)

--- a/enterprise_access/apps/subsidy_access_policy/tests/mixins.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/mixins.py
@@ -48,7 +48,7 @@ class MockPolicyDependenciesMixin:
             SubsidyAccessPolicy, 'enterprise_user_record'
         )
 
-        self.mock_enterprise_user_record= enterprise_user_record_patcher.start()
+        self.mock_enterprise_user_record = enterprise_user_record_patcher.start()
 
         self.addCleanup(subsidy_client_patcher.stop)
         self.addCleanup(transactions_cache_for_learner_patcher.stop)

--- a/enterprise_access/apps/subsidy_access_policy/tests/mixins.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/mixins.py
@@ -44,17 +44,16 @@ class MockPolicyDependenciesMixin:
 
         self.mock_lms_api_client = lms_api_client_patcher.start()
 
-        includes_user_patcher = patch.object(
-            SubsidyAccessPolicy, 'includes_user'
+        enterprise_user_record_patcher = patch.object(
+            SubsidyAccessPolicy, 'enterprise_user_record'
         )
 
-        self.mock_includes_user = includes_user_patcher.start()
-        self.mock_includes_user.return_value = True
+        self.mock_enterprise_user_record= enterprise_user_record_patcher.start()
 
         self.addCleanup(subsidy_client_patcher.stop)
         self.addCleanup(transactions_cache_for_learner_patcher.stop)
         self.addCleanup(catalog_contains_content_key_patcher.stop)
         self.addCleanup(get_content_metadata_patcher.stop)
         self.addCleanup(lms_api_client_patcher.stop)
-        self.addCleanup(includes_user_patcher.stop)
+        self.addCleanup(enterprise_user_record_patcher.stop)
         self.addCleanup(django_cache.clear)  # clear any leftover policy locks.

--- a/enterprise_access/apps/subsidy_access_policy/tests/test_models.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/test_models.py
@@ -320,6 +320,7 @@ class SubsidyAccessPolicyTests(MockPolicyDependenciesMixin, TestCase):
         Test the can_redeem method of PerLearnerEnrollmentCapLearnerCreditAccessPolicy model
         """
         self.mock_lms_api_client.get_enterprise_user.return_value = get_enterprise_user
+        self.mock_enterprise_user_record.return_value = get_enterprise_user
         self.mock_catalog_contains_content_key.return_value = catalog_contains_content
         self.mock_get_content_metadata.return_value = {
             'content_price': 200,
@@ -503,6 +504,7 @@ class SubsidyAccessPolicyTests(MockPolicyDependenciesMixin, TestCase):
         Test the can_redeem method of PerLearnerSpendCapLearnerCreditAccessPolicy model
         """
         self.mock_lms_api_client.get_enterprise_user.return_value = get_enterprise_user
+        self.mock_enterprise_user_record.return_value = get_enterprise_user
         self.mock_catalog_contains_content_key.return_value = catalog_contains_content
         self.mock_get_content_metadata.return_value = {
             'content_price': 200,


### PR DESCRIPTION
**Description:**
Updates usage of `get_enterprise_user` in `includes_learner` for groups, to include an additional argument `enterprise_user_record` which defaults to `None` if nothing is passed. This allows us to pass the learner record in if it exists. If no `enterprise_user_record` exists, it will attempt to retrieve it from the cache, or fetch and initialize the cache via the `get_and_cache_enterprise_learner_record` function.
Modifies `includes_user` to `enterprise_user_record` to return to user record as oppose to resolve its boolean value whether the enterprise_user_record exists. This was modified to reduce the amount of calls to `get_enterprise_user` and the cache by allowing the check of its existence to happen in line, and using the `enterprise_user_record` object if it does exist within `includes_learner`

**Jira:**
[ENT-8603](https://2u-internal.atlassian.net/browse/ENT-8603)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
