### PR TITLE
build: upgraded deps and local kafka installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,40 @@ Running migrations
   $ make app-shell
   # python ./manage.py migrate
 
+Setting up openedx-events
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Ensure you've installed the ``edx_event_bus_kafka`` and ``openedx_events`` requirements. Entering
+a shell with ``make app-shell`` and then running ``make requirements`` should install these for you.
+
+From your host, run ``make dev.up.with-events``, which will start a local kafka container for you.
+Visit http://localhost:9021/clusters to access the local "Confluent Control Center".
+Confluent is like a cloud wrapper around vanilla Kafka.
+
+Your ``devstack.py`` settings should already be configured to point at this event broker,
+and to configure enterprise-access as an openedx event consumer and produer.
+
+We have a specific enterprise "ping" event and management command defined to test
+that your local event bus is well-configured. Open a shell with ``make app-shell`` and run::
+
+  ./manage.py consume_enterprise_ping_events
+
+This will consume ping events from the ``dev-enterprise-core`` topic.
+You may see a ``Broker: Unknown topic`` error the first time you run it.  When you run your
+test event production below, that error will resolve (producing the event creates the topic
+if it does not exist). **Leave the consumer running.** You should see the ``enterprise-access-service``
+as a registered consumer in your local confluent control center.
+
+Now, go over to your **enterprise-subsidy** directory. Make sure requirements are installed,
+specifically the ``edx_event_bus_kafka`` and ``openedx_events`` packages. Use ``make app-shell``
+in this repo and we'll *produce* a ping event::
+
+  ./manage.py produce_enterprise_ping_event
+
+If this event was successfully produced, you'll see a log message that says
+``Message delivered to Kafka event bus: topic=dev-events-testing``.
+You should also now see the ``dev-events-testing`` topic available in your local confluent control center,
+and even the test events that are being published to the topic.
+
 A note on creating SubsidyRequestCustomerConfiguration Objects locally
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/enterprise_access/apps/core/management/commands/consume_enterprise_ping_events.py
+++ b/enterprise_access/apps/core/management/commands/consume_enterprise_ping_events.py
@@ -1,0 +1,116 @@
+"""
+Produce a single event for enterprise-specific testing or health checks.
+
+Implements required ``APP.management.commands.*.Command`` structure.
+"""
+import json
+import logging
+from argparse import RawTextHelpFormatter
+from pprint import pformat
+
+import attr
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.dispatch import receiver
+from openedx_events.event_bus import make_single_consumer
+from openedx_events.tooling import OpenEdxPublicSignal
+
+logger = logging.getLogger(__name__)
+
+
+# First define the topic that our consumer will subscribe to.
+ENTERPRISE_CORE_TOPIC = getattr(settings, 'EVENT_BUS_ENTERPRISE_CORE_TOPIC', 'enterprise-core')
+
+
+# Define the shape/schema of the data that our consumer will process.
+# It should be identical to the schema used to *produce* the event.
+@attr.s(frozen=True)
+class PingData:
+    """
+    Attributes of a ping record.
+    """
+    ping_uuid = attr.ib(type=str)
+    ping_message = attr.ib(type=str)
+
+
+ENTERPRISE_PING_DATA_SCHEMA = {
+    "ping": PingData,
+}
+
+# Define a Signal with the type (unique name) of the event to process,
+# and tell it about the expected schema of event data. The producer of our ping events
+# should emit an identical signal (same event_type and data schema).
+ENTERPRISE_PING_SIGNAL = OpenEdxPublicSignal(
+    event_type="org.openedx.enterprise.core.ping.v1",
+    data=ENTERPRISE_PING_DATA_SCHEMA
+)
+
+
+# Create a receiver function to do the "processing" of the signal data.
+@receiver(ENTERPRISE_PING_SIGNAL)
+def handle_enterprise_ping_signal(sender, **kwargs):
+    logger.info('RECEIVED PING DATA: %s', pformat(kwargs['ping']))
+
+
+class Command(BaseCommand):
+    """
+    Mgmt command to consume enterprise ping events.
+    """
+
+    help = """
+    Consume messages from the enterprise core topic and emit their data with
+    a corresponding signal.
+
+    Examples:
+
+        ./manage.py consume_enterprise_ping_events -g enterprise-access-service
+
+        # send extra args, for example pass check_backlog flag to redis consumer
+        ./manage.py consume_enterprise_ping_events -g user-activity-service -g enterprise-access-service \\
+            --extra '{"check_backlog": true}'
+
+        # send extra args, for example replay events from specific redis msg id.
+        ./manage.py consume_enterprise_ping_events -g enterprise-access-service \\
+            --extra '{"last_read_msg_id": "1679676448892-0"}'
+    """
+
+    def add_arguments(self, parser):
+        """
+        Add arguments for parsing topic, group, and extra args.
+        """
+        parser.add_argument(
+            '-g', '--group-id',
+            nargs='?',
+            required=False,
+            type=str,
+            default='enterprise-access-service',
+            help='Consumer group id'
+        )
+        parser.add_argument(
+            '--extra',
+            nargs='?',
+            type=str,
+            required=False,
+            help='JSON object to pass additional arguments to the consumer.'
+        )
+
+    def create_parser(self, *args, **kwargs):
+        parser = super(Command, self).create_parser(*args, **kwargs)
+        parser.formatter_class = RawTextHelpFormatter
+        return parser
+
+    def handle(self, *args, **options):
+        """
+        Create consumer based on django settings and consume events.
+        """
+        try:
+            # load additional arguments specific for the underlying implementation of event_bus.
+            extra = json.loads(options.get('extra') or '{}')
+            event_consumer = make_single_consumer(
+                topic=ENTERPRISE_CORE_TOPIC,
+                group_id=options['group_id'],
+                **extra,
+            )
+            event_consumer.consume_indefinitely()
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("Error consuming events")

