### PR TITLE
feat: validates spend limit against subsidy balance

### DIFF
--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -37,6 +37,13 @@ def policy_pre_write_validation(policy_instance_or_class, field_values_by_name):
     If a constraint occurs, raises a `ValidationError`.
     """
     violations = []
+
+    if isinstance(policy_instance_or_class, SubsidyAccessPolicy):
+        policy_instance_or_class.clean()
+    else:
+        instance = policy_instance_or_class(**field_values_by_name)
+        instance.clean()
+
     constraints = policy_instance_or_class.FIELD_CONSTRAINTS
 
     for field_name, new_value in field_values_by_name.items():

--- a/enterprise_access/apps/api/tests/test_serializers.py
+++ b/enterprise_access/apps/api/tests/test_serializers.py
@@ -86,6 +86,7 @@ class TestSubsidyAccessPolicyResponseSerializer(TestCase):
             'expiration_datetime': datetime.utcnow() + timedelta(days=1),
             'current_balance': starting_balance - redeemed,
             'is_active': True,
+            'total_deposits': starting_balance
         }
 
         # Create a test policy with a limit set to ``policy_spend_limit``.  Reminder: a value of 0 means no limit.
@@ -185,8 +186,9 @@ class TestSubsidyAccessPolicyCreditsAvailableResponseSerializer(TestCase):
         )
 
     @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.transactions_for_learner')
-    @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.subsidy_record')
-    def test_get_subsidy_end_date(self, mock_subsidy_record, mock_transactions_for_learner):
+    # @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.subsidy_record')
+    @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.subsidy_client')
+    def test_get_subsidy_end_date(self, mock_subsidy_client, mock_transactions_for_learner):
         """
         Test that the get_subsidy_end_date method returns the correct
         subsidy expiration date.
@@ -198,13 +200,14 @@ class TestSubsidyAccessPolicyCreditsAvailableResponseSerializer(TestCase):
             },
         }
         subsidy_exp_date = '2030-01-01 12:00:00Z'
