### PR TITLE
feat: allowing for group members to be specified when fetched

### DIFF
--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -822,6 +822,10 @@ class GroupMemberWithAggregatesRequestSerializer(serializers.Serializer):
         default=False,
         help_text=('Set to True to traverse over and return all group members records across all pages of data.')
     )
+    learners = serializers.ListField(
+        child=serializers.EmailField(required=True),
+        required=False,
+    )
 
     def validate(self, attrs):
         """

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -2305,6 +2305,36 @@ class TestSubsidyAccessPolicyGroupViewset(CRUDViewTestMixin, APITestWithMocks):
     @mock.patch(
         'enterprise_access.apps.api.v1.views.subsidy_access_policy.get_and_cache_subsidy_learners_aggregate_data'
     )
+    def test_get_group_member_data_with_aggregates_supports_specified_learners(
+        self,
+        mock_subsidy_learners_aggregate_data_cache,
+        mock_lms_api_client,
+    ):
+        """
+        Test that the `get_group_member_data_with_aggregates` endpoint supports specifying individual learners
+        """
+        mock_subsidy_learners_aggregate_data_cache.return_value = {1: 99}
+        mock_lms_api_client.return_value.fetch_group_members.return_value = self.mock_fetch_group_members
+        uuid = uuid4()
+        self.client.get(
+            self.subsidy_access_policy_can_redeem_endpoint,
+            {'group_uuid': uuid, 'learners': ["foobar@example.com"], 'page': 1}
+        )
+        mock_lms_api_client.return_value.fetch_group_members.assert_called_with(
+            group_uuid=uuid,
+            sort_by=None,
+            user_query=None,
+            show_removed=False,
+            is_reversed=False,
+            traverse_pagination=False,
+            page=1,
+            learners=["foobar@example.com"],
+        )
+
+    @mock.patch('enterprise_access.apps.api.v1.views.subsidy_access_policy.LmsApiClient')
+    @mock.patch(
+        'enterprise_access.apps.api.v1.views.subsidy_access_policy.get_and_cache_subsidy_learners_aggregate_data'
+    )
     def test_get_group_member_data_with_aggregates_csv_format(
         self,
         mock_subsidy_learners_aggregate_data_cache,

--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -1006,6 +1006,8 @@ class SubsidyAccessPolicyGroupViewset(UserDetailsFromJwtMixin, PermissionRequire
             format_csv: (Optional) Whether or not to return data in a csv format, defaults to `False`
             page: (Optional) Which page of Enterprise Group Membership records to request. Leave blank to fetch all
                 group membership records
+            learners: (Optional) Array of learner emails. If specified, the endpoint will only return membership
+                records associated with one of the provided emails.
         """
         request_serializer = serializers.GroupMemberWithAggregatesRequestSerializer(data=request.query_params)
         request_serializer.is_valid(raise_exception=True)
@@ -1014,6 +1016,7 @@ class SubsidyAccessPolicyGroupViewset(UserDetailsFromJwtMixin, PermissionRequire
         traverse_pagination = request_serializer.validated_data.get('traverse_pagination')
         sort_by = request_serializer.validated_data.get('sort_by')
         is_reversed = request_serializer.validated_data.get('is_reversed')
+        learners = request_serializer.validated_data.get('learners')
 
         try:
             policy = SubsidyAccessPolicy.objects.get(uuid=uuid)
@@ -1051,6 +1054,7 @@ class SubsidyAccessPolicyGroupViewset(UserDetailsFromJwtMixin, PermissionRequire
             is_reversed=is_reversed,
             traverse_pagination=(traverse_pagination or sort_by_enrollment_count),
             page=page_requested_by_client,
+            learners=learners,
         )
         member_results = member_response.get('results')
 

--- a/enterprise_access/apps/api_client/lms_client.py
+++ b/enterprise_access/apps/api_client/lms_client.py
@@ -23,6 +23,7 @@ def all_pages_enterprise_group_members_cache_key(
     user_query,
     show_removed,
     is_reversed,
+    learners,
 ):
     """
     helper method to retrieve the all enterprise group members cache key
@@ -34,6 +35,7 @@ def all_pages_enterprise_group_members_cache_key(
         user_query,
         show_removed,
         is_reversed,
+        learners,
     )
 
 
@@ -161,6 +163,7 @@ class LmsApiClient(BaseOAuthClient):
         is_reversed=False,
         traverse_pagination=False,
         page=1,
+        learners=None,
     ):
         """
         Fetches enterprise group member records from edx-platform.
@@ -194,6 +197,8 @@ class LmsApiClient(BaseOAuthClient):
             params['show_removed'] = show_removed
         if is_reversed:
             params['is_reversed'] = is_reversed
+        if learners:
+            params['learners'] = learners
         if traverse_pagination:
             cache_key = all_pages_enterprise_group_members_cache_key(
                 group_uuid,
@@ -201,6 +206,7 @@ class LmsApiClient(BaseOAuthClient):
                 user_query,
                 show_removed,
                 is_reversed,
+                learners,
             )
             cached_response = TieredCache.get_cached_response(cache_key)
             if cached_response.is_found:


### PR DESCRIPTION
**Description:**
when fetching group member data with subsidy aggregate data, allowing for the specification of individual learners to be fetched

**Jira:**
https://2u-internal.atlassian.net/browse/ENT-8974

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
