### PR TITLE
feat: allowing for sort by enrollment count on group members endpoint

### DIFF
--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -14,7 +14,11 @@ from requests.exceptions import HTTPError
 from rest_framework import serializers
 
 from enterprise_access.apps.content_assignments.content_metadata_api import get_content_metadata_for_assignments
-from enterprise_access.apps.subsidy_access_policy.constants import CENTS_PER_DOLLAR, PolicyTypes
+from enterprise_access.apps.subsidy_access_policy.constants import (
+    CENTS_PER_DOLLAR,
+    SORT_BY_ENROLLMENT_COUNT,
+    PolicyTypes,
+)
 from enterprise_access.apps.subsidy_access_policy.models import SubsidyAccessPolicy
 
 from .content_assignments.assignment import (
@@ -786,7 +790,8 @@ class GroupMemberWithAggregatesRequestSerializer(serializers.Serializer):
         choices=[
             ('member_details', 'member_details'),
             ('status', 'status'),
-            ('recent_action', 'recent_action')
+            ('recent_action', 'recent_action'),
+            (SORT_BY_ENROLLMENT_COUNT, SORT_BY_ENROLLMENT_COUNT),
         ],
         required=False,
     )

--- a/enterprise_access/apps/subsidy_access_policy/constants.py
+++ b/enterprise_access/apps/subsidy_access_policy/constants.py
@@ -117,3 +117,5 @@ REASON_LEARNER_ASSIGNMENT_FAILED = "reason_learner_assignment_failed"
 # Redeem metadata keyword that
 # forces enrollment to take place, regardless of course state.
 FORCE_ENROLLMENT_KEYWORD = 'allow_late_enrollment'
+
+SORT_BY_ENROLLMENT_COUNT = 'enrollment_count'


### PR DESCRIPTION
**Description:**
Adds the ability to sort group members with aggregates data by enrollment count

**Jira:**
https://2u-internal.atlassian.net/browse/ENT-8865

**Merge checklist:**
- [x] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