-        mock_subsidy_record.return_value = {
+        mock_subsidy_client.return_value = {
             'uuid': str(uuid4()),
             'title': 'Test Subsidy',
             'enterprise_customer_uuid': str(self.enterprise_uuid),
             'expiration_datetime': subsidy_exp_date,
             'active_datetime': '2020-01-01 12:00:00Z',
             'current_balance': '1000',
+            'total_deposits': '1000',
         }
         serializer = SubsidyAccessPolicyCreditsAvailableResponseSerializer(
             [self.redeemable_policy],

--- a/enterprise_access/apps/api/tests/test_serializers.py
+++ b/enterprise_access/apps/api/tests/test_serializers.py
@@ -186,9 +186,8 @@ class TestSubsidyAccessPolicyCreditsAvailableResponseSerializer(TestCase):
         )
 
     @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.transactions_for_learner')
-    # @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.subsidy_record')
-    @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.subsidy_client')
-    def test_get_subsidy_end_date(self, mock_subsidy_client, mock_transactions_for_learner):
+    @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.subsidy_record')
+    def test_get_subsidy_end_date(self, mock_subsidy_record, mock_transactions_for_learner):
         """
         Test that the get_subsidy_end_date method returns the correct
         subsidy expiration date.
@@ -200,7 +199,7 @@ class TestSubsidyAccessPolicyCreditsAvailableResponseSerializer(TestCase):
             },
         }
         subsidy_exp_date = '2030-01-01 12:00:00Z'
-        mock_subsidy_client.return_value = {
+        mock_subsidy_record.return_value = {
             'uuid': str(uuid4()),
             'title': 'Test Subsidy',
             'enterprise_customer_uuid': str(self.enterprise_uuid),

--- a/enterprise_access/apps/api/tests/test_serializers.py
+++ b/enterprise_access/apps/api/tests/test_serializers.py
@@ -8,7 +8,6 @@ from uuid import uuid4
 import ddt
 from django.conf import settings
 from django.test import TestCase
-from enterprise_access.apps.subsidy_access_policy.models import AssignedLearnerCreditAccessPolicy
 from freezegun import freeze_time
 
 from enterprise_access.apps.api.serializers.subsidy_access_policy import (

--- a/enterprise_access/apps/api/tests/test_serializers.py
+++ b/enterprise_access/apps/api/tests/test_serializers.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 import ddt
 from django.conf import settings
 from django.test import TestCase
+from enterprise_access.apps.subsidy_access_policy.models import AssignedLearnerCreditAccessPolicy
 from freezegun import freeze_time
 
 from enterprise_access.apps.api.serializers.subsidy_access_policy import (

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -10,6 +10,7 @@ from uuid import UUID, uuid4
 
 import ddt
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from requests.exceptions import HTTPError
 from rest_framework import status
 from rest_framework.reverse import reverse
@@ -95,6 +96,8 @@ class CRUDViewTestMixin:
             'expiration_datetime': self.tomorrow,
             'current_balance': 4,
             'is_active': True,
+            'starting_balance': 4,
+            'total_deposits': 4,
         }
         subsidy_client_patcher = patch.object(
             SubsidyAccessPolicy, 'subsidy_client'
@@ -647,6 +650,50 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
         }
         expected_response.update(request_payload)
         self.assertEqual(expected_response, response.json())
+
+    @ddt.data(
+        # Test sending a bunch of updates as a PATCH.
+        {
+            'is_patch': True,
+            'request_payload': {
+                'description': 'the new description',
+                'display_name': 'new display_name',
+                'active': True,
+                'retired': True,
+                'catalog_uuid': str(uuid4()),
+                'subsidy_uuid': str(uuid4()),
+                'access_method': AccessMethods.ASSIGNED,
+                'spend_limit': 6,
+                'per_learner_spend_limit': 10000,
+            },
+        },
+    )
+    @ddt.unpack
+    def test_update_views_with_exceeding_spend_limit(self, is_patch, request_payload):
+        """
+        Test that the update and partial_update views can modify certain
+        fields of a policy record.
+        """
+        # Set the JWT-based auth to an operator.
+        self.set_jwt_cookie([
+            {'system_wide_role': SYSTEM_ENTERPRISE_OPERATOR_ROLE, 'context': str(TEST_ENTERPRISE_UUID)}
+        ])
+
+        policy_for_edit = PerLearnerSpendCapLearnerCreditAccessPolicyFactory(
+            enterprise_customer_uuid=self.enterprise_uuid,
+            display_name='old display_name',
+            spend_limit=5,
+            active=False,
+        )
+
+        action = self.client.patch if is_patch else self.client.put
+        url = reverse(
+            'api:v1:subsidy-access-policies-detail',
+            kwargs={'uuid': str(policy_for_edit.uuid)}
+        )
+
+        with self.assertRaises(ValidationError):
+            action(url, data=request_payload)
 
     @ddt.data(
         {

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -651,25 +651,7 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
         expected_response.update(request_payload)
         self.assertEqual(expected_response, response.json())
 
-    @ddt.data(
-        # Test sending a bunch of updates as a PATCH.
-        {
-            'is_patch': True,
-            'request_payload': {
-                'description': 'the new description',
-                'display_name': 'new display_name',
-                'active': True,
-                'retired': True,
-                'catalog_uuid': str(uuid4()),
-                'subsidy_uuid': str(uuid4()),
-                'access_method': AccessMethods.ASSIGNED,
-                'spend_limit': 6,
-                'per_learner_spend_limit': 10000,
-            },
-        },
-    )
-    @ddt.unpack
-    def test_update_views_with_exceeding_spend_limit(self, is_patch, request_payload):
+    def test_update_views_with_exceeding_spend_limit(self):
         """
         Test that the update and partial_update views can modify certain
         fields of a policy record.
@@ -686,14 +668,25 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
             active=False,
         )
 
