### PR TITLE
feat: add enterprise_groups to project apps

### DIFF
--- a/enterprise_access/apps/api_client/enterprise_catalog_client.py
+++ b/enterprise_access/apps/api_client/enterprise_catalog_client.py
@@ -67,3 +67,16 @@ class EnterpriseCatalogApiClient(BaseOAuthClient):
         response = self.client.get(endpoint, params=query_params)
         response.raise_for_status()
         return response.json()
+
+    def get_content_metadata_count(self, catalog_uuid):
+        """
+        Returns the count of content metadata for a catalog.
+        Arguments:
+            catalog_uuid (UUID): UUID of the enterprise catalog to check.
+        Returns:
+            The number of content metadata for a catalog.
+        """
+        endpoint = self.enterprise_catalog_endpoint + str(catalog_uuid) + '/get_content_metadata/'
+        response = self.client.get(endpoint)
+        response.raise_for_status()
+        return response.json()['count']

--- a/enterprise_access/apps/api_client/tests/test_enterprise_catalog_client.py
+++ b/enterprise_access/apps/api_client/tests/test_enterprise_catalog_client.py
@@ -93,3 +93,21 @@ class TestEnterpriseCatalogApiClient(TestCase):
                 'traverse_pagination': True,
             },
         )
+
+    @mock.patch('enterprise_access.apps.api_client.base_oauth.OAuthAPIClient')
+    def test_get_content_metadata_count(self, mock_oauth_client):
+        mock_response_json = {
+            'count': 2
+        }
+        request_response = Response()
+        request_response.status_code = 200
+        mock_oauth_client.return_value.get.return_value.json.return_value = mock_response_json
+
+        catalog_uuid = uuid4()
+        client = EnterpriseCatalogApiClient()
+        fetched_metadata = client.get_content_metadata_count(catalog_uuid)
+
+        self.assertEqual(fetched_metadata, mock_response_json['count'])
+        mock_oauth_client.return_value.get.assert_called_with(
+            f'http://enterprise-catalog.example.com/api/v1/enterprise-catalogs/{catalog_uuid}/get_content_metadata/',
+        )

--- a/enterprise_access/apps/enterprise_groups/constants.py
+++ b/enterprise_access/apps/enterprise_groups/constants.py
@@ -1,3 +1,7 @@
+"""
+Constants for the enterprise_groups app.
+"""
+
 DAYS_TO_PURGE_PII = 90
 
 BRAZE_GROUPS_EMAIL_CAMPAIGNS_FIRST_REMINDER_DAY = 5

--- a/enterprise_access/apps/enterprise_groups/management/commands/groups_reminder_emails.py
+++ b/enterprise_access/apps/enterprise_groups/management/commands/groups_reminder_emails.py
@@ -51,7 +51,7 @@ class Command(BaseCommand):
             catalog_uuid = policy_group_association.subsidy_access_policy.catalog_uuid
             catalog_count = enterprise_catalog_client.get_content_metadata_count(
                 catalog_uuid
-            )['count']
+            )
 
             for pending_enterprise_customer_user in pending_enterprise_customer_users:
                 pending_enterprise_customer_user["subsidy_expiration_datetime"] = (

--- a/enterprise_access/apps/enterprise_groups/management/commands/groups_reminder_emails.py
+++ b/enterprise_access/apps/enterprise_groups/management/commands/groups_reminder_emails.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
                 policy_group_association.subsidy_access_policy.subsidy_expiration_datetime
             )
             catalog_uuid = policy_group_association.subsidy_access_policy.catalog_uuid
-            catalog_count = enterprise_catalog_client.catalog_content_metadata(
+            catalog_count = enterprise_catalog_client.get_content_metadata_count(
                 catalog_uuid
             )['count']
 

--- a/enterprise_access/apps/enterprise_groups/management/commands/tests/test_groups_reminder_emails.py
+++ b/enterprise_access/apps/enterprise_groups/management/commands/tests/test_groups_reminder_emails.py
@@ -79,7 +79,7 @@ class TestGroupsReminderEmails(TestCase):
                 "user_email": "test2@2u.com",
             },
         ]
-        mock_enterprise_catalog_client().catalog_content_metadata.return_value = {
+        mock_enterprise_catalog_client().get_content_metadata_count.return_value = {
             'count': 5
         }
         mock_lms_api_client().get_pending_enterprise_group_memberships.return_value = (

--- a/enterprise_access/apps/enterprise_groups/tasks.py
+++ b/enterprise_access/apps/enterprise_groups/tasks.py
@@ -129,7 +129,7 @@ def send_group_reminder_emails(pending_enterprise_users):
             pending_enterprise_user["catalog_count"],
             pending_enterprise_user["subsidy_expiration_datetime"],
         )
-
+        logger.info(f'Sending braze campaign group reminder email to {recipient}.')
         braze_client_instance.send_campaign_message(
             braze_properties["braze_campaign_id"],
             recipients=[recipient],

--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -72,6 +72,7 @@ PROJECT_APPS = (
     'enterprise_access.apps.events',
     'enterprise_access.apps.subsidy_access_policy',
     'enterprise_access.apps.content_assignments',
+    'enterprise_access.apps.enterprise_groups',
 )
 
 INSTALLED_APPS += THIRD_PARTY_APPS


### PR DESCRIPTION
**Description:**
We created a cronjob to trigger the management command `groups_reminder_emails` but the command is currently not being recognized. To resolve this, this PR adds `enterprise_access.apps.enterprise_groups` to the `PROJECT_APPS` in order to run the management command `groups_reminder_emails`.

Additionally, this PR adds the `get_catalog_metadata_count` method to retrieve just the catalog count and adds logging. Previously, we were using an existing method `catalog_content_metadata`; however that method requires the `content_keys` param. 

![Screenshot 2024-06-03 at 10 57 18 AM](https://github.com/openedx/enterprise-access/assets/71999631/f14338ef-e2c6-4f1f-826e-8495b3336cb0)


**Jira:**
ENT-9057
https://2u-internal.atlassian.net/browse/ENT-9057

**Merge checklist:**
- [x] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
