### PR TITLE
fix: omitting groups with aggregates false query param passed along to platform

### DIFF
--- a/enterprise_access/apps/api_client/lms_client.py
+++ b/enterprise_access/apps/api_client/lms_client.py
@@ -165,9 +165,10 @@ class LmsApiClient(BaseOAuthClient):
         params = {
             "sort_by": sort_by,
             "user_query": user_query,
-            "show_removed": show_removed,
             "page": page,
         }
+        if show_removed:
+            params['show_removed'] = show_removed
         if is_reversed:
             params['is_reversed'] = is_reversed
 


### PR DESCRIPTION
**Description:**
Platform treats `show_removed` as true if it's included, no matter the value. Therefore, the only way to pass a False value is to omit it entirely.


**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