-        action = self.client.patch if is_patch else self.client.put
+        request_payload = {
+                'description': 'the new description',
+                'display_name': 'new display_name',
+                'active': True,
+                'retired': True,
+                'catalog_uuid': str(uuid4()),
+                'subsidy_uuid': str(uuid4()),
+                'access_method': AccessMethods.ASSIGNED,
+                'spend_limit': 6,
+                'per_learner_spend_limit': 10000,
+            }
+
         url = reverse(
             'api:v1:subsidy-access-policies-detail',
             kwargs={'uuid': str(policy_for_edit.uuid)}
         )
 
         with self.assertRaises(ValidationError):
-            action(url, data=request_payload)
+            self.client.patch(url, data=request_payload)
 
     @ddt.data(
         {

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -669,16 +669,16 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
         )
 
         request_payload = {
-                'description': 'the new description',
-                'display_name': 'new display_name',
-                'active': True,
-                'retired': True,
-                'catalog_uuid': str(uuid4()),
-                'subsidy_uuid': str(uuid4()),
-                'access_method': AccessMethods.ASSIGNED,
-                'spend_limit': 6,
-                'per_learner_spend_limit': 10000,
-            }
+            'description': 'the new description',
+            'display_name': 'new display_name',
+            'active': True,
+            'retired': True,
+            'catalog_uuid': str(uuid4()),
+            'subsidy_uuid': str(uuid4()),
+            'access_method': AccessMethods.ASSIGNED,
+            'spend_limit': 6,
+            'per_learner_spend_limit': 10000,
+        }
 
         url = reverse(
             'api:v1:subsidy-access-policies-detail',

--- a/enterprise_access/apps/subsidy_access_policy/constants.py
+++ b/enterprise_access/apps/subsidy_access_policy/constants.py
@@ -121,3 +121,8 @@ FORCE_ENROLLMENT_KEYWORD = 'allow_late_enrollment'
 SORT_BY_ENROLLMENT_COUNT = 'enrollment_count'
 
 GROUP_MEMBERS_WITH_AGGREGATES_DEFAULT_PAGE_SIZE = 10
+
+# Exceeding the spend_limit validation error
+VALIDATION_ERROR_SPEND_LIMIT_EXCEEDS_STARTING_BALANCE = "You cannot make this change, as the value of all budget limits would exceed the funds available on the subsidy. \
+    Please double-check the subsidy’s initial value and any adjustments, then ensure the budgets sum to an equal or lower amount. If you are trying to re-balance policies, \
+        please reduce the value of one first, then proceed to increase the value of another"

--- a/enterprise_access/apps/subsidy_access_policy/constants.py
+++ b/enterprise_access/apps/subsidy_access_policy/constants.py
@@ -124,5 +124,5 @@ GROUP_MEMBERS_WITH_AGGREGATES_DEFAULT_PAGE_SIZE = 10
 
 # Exceeding the spend_limit validation error
 VALIDATION_ERROR_SPEND_LIMIT_EXCEEDS_STARTING_BALANCE = "You cannot make this change, as the value of all budget limits would exceed the funds available on the subsidy. \
-    Please double-check the subsidy’s initial value and any adjustments, then ensure the budgets sum to an equal or lower amount. If you are trying to re-balance policies, \
-        please reduce the value of one first, then proceed to increase the value of another"
+Please double-check the subsidy’s initial value and any adjustments, then ensure the budgets sum to an equal or lower amount. If you are trying to re-balance policies, \
+please reduce the value of one first, then proceed to increase the value of another"

--- a/enterprise_access/apps/subsidy_access_policy/constants.py
+++ b/enterprise_access/apps/subsidy_access_policy/constants.py
@@ -123,6 +123,7 @@ SORT_BY_ENROLLMENT_COUNT = 'enrollment_count'
 GROUP_MEMBERS_WITH_AGGREGATES_DEFAULT_PAGE_SIZE = 10
 
 # Exceeding the spend_limit validation error
-VALIDATION_ERROR_SPEND_LIMIT_EXCEEDS_STARTING_BALANCE = "You cannot make this change, as the value of all budget limits would exceed the funds available on the subsidy. \
-Please double-check the subsidy’s initial value and any adjustments, then ensure the budgets sum to an equal or lower amount. If you are trying to re-balance policies, \
+VALIDATION_ERROR_SPEND_LIMIT_EXCEEDS_STARTING_BALANCE = "You cannot make this change, as the value of all budget \
+limits would exceed the funds available on the subsidy. Please double-check the subsidy’s initial value and any \
+adjustments, then ensure the budgets sum to an equal or lower amount. If you are trying to re-balance policies, \
 please reduce the value of one first, then proceed to increase the value of another"

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -40,8 +40,8 @@ from .constants import (
     REASON_SUBSIDY_EXPIRED,
     VALIDATION_ERROR_SPEND_LIMIT_EXCEEDS_STARTING_BALANCE,
     AccessMethods,
-    TransactionStateChoices,
     PolicyTypes,
+    TransactionStateChoices
 )
 from .content_metadata_api import (
     get_and_cache_catalog_contains_content,
@@ -313,7 +313,7 @@ class SubsidyAccessPolicy(TimeStampedModel):
         policy_balances = []
         for policy in policies:
             policy_uuid = getattr(policy, 'uuid')
-            if(policy_uuid != self.uuid):
+            if policy_uuid != self.uuid:
                 spend_available_usd_cents = getattr(policy, 'spend_limit')
                 policy_balances.append(spend_available_usd_cents)
         policy_balances.append(self.spend_limit)
@@ -429,7 +429,7 @@ class SubsidyAccessPolicy(TimeStampedModel):
         """
         current_balance = self.subsidy_record().get('current_balance') or 0
         return int(current_balance)
-    
+
     def subsidy_total_deposits(self):
         """
         Returns total remaining balance for the associated subsidy ledger.

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -40,7 +40,8 @@ from .constants import (
     REASON_SUBSIDY_EXPIRED,
     VALIDATION_ERROR_SPEND_LIMIT_EXCEEDS_STARTING_BALANCE,
     AccessMethods,
-    TransactionStateChoices
+    TransactionStateChoices,
+    PolicyTypes,
 )
 from .content_metadata_api import (
     get_and_cache_catalog_contains_content,
@@ -299,7 +300,8 @@ class SubsidyAccessPolicy(TimeStampedModel):
                 return policy_class
         return None
 
-    def get_policies_associated_to_subsidy(self):
+    @property
+    def get_all_policies_associated_to_subsidy(self):
         enterprise_customer_uuid = str(self.enterprise_customer_uuid)
         subsidy_uuid = str(self.subsidy_uuid)
         return SubsidyAccessPolicy.objects.filter(
@@ -328,10 +330,13 @@ class SubsidyAccessPolicy(TimeStampedModel):
         """
         Used to help validate field values before saving this model instance.
         """
-        policies = self.get_policies_associated_to_subsidy()
-        sum_of_policy_balances = self.total_spend_limit_for_all_policies_associated_to_subsidy(policies)
-        if sum_of_policy_balances > self.subsidy_balance():
-            raise ValidationError(f'{self} {VALIDATION_ERROR_SPEND_LIMIT_EXCEEDS_STARTING_BALANCE}')
+        # Specific call on spent_limit change, move to save vs clean
+        if(self.policy_type == PolicyTypes().ASSIGNED_LEARNER_CREDIT): 
+            sum_of_policy_balances = self.total_spend_limit_for_all_policies_associated_to_subsidy(
+                policies=self.get_all_policies_associated_to_subsidy
+            )
+            if sum_of_policy_balances > self.subsidy_initial_balance():
+                raise ValidationError(f'{self} {VALIDATION_ERROR_SPEND_LIMIT_EXCEEDS_STARTING_BALANCE}')
         for field_name, (constraint_function, error_message) in self.FIELD_CONSTRAINTS.items():
             field = getattr(self, field_name)
             if not constraint_function(field):
@@ -347,6 +352,12 @@ class SubsidyAccessPolicy(TimeStampedModel):
             raise TypeError("Can not create object of class SubsidyAccessPolicy")
 
         self.policy_type = type(self).__name__
+        # Issue with placing it in the save() function is that the django admin screen does not fail gracefully
+        # sum_of_policy_balances = self.total_spend_limit_for_all_policies_associated_to_subsidy(
+        #     policies=self.get_all_policies_associated_to_subsidy
+        # )
+        # if sum_of_policy_balances > self.subsidy_balance():
+        #     raise ValidationError(f'{self} {VALIDATION_ERROR_SPEND_LIMIT_EXCEEDS_STARTING_BALANCE}')
         self.full_clean()
         super().save(*args, **kwargs)
 
@@ -425,6 +436,13 @@ class SubsidyAccessPolicy(TimeStampedModel):
         """
         current_balance = self.subsidy_record().get('current_balance') or 0
         return int(current_balance)
+    
+    def subsidy_initial_balance(self):
+        """
+        Returns total remaining balance for the associated subsidy ledger.
+        """
+        starting_balance = self.subsidy_record().get('starting_balance')
+        return int(starting_balance)
 
     @property
     def spend_available(self):
@@ -440,6 +458,7 @@ class SubsidyAccessPolicy(TimeStampedModel):
             requests.exceptions.HTTPError if the request to Subsidy API (to fetch aggregates) fails.
         """
         # This is how much available spend the policy limit would allow, ignoring the subsidy balance.
+        print(self.spend_limit, self.total_redeemed, self.subsidy_balance(), 'hIiiii')
         if self.spend_limit is not None:
             # total_redeemed is negative
             policy_limit_balance = max(0, self.spend_limit + self.total_redeemed)

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -317,6 +317,10 @@ class SubsidyAccessPolicy(TimeStampedModel):
 
     @property
     def is_spend_limit_updated(self):
+        """
+        Checks if SubsidyAccessPolicy object exists in the database, and determines if the
+        database value of spend_limit differs from the current instance of spend_limit
+        """
         if self._state.adding:
             return False
         record_from_db = SubsidyAccessPolicy.objects.get(uuid=self.uuid)


### PR DESCRIPTION
**Description:**
Updates the validation for a policies `spend_limit` where the `spend_limit` may not exceed the `total_deposits`.
The `total_deposits` field from the Subsidy model is the sum of all adjustments and the starting balance.
It will take into account all policies from the the parent `subsidy_uuid`.

The Django Admin screen will display a validation error at the top of the screen if this constraint is violated.
![Screenshot 2024-06-04 at 11 53 33 AM](https://github.com/openedx/enterprise-access/assets/82611798/7810c003-8d3b-4152-9f47-6d62c3e5629f)

The validation that exists in the `clean()` function on the `SubsidyAccessPolicy` modal only runs if the expected updated `spend_limit` does not equal the current db value of the spend limit. This is done to allow modifications to other fields without running through the specific spend limit logic. This is also done as a precautionary measure for any policies that may already exist that violate this new constraint.

Updates the serializer validation helper function `policy_pre_write_validation` to run the `clean()` method to also check for this constraint. This is the [recommended method](https://twou.slack.com/archives/D04A0TDBBDL/p1717102085835939) for running clean on a validation serializer. 

Example: A (subsidy/plan) with 2 (policies/budgets) associated. When attempting to update the spend limit, it will take into account the values associated with all (policies/budgets) associated with the (subsidy/plan).

**Jira:**
[ENT-9004](https://2u-internal.atlassian.net/browse/ENT-9004)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