--- a/enterprise_access/settings/devstack.py
+++ b/enterprise_access/settings/devstack.py
@@ -61,7 +61,11 @@ JWT_AUTH.update({
 
 # Install django-extensions for improved dev experiences
 # https://github.com/django-extensions/django-extensions#using-it
-INSTALLED_APPS += ('django_extensions',)
+INSTALLED_APPS += (
+    'django_extensions',
+    'edx_event_bus_kafka',
+    'openedx_events',
+)
 
 # BEGIN CELERY
 CELERY_WORKER_HIJACK_ROOT_LOGGER = True
@@ -109,12 +113,17 @@ SHELL_PLUS_IMPORTS = [
 
 
 ################### Kafka Related Settings ##############################
+
+# "Standard" Kafka settings as defined in https://github.com/openedx/event-bus-kafka/tree/main
+EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL = 'http://edx.devstack.schema-registry:8081'
+EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS = 'edx.devstack.kafka:29092'
+EVENT_BUS_PRODUCER = 'edx_event_bus_kafka.create_producer'
+EVENT_BUS_CONSUMER = 'edx_event_bus_kafka.KafkaEventConsumer'
+EVENT_BUS_TOPIC_PREFIX = 'dev'
+
+# Potentially deprecated kafka settings
 KAFKA_ENABLED = False
-
-KAFKA_BOOTSTRAP_SERVER = 'edx.devstack.kafka:29092'
-SCHEMA_REGISTRY_URL = 'http://edx.devstack.schema-registry:8081'
 KAFKA_REPLICATION_FACTOR_PER_TOPIC = 1
-
 COUPON_CODE_REQUEST_TOPIC_NAME = "coupon-code-request-dev"
 LICENSE_REQUEST_TOPIC_NAME = "license-request-dev"
 ACCESS_POLICY_TOPIC_NAME = "access-policy-dev"

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -26,6 +26,7 @@ edx-django-utils
 edx-django-release-util
 edx-drf-extensions
 edx-enterprise-subsidy-client
+edx-event-bus-kafka
 edx-rbac
 edx-rest-api-client
 jsonfield2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -49,6 +49,7 @@ click==8.1.7
     #   click-didyoumean
     #   click-plugins
     #   click-repl
+    #   code-annotations
     #   edx-django-utils
 click-didyoumean==0.3.1
     # via celery
@@ -56,7 +57,9 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.3.0
     # via celery
-confluent-kafka==2.3.0
+code-annotations==1.8.0
+    # via edx-toggles
+confluent-kafka==2.4.0
     # via -r requirements/base.in
 coreapi==2.3.3
     # via
@@ -64,7 +67,7 @@ coreapi==2.3.3
     #   openapi-codec
 coreschema==0.0.4
     # via coreapi
-cryptography==42.0.5
+cryptography==42.0.7
     # via
     #   pyjwt
     #   social-auth-core
@@ -94,7 +97,9 @@ django==4.2.13
     #   edx-django-release-util
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rbac
+    #   edx-toggles
     #   jsonfield
     #   jsonfield2
     #   openedx-events
@@ -108,13 +113,14 @@ django-crum==0.7.9
     #   -r requirements/base.in
     #   edx-django-utils
     #   edx-rbac
+    #   edx-toggles
 django-extensions==3.2.3
     # via -r requirements/base.in
 django-filter==24.2
     # via -r requirements/base.in
 django-log-request-id==2.1.0
     # via -r requirements/base.in
-django-model-utils==4.5.0
+django-model-utils==4.5.1
     # via
     #   edx-celeryutils
     #   edx-rbac
@@ -129,6 +135,7 @@ django-waffle==4.1.0
     #   -r requirements/base.in
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
 djangoql==0.18.1
     # via -r requirements/base.in
 djangorestframework==3.14.0
@@ -156,8 +163,10 @@ edx-api-doc-tools==1.8.0
     # via -r requirements/base.in
 edx-auth-backends==4.3.0
     # via -r requirements/base.in
-edx-braze-client==0.2.3
+edx-braze-client==0.2.5
     # via -r requirements/base.in
+edx-ccx-keys==1.3.0
+    # via openedx-events
 edx-celeryutils==1.3.0
     # via -r requirements/base.in
 edx-django-release-util==1.4.0
@@ -166,7 +175,9 @@ edx-django-utils==5.13.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rest-api-client
+    #   edx-toggles
     #   openedx-events
 edx-drf-extensions==10.3.0
     # via
@@ -174,8 +185,11 @@ edx-drf-extensions==10.3.0
     #   edx-rbac
 edx-enterprise-subsidy-client==0.4.3
     # via -r requirements/base.in
+edx-event-bus-kafka==5.7.0
+    # via -r requirements/base.in
 edx-opaque-keys[django]==2.9.0
     # via
+    #   edx-ccx-keys
     #   edx-drf-extensions
     #   openedx-events
 edx-rbac==1.9.0
@@ -184,6 +198,8 @@ edx-rest-api-client==5.7.0
     # via
     #   -r requirements/base.in
     #   edx-enterprise-subsidy-client
+edx-toggles==5.2.0
+    # via edx-event-bus-kafka
 fastavro==1.9.4
     # via
     #   -r requirements/base.in
@@ -200,8 +216,10 @@ inflection==0.5.1
     #   drf-yasg
 itypes==1.2.0
     # via coreapi
-jinja2==3.1.3
-    # via coreschema
+jinja2==3.1.4
+    # via
+    #   code-annotations
+    #   coreschema
 jsonfield==3.1.0
     # via edx-celeryutils
 jsonfield2==4.0.0.post0
@@ -226,8 +244,10 @@ oauthlib==3.2.2
     #   social-auth-core
 openapi-codec==1.3.2
     # via django-rest-swagger
-openedx-events==9.9.2
-    # via -r requirements/base.in
+openedx-events==9.10.0
+    # via
+    #   -r requirements/base.in
+    #   edx-event-bus-kafka
 packaging==24.0
     # via drf-yasg
 pbr==6.0.0
@@ -242,7 +262,7 @@ psutil==5.9.8
     # via edx-django-utils
 pycparser==2.22
     # via cffi
-pygments==2.17.2
+pygments==2.18.0
     # via -r requirements/base.in
 pyjwt[crypto]==2.8.0
     # via
@@ -261,6 +281,8 @@ python-dateutil==2.9.0.post0
     # via
     #   analytics-python
     #   celery
+python-slugify==8.0.4
+    # via code-annotations
 python3-openid==3.2.0
     # via social-auth-core
 pytz==2024.1
@@ -270,12 +292,13 @@ pytz==2024.1
     #   drf-yasg
 pyyaml==6.0.1
     # via
+    #   code-annotations
     #   drf-spectacular
     #   drf-yasg
     #   edx-django-release-util
 redis==5.0.4
     # via -r requirements/base.in
-referencing==0.35.0
+referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -290,7 +313,7 @@ requests==2.31.0
     #   social-auth-core
 requests-oauthlib==2.0.0
     # via social-auth-core
-rpds-py==0.18.0
+rpds-py==0.18.1
     # via
     #   jsonschema
     #   referencing
@@ -304,6 +327,7 @@ six==1.16.0
     # via
     #   analytics-python
     #   edx-auth-backends
+    #   edx-ccx-keys
     #   edx-django-release-util
     #   edx-rbac
     #   python-dateutil
@@ -319,8 +343,11 @@ sqlparse==0.5.0
     # via django
 stevedore==5.2.0
     # via
+    #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
+text-unidecode==1.3
+    # via python-slugify
 typing-extensions==4.11.0
     # via
     #   asgiref

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -113,11 +113,12 @@ code-annotations==1.8.0
     # via
     #   -r requirements/validation.txt
     #   edx-lint
+    #   edx-toggles
 colorama==0.4.6
     # via
     #   -r requirements/validation.txt
     #   tox
-confluent-kafka==2.3.0
+confluent-kafka==2.4.0
     # via -r requirements/validation.txt
 coreapi==2.3.3
     # via
@@ -128,11 +129,11 @@ coreschema==0.0.4
     # via
     #   -r requirements/validation.txt
     #   coreapi
-coverage[toml]==7.5.0
+coverage[toml]==7.5.1
     # via
     #   -r requirements/validation.txt
     #   pytest-cov
-cryptography==42.0.5
+cryptography==42.0.7
     # via
     #   -r requirements/validation.txt
     #   pyjwt
@@ -177,8 +178,10 @@ django==4.2.13
     #   edx-django-release-util
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-i18n-tools
     #   edx-rbac
+    #   edx-toggles
     #   jsonfield
     #   jsonfield2
     #   openedx-events
@@ -192,6 +195,7 @@ django-crum==0.7.9
     #   -r requirements/validation.txt
     #   edx-django-utils
     #   edx-rbac
+    #   edx-toggles
 django-debug-toolbar==4.3.0
     # via -r requirements/dev.in
 django-dynamic-fixture==4.0.1
@@ -202,7 +206,7 @@ django-filter==24.2
     # via -r requirements/validation.txt
 django-log-request-id==2.1.0
     # via -r requirements/validation.txt
-django-model-utils==4.5.0
+django-model-utils==4.5.1
     # via
     #   -r requirements/validation.txt
     #   edx-celeryutils
@@ -218,6 +222,7 @@ django-waffle==4.1.0
     #   -r requirements/validation.txt
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
 djangoql==0.18.1
     # via -r requirements/validation.txt
 djangorestframework==3.14.0
@@ -254,8 +259,12 @@ edx-api-doc-tools==1.8.0
     # via -r requirements/validation.txt
 edx-auth-backends==4.3.0
     # via -r requirements/validation.txt
-edx-braze-client==0.2.3
+edx-braze-client==0.2.5
     # via -r requirements/validation.txt
+edx-ccx-keys==1.3.0
+    # via
+    #   -r requirements/validation.txt
+    #   openedx-events
 edx-celeryutils==1.3.0
     # via -r requirements/validation.txt
 edx-django-release-util==1.4.0
@@ -264,13 +273,17 @@ edx-django-utils==5.13.0
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rest-api-client
+    #   edx-toggles
     #   openedx-events
 edx-drf-extensions==10.3.0
     # via
     #   -r requirements/validation.txt
     #   edx-rbac
 edx-enterprise-subsidy-client==0.4.3
+    # via -r requirements/validation.txt
+edx-event-bus-kafka==5.7.0
     # via -r requirements/validation.txt
 edx-i18n-tools==1.6.0
     # via -r requirements/dev.in
@@ -279,6 +292,7 @@ edx-lint==5.3.6
 edx-opaque-keys[django]==2.9.0
     # via
     #   -r requirements/validation.txt
+    #   edx-ccx-keys
     #   edx-drf-extensions
     #   openedx-events
 edx-rbac==1.9.0
@@ -287,13 +301,17 @@ edx-rest-api-client==5.7.0
     # via
     #   -r requirements/validation.txt
     #   edx-enterprise-subsidy-client
+edx-toggles==5.2.0
+    # via
+    #   -r requirements/validation.txt
+    #   edx-event-bus-kafka
 exceptiongroup==1.2.1
     # via
     #   -r requirements/validation.txt
     #   pytest
 factory-boy==3.3.0
     # via -r requirements/validation.txt
-faker==25.0.0
+faker==25.1.0
     # via
     #   -r requirements/validation.txt
     #   factory-boy
@@ -306,7 +324,7 @@ filelock==3.14.0
     #   -r requirements/validation.txt
     #   tox
     #   virtualenv
-freezegun==1.5.0
+freezegun==1.5.1
     # via -r requirements/validation.txt
 idna==3.7
     # via
@@ -359,7 +377,7 @@ jeepney==0.8.0
     #   -r requirements/validation.txt
     #   keyring
     #   secretstorage
-jinja2==3.1.3
+jinja2==3.1.4
     # via
     #   -r requirements/validation.txt
     #   code-annotations
@@ -387,7 +405,7 @@ kombu==5.3.7
     # via
     #   -r requirements/validation.txt
     #   celery
-lxml[html-clean,html_clean]==5.2.1
+lxml[html-clean,html_clean]==5.2.2
     # via
     #   edx-i18n-tools
     #   lxml-html-clean
@@ -437,8 +455,10 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/validation.txt
     #   django-rest-swagger
-openedx-events==9.9.2
-    # via -r requirements/validation.txt
+openedx-events==9.10.0
+    # via
+    #   -r requirements/validation.txt
+    #   edx-event-bus-kafka
 packaging==24.0
     # via
     #   -r requirements/pip-tools.txt
@@ -498,7 +518,7 @@ pycparser==2.22
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/validation.txt
-pygments==2.17.2
+pygments==2.18.0
     # via
     #   -r requirements/validation.txt
     #   diff-cover
@@ -512,7 +532,7 @@ pyjwt[crypto]==2.8.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==3.1.0
+pylint==3.1.1
     # via
     #   -r requirements/validation.txt
     #   edx-lint
@@ -594,7 +614,7 @@ readme-renderer==43.0
     #   twine
 redis==5.0.4
     # via -r requirements/validation.txt
-referencing==0.35.0
+referencing==0.35.1
     # via
     #   -r requirements/validation.txt
     #   jsonschema
@@ -627,7 +647,7 @@ rich==13.7.1
     # via
     #   -r requirements/validation.txt
     #   twine
-rpds-py==0.18.0
+rpds-py==0.18.1
     # via
     #   -r requirements/validation.txt
     #   jsonschema
@@ -651,6 +671,7 @@ six==1.16.0
     #   -r requirements/validation.txt
     #   analytics-python
     #   edx-auth-backends
+    #   edx-ccx-keys
     #   edx-django-release-util
     #   edx-lint
     #   edx-rbac
@@ -698,7 +719,7 @@ tomli==2.0.1
     #   pyproject-api
     #   pytest
     #   tox
-tomlkit==0.12.4
+tomlkit==0.12.5
     # via
     #   -r requirements/validation.txt
     #   pylint

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -35,7 +35,7 @@ attrs==23.2.0
     #   jsonschema
     #   openedx-events
     #   referencing
-babel==2.14.0
+babel==2.15.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
@@ -113,11 +113,12 @@ code-annotations==1.8.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
+    #   edx-toggles
 colorama==0.4.6
     # via
     #   -r requirements/test.txt
     #   tox
-confluent-kafka==2.3.0
+confluent-kafka==2.4.0
     # via -r requirements/test.txt
 coreapi==2.3.3
     # via
@@ -128,11 +129,11 @@ coreschema==0.0.4
     # via
     #   -r requirements/test.txt
     #   coreapi
-coverage[toml]==7.5.0
+coverage[toml]==7.5.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==42.0.5
+cryptography==42.0.7
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -174,7 +175,9 @@ django==4.2.13
     #   edx-django-release-util
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rbac
+    #   edx-toggles
     #   jsonfield
     #   jsonfield2
     #   openedx-events
@@ -188,6 +191,7 @@ django-crum==0.7.9
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-rbac
+    #   edx-toggles
 django-dynamic-fixture==4.0.1
     # via -r requirements/test.txt
 django-extensions==3.2.3
@@ -196,7 +200,7 @@ django-filter==24.2
     # via -r requirements/test.txt
 django-log-request-id==2.1.0
     # via -r requirements/test.txt
-django-model-utils==4.5.0
+django-model-utils==4.5.1
     # via
     #   -r requirements/test.txt
     #   edx-celeryutils
@@ -212,6 +216,7 @@ django-waffle==4.1.0
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
 djangoql==0.18.1
     # via -r requirements/test.txt
 djangorestframework==3.14.0
@@ -254,8 +259,12 @@ edx-api-doc-tools==1.8.0
     # via -r requirements/test.txt
 edx-auth-backends==4.3.0
     # via -r requirements/test.txt
-edx-braze-client==0.2.3
+edx-braze-client==0.2.5
     # via -r requirements/test.txt
+edx-ccx-keys==1.3.0
+    # via
+    #   -r requirements/test.txt
+    #   openedx-events
 edx-celeryutils==1.3.0
     # via -r requirements/test.txt
 edx-django-release-util==1.4.0
@@ -264,7 +273,9 @@ edx-django-utils==5.13.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rest-api-client
+    #   edx-toggles
     #   openedx-events
 edx-drf-extensions==10.3.0
     # via
@@ -272,11 +283,14 @@ edx-drf-extensions==10.3.0
     #   edx-rbac
 edx-enterprise-subsidy-client==0.4.3
     # via -r requirements/test.txt
+edx-event-bus-kafka==5.7.0
+    # via -r requirements/test.txt
 edx-lint==5.3.6
     # via -r requirements/test.txt
 edx-opaque-keys[django]==2.9.0
     # via
     #   -r requirements/test.txt
+    #   edx-ccx-keys
     #   edx-drf-extensions
     #   openedx-events
 edx-rbac==1.9.0
@@ -285,13 +299,17 @@ edx-rest-api-client==5.7.0
     # via
     #   -r requirements/test.txt
     #   edx-enterprise-subsidy-client
+edx-toggles==5.2.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-event-bus-kafka
 exceptiongroup==1.2.1
     # via
     #   -r requirements/test.txt
     #   pytest
 factory-boy==3.3.0
     # via -r requirements/test.txt
-faker==25.0.0
+faker==25.1.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -304,7 +322,7 @@ filelock==3.14.0
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
-freezegun==1.5.0
+freezegun==1.5.1
     # via -r requirements/test.txt
 idna==3.7
     # via
@@ -338,7 +356,7 @@ itypes==1.2.0
     # via
     #   -r requirements/test.txt
     #   coreapi
-jinja2==3.1.3
+jinja2==3.1.4
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -391,8 +409,10 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
-openedx-events==9.9.2
-    # via -r requirements/test.txt
+openedx-events==9.10.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-event-bus-kafka
 packaging==24.0
     # via
     #   -r requirements/test.txt
@@ -439,7 +459,7 @@ pycparser==2.22
     #   cffi
 pydata-sphinx-theme==0.14.4
     # via sphinx-book-theme
-pygments==2.17.2
+pygments==2.18.0
     # via
     #   -r requirements/test.txt
     #   accessible-pygments
@@ -455,7 +475,7 @@ pyjwt[crypto]==2.8.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==3.1.0
+pylint==3.1.1
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -530,7 +550,7 @@ readme-renderer==43.0
     # via -r requirements/doc.in
 redis==5.0.4
     # via -r requirements/test.txt
-referencing==0.35.0
+referencing==0.35.1
     # via
     #   -r requirements/test.txt
     #   jsonschema
@@ -552,7 +572,7 @@ requests-oauthlib==2.0.0
     #   social-auth-core
 restructuredtext-lint==1.4.0
     # via doc8
-rpds-py==0.18.0
+rpds-py==0.18.1
     # via
     #   -r requirements/test.txt
     #   jsonschema
@@ -572,6 +592,7 @@ six==1.16.0
     #   -r requirements/test.txt
     #   analytics-python
     #   edx-auth-backends
+    #   edx-ccx-keys
     #   edx-django-release-util
     #   edx-lint
     #   edx-rbac
@@ -636,7 +657,7 @@ tomli==2.0.1
     #   pyproject-api
     #   pytest
     #   tox
-tomlkit==0.12.4
+tomlkit==0.12.5
     # via
     #   -r requirements/test.txt
     #   pylint

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -65,6 +65,7 @@ click==8.1.7
     #   click-didyoumean
     #   click-plugins
     #   click-repl
+    #   code-annotations
     #   edx-django-utils
 click-didyoumean==0.3.1
     # via
@@ -78,7 +79,11 @@ click-repl==0.3.0
     # via
     #   -r requirements/base.txt
     #   celery
-confluent-kafka==2.3.0
+code-annotations==1.8.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-toggles
+confluent-kafka==2.4.0
     # via -r requirements/base.txt
 coreapi==2.3.3
     # via
@@ -89,7 +94,7 @@ coreschema==0.0.4
     # via
     #   -r requirements/base.txt
     #   coreapi
-cryptography==42.0.5
+cryptography==42.0.7
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -120,7 +125,9 @@ django==4.2.13
     #   edx-django-release-util
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rbac
+    #   edx-toggles
     #   jsonfield
     #   jsonfield2
     #   openedx-events
@@ -134,13 +141,14 @@ django-crum==0.7.9
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-rbac
+    #   edx-toggles
 django-extensions==3.2.3
     # via -r requirements/base.txt
 django-filter==24.2
     # via -r requirements/base.txt
 django-log-request-id==2.1.0
     # via -r requirements/base.txt
-django-model-utils==4.5.0
+django-model-utils==4.5.1
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
@@ -156,6 +164,7 @@ django-waffle==4.1.0
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
 djangoql==0.18.1
     # via -r requirements/base.txt
 djangorestframework==3.14.0
@@ -188,8 +197,12 @@ edx-api-doc-tools==1.8.0
     # via -r requirements/base.txt
 edx-auth-backends==4.3.0
     # via -r requirements/base.txt
-edx-braze-client==0.2.3
+edx-braze-client==0.2.5
     # via -r requirements/base.txt
+edx-ccx-keys==1.3.0
+    # via
+    #   -r requirements/base.txt
+    #   openedx-events
 edx-celeryutils==1.3.0
     # via -r requirements/base.txt
 edx-django-release-util==1.4.0
@@ -198,7 +211,9 @@ edx-django-utils==5.13.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rest-api-client
+    #   edx-toggles
     #   openedx-events
 edx-drf-extensions==10.3.0
     # via
@@ -206,9 +221,12 @@ edx-drf-extensions==10.3.0
     #   edx-rbac
 edx-enterprise-subsidy-client==0.4.3
     # via -r requirements/base.txt
+edx-event-bus-kafka==5.7.0
+    # via -r requirements/base.txt
 edx-opaque-keys[django]==2.9.0
     # via
     #   -r requirements/base.txt
+    #   edx-ccx-keys
     #   edx-drf-extensions
     #   openedx-events
 edx-rbac==1.9.0
@@ -217,6 +235,10 @@ edx-rest-api-client==5.7.0
     # via
     #   -r requirements/base.txt
     #   edx-enterprise-subsidy-client
+edx-toggles==5.2.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-event-bus-kafka
 fastavro==1.9.4
     # via
     #   -r requirements/base.txt
@@ -245,9 +267,10 @@ itypes==1.2.0
     # via
     #   -r requirements/base.txt
     #   coreapi
-jinja2==3.1.3
+jinja2==3.1.4
     # via
     #   -r requirements/base.txt
+    #   code-annotations
     #   coreschema
 jsonfield==3.1.0
     # via
@@ -292,8 +315,10 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-openedx-events==9.9.2
-    # via -r requirements/base.txt
+openedx-events==9.10.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-event-bus-kafka
 packaging==24.0
     # via
     #   -r requirements/base.txt
@@ -323,7 +348,7 @@ pycparser==2.22
     # via
     #   -r requirements/base.txt
     #   cffi
-pygments==2.17.2
+pygments==2.18.0
     # via -r requirements/base.txt
 pyjwt[crypto]==2.8.0
     # via
@@ -350,6 +375,10 @@ python-dateutil==2.9.0.post0
     #   celery
 python-memcached==1.62
     # via -r requirements/production.in
+python-slugify==8.0.4
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
 python3-openid==3.2.0
     # via
     #   -r requirements/base.txt
@@ -363,12 +392,13 @@ pyyaml==6.0.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/production.in
+    #   code-annotations
     #   drf-spectacular
     #   drf-yasg
     #   edx-django-release-util
 redis==5.0.4
     # via -r requirements/base.txt
-referencing==0.35.0
+referencing==0.35.1
     # via
     #   -r requirements/base.txt
     #   jsonschema
@@ -387,7 +417,7 @@ requests-oauthlib==2.0.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-rpds-py==0.18.0
+rpds-py==0.18.1
     # via
     #   -r requirements/base.txt
     #   jsonschema
@@ -407,6 +437,7 @@ six==1.16.0
     #   -r requirements/base.txt
     #   analytics-python
     #   edx-auth-backends
+    #   edx-ccx-keys
     #   edx-django-release-util
     #   edx-rbac
     #   python-dateutil
@@ -430,8 +461,13 @@ sqlparse==0.5.0
 stevedore==5.2.0
     # via
     #   -r requirements/base.txt
+    #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
+text-unidecode==1.3
+    # via
+    #   -r requirements/base.txt
+    #   python-slugify
 typing-extensions==4.11.0
     # via
     #   -r requirements/base.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -105,11 +105,12 @@ code-annotations==1.8.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
+    #   edx-toggles
 colorama==0.4.6
     # via
     #   -r requirements/test.txt
     #   tox
-confluent-kafka==2.3.0
+confluent-kafka==2.4.0
     # via -r requirements/test.txt
 coreapi==2.3.3
     # via
@@ -120,11 +121,11 @@ coreschema==0.0.4
     # via
     #   -r requirements/test.txt
     #   coreapi
-coverage[toml]==7.5.0
+coverage[toml]==7.5.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==42.0.5
+cryptography==42.0.7
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -167,7 +168,9 @@ django==4.2.13
     #   edx-django-release-util
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rbac
+    #   edx-toggles
     #   jsonfield
     #   jsonfield2
     #   openedx-events
@@ -181,6 +184,7 @@ django-crum==0.7.9
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-rbac
+    #   edx-toggles
 django-dynamic-fixture==4.0.1
     # via -r requirements/test.txt
 django-extensions==3.2.3
@@ -189,7 +193,7 @@ django-filter==24.2
     # via -r requirements/test.txt
 django-log-request-id==2.1.0
     # via -r requirements/test.txt
-django-model-utils==4.5.0
+django-model-utils==4.5.1
     # via
     #   -r requirements/test.txt
     #   edx-celeryutils
@@ -205,6 +209,7 @@ django-waffle==4.1.0
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
 djangoql==0.18.1
     # via -r requirements/test.txt
 djangorestframework==3.14.0
@@ -240,8 +245,12 @@ edx-api-doc-tools==1.8.0
     # via -r requirements/test.txt
 edx-auth-backends==4.3.0
     # via -r requirements/test.txt
-edx-braze-client==0.2.3
+edx-braze-client==0.2.5
     # via -r requirements/test.txt
+edx-ccx-keys==1.3.0
+    # via
+    #   -r requirements/test.txt
+    #   openedx-events
 edx-celeryutils==1.3.0
     # via -r requirements/test.txt
 edx-django-release-util==1.4.0
@@ -250,13 +259,17 @@ edx-django-utils==5.13.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rest-api-client
+    #   edx-toggles
     #   openedx-events
 edx-drf-extensions==10.3.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
 edx-enterprise-subsidy-client==0.4.3
+    # via -r requirements/test.txt
+edx-event-bus-kafka==5.7.0
     # via -r requirements/test.txt
 edx-lint==5.3.6
     # via
@@ -265,6 +278,7 @@ edx-lint==5.3.6
 edx-opaque-keys[django]==2.9.0
     # via
     #   -r requirements/test.txt
+    #   edx-ccx-keys
     #   edx-drf-extensions
     #   openedx-events
 edx-rbac==1.9.0
@@ -273,13 +287,17 @@ edx-rest-api-client==5.7.0
     # via
     #   -r requirements/test.txt
     #   edx-enterprise-subsidy-client
+edx-toggles==5.2.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-event-bus-kafka
 exceptiongroup==1.2.1
     # via
     #   -r requirements/test.txt
     #   pytest
 factory-boy==3.3.0
     # via -r requirements/test.txt
-faker==25.0.0
+faker==25.1.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -292,7 +310,7 @@ filelock==3.14.0
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
-freezegun==1.5.0
+freezegun==1.5.1
     # via -r requirements/test.txt
 idna==3.7
     # via
@@ -337,7 +355,7 @@ jeepney==0.8.0
     # via
     #   keyring
     #   secretstorage
-jinja2==3.1.3
+jinja2==3.1.4
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -399,8 +417,10 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
-openedx-events==9.9.2
-    # via -r requirements/test.txt
+openedx-events==9.10.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-event-bus-kafka
 packaging==24.0
     # via
     #   -r requirements/test.txt
@@ -449,7 +469,7 @@ pycparser==2.22
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pygments==2.17.2
+pygments==2.18.0
     # via
     #   -r requirements/test.txt
     #   readme-renderer
@@ -462,7 +482,7 @@ pyjwt[crypto]==2.8.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==3.1.0
+pylint==3.1.1
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -536,7 +556,7 @@ readme-renderer==43.0
     # via twine
 redis==5.0.4
     # via -r requirements/test.txt
-referencing==0.35.0
+referencing==0.35.1
     # via
     #   -r requirements/test.txt
     #   jsonschema
@@ -563,7 +583,7 @@ rfc3986==2.0.0
     # via twine
 rich==13.7.1
     # via twine
-rpds-py==0.18.0
+rpds-py==0.18.1
     # via
     #   -r requirements/test.txt
     #   jsonschema
@@ -585,6 +605,7 @@ six==1.16.0
     #   -r requirements/test.txt
     #   analytics-python
     #   edx-auth-backends
+    #   edx-ccx-keys
     #   edx-django-release-util
     #   edx-lint
     #   edx-rbac
@@ -626,7 +647,7 @@ tomli==2.0.1
     #   pyproject-api
     #   pytest
     #   tox
-tomlkit==0.12.4
+tomlkit==0.12.5
     # via
     #   -r requirements/test.txt
     #   pylint

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -94,11 +94,13 @@ click-repl==0.3.0
     #   celery
 code-annotations==1.8.0
     # via
+    #   -r requirements/base.txt
     #   -r requirements/test.in
     #   edx-lint
+    #   edx-toggles
 colorama==0.4.6
     # via tox
-confluent-kafka==2.3.0
+confluent-kafka==2.4.0
     # via -r requirements/base.txt
 coreapi==2.3.3
     # via
@@ -109,11 +111,11 @@ coreschema==0.0.4
     # via
     #   -r requirements/base.txt
     #   coreapi
-coverage[toml]==7.5.0
+coverage[toml]==7.5.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==42.0.5
+cryptography==42.0.7
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -150,7 +152,9 @@ distlib==0.3.8
     #   edx-django-release-util
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rbac
+    #   edx-toggles
     #   jsonfield
     #   jsonfield2
     #   openedx-events
@@ -164,6 +168,7 @@ django-crum==0.7.9
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-rbac
+    #   edx-toggles
 django-dynamic-fixture==4.0.1
     # via -r requirements/test.in
 django-extensions==3.2.3
@@ -172,7 +177,7 @@ django-filter==24.2
     # via -r requirements/base.txt
 django-log-request-id==2.1.0
     # via -r requirements/base.txt
-django-model-utils==4.5.0
+django-model-utils==4.5.1
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
@@ -188,6 +193,7 @@ django-waffle==4.1.0
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
 djangoql==0.18.1
     # via -r requirements/base.txt
 djangorestframework==3.14.0
@@ -221,8 +227,12 @@ edx-api-doc-tools==1.8.0
     # via -r requirements/base.txt
 edx-auth-backends==4.3.0
     # via -r requirements/base.txt
-edx-braze-client==0.2.3
+edx-braze-client==0.2.5
     # via -r requirements/base.txt
+edx-ccx-keys==1.3.0
+    # via
+    #   -r requirements/base.txt
+    #   openedx-events
 edx-celeryutils==1.3.0
     # via -r requirements/base.txt
 edx-django-release-util==1.4.0
@@ -231,7 +241,9 @@ edx-django-utils==5.13.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rest-api-client
+    #   edx-toggles
     #   openedx-events
 edx-drf-extensions==10.3.0
     # via
@@ -239,11 +251,14 @@ edx-drf-extensions==10.3.0
     #   edx-rbac
 edx-enterprise-subsidy-client==0.4.3
     # via -r requirements/base.txt
+edx-event-bus-kafka==5.7.0
+    # via -r requirements/base.txt
 edx-lint==5.3.6
     # via -r requirements/test.in
 edx-opaque-keys[django]==2.9.0
     # via
     #   -r requirements/base.txt
+    #   edx-ccx-keys
     #   edx-drf-extensions
     #   openedx-events
 edx-rbac==1.9.0
@@ -252,11 +267,15 @@ edx-rest-api-client==5.7.0
     # via
     #   -r requirements/base.txt
     #   edx-enterprise-subsidy-client
+edx-toggles==5.2.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-event-bus-kafka
 exceptiongroup==1.2.1
     # via pytest
 factory-boy==3.3.0
     # via -r requirements/test.in
-faker==25.0.0
+faker==25.1.0
     # via factory-boy
 fastavro==1.9.4
     # via
@@ -266,7 +285,7 @@ filelock==3.14.0
     # via
     #   tox
     #   virtualenv
-freezegun==1.5.0
+freezegun==1.5.1
     # via -r requirements/test.in
 idna==3.7
     # via
@@ -290,7 +309,7 @@ itypes==1.2.0
     # via
     #   -r requirements/base.txt
     #   coreapi
-jinja2==3.1.3
+jinja2==3.1.4
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -338,8 +357,10 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-openedx-events==9.9.2
-    # via -r requirements/base.txt
+openedx-events==9.10.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-event-bus-kafka
 packaging==24.0
     # via
     #   -r requirements/base.txt
@@ -380,7 +401,7 @@ pycparser==2.22
     # via
     #   -r requirements/base.txt
     #   cffi
-pygments==2.17.2
+pygments==2.18.0
     # via -r requirements/base.txt
 pyjwt[crypto]==2.8.0
     # via
@@ -390,7 +411,7 @@ pyjwt[crypto]==2.8.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==3.1.0
+pylint==3.1.1
     # via
     #   edx-lint
     #   pylint-celery
@@ -432,7 +453,9 @@ python-dateutil==2.9.0.post0
     #   faker
     #   freezegun
 python-slugify==8.0.4
-    # via code-annotations
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
 python3-openid==3.2.0
     # via
     #   -r requirements/base.txt
@@ -451,7 +474,7 @@ pyyaml==6.0.1
     #   edx-django-release-util
 redis==5.0.4
     # via -r requirements/base.txt
-referencing==0.35.0
+referencing==0.35.1
     # via
     #   -r requirements/base.txt
     #   jsonschema
@@ -470,7 +493,7 @@ requests-oauthlib==2.0.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-rpds-py==0.18.0
+rpds-py==0.18.1
     # via
     #   -r requirements/base.txt
     #   jsonschema
@@ -490,6 +513,7 @@ six==1.16.0
     #   -r requirements/base.txt
     #   analytics-python
     #   edx-auth-backends
+    #   edx-ccx-keys
     #   edx-django-release-util
     #   edx-lint
     #   edx-rbac
@@ -518,7 +542,9 @@ stevedore==5.2.0
     #   edx-django-utils
     #   edx-opaque-keys
 text-unidecode==1.3
-    # via python-slugify
+    # via
+    #   -r requirements/base.txt
+    #   python-slugify
 tomli==2.0.1
     # via
     #   coverage
@@ -526,7 +552,7 @@ tomli==2.0.1
     #   pyproject-api
     #   pytest
     #   tox
-tomlkit==0.12.4
+tomlkit==0.12.5
     # via pylint
 tox==4.15.0
     # via -r requirements/test.in

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -128,12 +128,13 @@ code-annotations==1.8.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-lint
+    #   edx-toggles
 colorama==0.4.6
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   tox
-confluent-kafka==2.3.0
+confluent-kafka==2.4.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -148,12 +149,12 @@ coreschema==0.0.4
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   coreapi
-coverage[toml]==7.5.0
+coverage[toml]==7.5.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==42.0.5
+cryptography==42.0.7
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -202,7 +203,9 @@ django==4.2.13
     #   edx-django-release-util
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rbac
+    #   edx-toggles
     #   jsonfield
     #   jsonfield2
     #   openedx-events
@@ -221,6 +224,7 @@ django-crum==0.7.9
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-rbac
+    #   edx-toggles
 django-dynamic-fixture==4.0.1
     # via
     #   -r requirements/quality.txt
@@ -237,7 +241,7 @@ django-log-request-id==2.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-django-model-utils==4.5.0
+django-model-utils==4.5.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -261,6 +265,7 @@ django-waffle==4.1.0
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
 djangoql==0.18.1
     # via
     #   -r requirements/quality.txt
@@ -311,10 +316,15 @@ edx-auth-backends==4.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-braze-client==0.2.3
+edx-braze-client==0.2.5
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+edx-ccx-keys==1.3.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   openedx-events
 edx-celeryutils==1.3.0
     # via
     #   -r requirements/quality.txt
@@ -328,7 +338,9 @@ edx-django-utils==5.13.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rest-api-client
+    #   edx-toggles
     #   openedx-events
 edx-drf-extensions==10.3.0
     # via
@@ -336,6 +348,10 @@ edx-drf-extensions==10.3.0
     #   -r requirements/test.txt
     #   edx-rbac
 edx-enterprise-subsidy-client==0.4.3
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+edx-event-bus-kafka==5.7.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -347,6 +363,7 @@ edx-opaque-keys[django]==2.9.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   edx-ccx-keys
     #   edx-drf-extensions
     #   openedx-events
 edx-rbac==1.9.0
@@ -358,6 +375,11 @@ edx-rest-api-client==5.7.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-enterprise-subsidy-client
+edx-toggles==5.2.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-event-bus-kafka
 exceptiongroup==1.2.1
     # via
     #   -r requirements/quality.txt
@@ -367,7 +389,7 @@ factory-boy==3.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-faker==25.0.0
+faker==25.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -383,7 +405,7 @@ filelock==3.14.0
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
-freezegun==1.5.0
+freezegun==1.5.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -442,7 +464,7 @@ jeepney==0.8.0
     #   -r requirements/quality.txt
     #   keyring
     #   secretstorage
-jinja2==3.1.3
+jinja2==3.1.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -528,10 +550,11 @@ openapi-codec==1.3.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django-rest-swagger
-openedx-events==9.9.2
+openedx-events==9.10.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   edx-event-bus-kafka
 packaging==24.0
     # via
     #   -r requirements/quality.txt
@@ -591,7 +614,7 @@ pycparser==2.22
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
-pygments==2.17.2
+pygments==2.18.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -606,7 +629,7 @@ pyjwt[crypto]==2.8.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==3.1.0
+pylint==3.1.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -703,7 +726,7 @@ redis==5.0.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-referencing==0.35.0
+referencing==0.35.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -739,7 +762,7 @@ rich==13.7.1
     # via
     #   -r requirements/quality.txt
     #   twine
-rpds-py==0.18.0
+rpds-py==0.18.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -769,6 +792,7 @@ six==1.16.0
     #   -r requirements/test.txt
     #   analytics-python
     #   edx-auth-backends
+    #   edx-ccx-keys
     #   edx-django-release-util
     #   edx-lint
     #   edx-rbac
@@ -819,7 +843,7 @@ tomli==2.0.1
     #   pyproject-api
     #   pytest
     #   tox
-tomlkit==0.12.4
+tomlkit==0.12.5
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
Installs openedx-events, kafka, and so forth for local development of kafka events.  Upgrades deps due to installation of events packages. Provides example of brining the kafka broker up and consuming a test event.
ENT-8761

Should be used in conjunction with https://github.com/openedx/enterprise-subsidy/pull/243 for testing interservice event pub-sub.

See the additions to the `README` for how to test this locally.

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
