### PR TITLE
feat: Send action required by time to braze campaign

### DIFF
--- a/enterprise_access/apps/content_assignments/constants.py
+++ b/enterprise_access/apps/content_assignments/constants.py
@@ -121,3 +121,5 @@ class AssignmentAutomaticExpiredReason:
 NUM_DAYS_BEFORE_AUTO_EXPIRATION = 90
 
 RETIRED_EMAIL_ADDRESS_FORMAT = 'retired_user{}@retired.invalid'
+
+BRAZE_ACTION_REQUIRED_BY_TIMESTAMP_FORMAT = "%-I:%M %p %b %d, %Y"

--- a/enterprise_access/apps/content_assignments/tasks.py
+++ b/enterprise_access/apps/content_assignments/tasks.py
@@ -447,6 +447,7 @@ def send_reminder_email_for_pending_assignment(assignment_uuid):
         'course_partner',
         'course_card_image',
         'learner_portal_link',
+        'action_required_by',
         'action_required_by_timestamp'
     )
     campaign_uuid = settings.BRAZE_ASSIGNMENT_REMINDER_NOTIFICATION_CAMPAIGN
@@ -490,6 +491,7 @@ def send_email_for_new_assignment(new_assignment_uuid):
         'course_partner',
         'course_card_image',
         'learner_portal_link',
+        'action_required_by',
         'action_required_by_timestamp'
     )
     campaign_uuid = settings.BRAZE_ASSIGNMENT_NOTIFICATION_CAMPAIGN

--- a/enterprise_access/apps/content_assignments/tasks.py
+++ b/enterprise_access/apps/content_assignments/tasks.py
@@ -59,6 +59,7 @@ class BrazeCampaignSender:
         'course_card_image',
         'learner_portal_link',
         'action_required_by',
+        'action_required_by_time'
     }
 
     def __init__(self, assignment):
@@ -212,6 +213,16 @@ class BrazeCampaignSender:
         if not action_required_by:
             return None
         return format_datetime_obj(action_required_by['date'])
+
+    def get_action_required_by_time(self):
+        """
+        Returns the minimum of this assignment's auto-expiration date,
+        the content's enrollment deadline, and the related policy's expiration time.
+        """
+        action_required_by_time = get_automatic_expiration_date_and_reason(self.assignment)
+        if not action_required_by_time:
+            return None
+        return format_datetime_obj(action_required_by_time['date'], output_pattern="%H:%M")
 
     def get_course_partner(self):
         return get_course_partners(self.course_metadata)
@@ -436,6 +447,7 @@ def send_reminder_email_for_pending_assignment(assignment_uuid):
         'course_card_image',
         'learner_portal_link',
         'action_required_by',
+        'action_required_by_time'
     )
     campaign_uuid = settings.BRAZE_ASSIGNMENT_REMINDER_NOTIFICATION_CAMPAIGN
     if assignment.lms_user_id is not None:

--- a/enterprise_access/apps/content_assignments/tests/test_tasks.py
+++ b/enterprise_access/apps/content_assignments/tests/test_tasks.py
@@ -367,6 +367,7 @@ class TestBrazeEmailTasks(APITestWithMocks):
                 'course_partner': 'Smart Folks, Good People, and Fast Learners',
                 'course_card_image': 'https://itsanimage.com',
                 'learner_portal_link': 'http://enterprise-learner-portal.example.com/test-slug',
+                'action_required_by': 'Jan 01, 2021',
                 'action_required_by_timestamp': '12:00 PM Jan 01, 2021'
             },
         )
@@ -447,6 +448,7 @@ class TestBrazeEmailTasks(APITestWithMocks):
                 'course_partner': 'Smart Folks and Good People',
                 'course_card_image': 'https://itsanimage.com',
                 'learner_portal_link': '{}/{}'.format(settings.ENTERPRISE_LEARNER_PORTAL_URL, 'test-slug'),
+                'action_required_by': 'Jan 01, 2021',
                 'action_required_by_timestamp': '12:00 PM Jan 01, 2021'
             },
         )

--- a/enterprise_access/apps/content_assignments/tests/test_tasks.py
+++ b/enterprise_access/apps/content_assignments/tests/test_tasks.py
@@ -368,6 +368,7 @@ class TestBrazeEmailTasks(APITestWithMocks):
                 'course_card_image': 'https://itsanimage.com',
                 'learner_portal_link': 'http://enterprise-learner-portal.example.com/test-slug',
                 'action_required_by': 'Jan 01, 2021',
+                'action_required_by_time': '12:00'
             },
         )
 

--- a/enterprise_access/apps/content_assignments/tests/test_tasks.py
+++ b/enterprise_access/apps/content_assignments/tests/test_tasks.py
@@ -334,7 +334,6 @@ class TestBrazeEmailTasks(APITestWithMocks):
             'uuid': self.policy.subsidy_uuid,
             'expiration_datetime': (now() + timedelta(days=1)).strftime('%Y-%m-%d %H:%M:%SZ'),
         }
-        print(mock_subsidy)
         mock_subsidy_client.retrieve_subsidy.return_value = mock_subsidy
         mock_braze_client.generate_mailto_link.return_value = f'mailto:{admin_email}'
 

--- a/enterprise_access/apps/content_assignments/tests/test_tasks.py
+++ b/enterprise_access/apps/content_assignments/tests/test_tasks.py
@@ -334,6 +334,7 @@ class TestBrazeEmailTasks(APITestWithMocks):
             'uuid': self.policy.subsidy_uuid,
             'expiration_datetime': (now() + timedelta(days=1)).strftime('%Y-%m-%d %H:%M:%SZ'),
         }
+        print(mock_subsidy)
         mock_subsidy_client.retrieve_subsidy.return_value = mock_subsidy
         mock_braze_client.generate_mailto_link.return_value = f'mailto:{admin_email}'
 
@@ -367,8 +368,7 @@ class TestBrazeEmailTasks(APITestWithMocks):
                 'course_partner': 'Smart Folks, Good People, and Fast Learners',
                 'course_card_image': 'https://itsanimage.com',
                 'learner_portal_link': 'http://enterprise-learner-portal.example.com/test-slug',
-                'action_required_by': 'Jan 01, 2021',
-                'action_required_by_time': '12:00'
+                'action_required_by_timestamp': '12:00 PM Jan 01, 2021'
             },
         )
 
@@ -448,7 +448,7 @@ class TestBrazeEmailTasks(APITestWithMocks):
                 'course_partner': 'Smart Folks and Good People',
                 'course_card_image': 'https://itsanimage.com',
                 'learner_portal_link': '{}/{}'.format(settings.ENTERPRISE_LEARNER_PORTAL_URL, 'test-slug'),
-                'action_required_by': 'Jan 01, 2021',
+                'action_required_by_timestamp': '12:00 PM Jan 01, 2021'
             },
         )
         assert mock_braze_client.return_value.send_campaign_message.call_count == 1


### PR DESCRIPTION
**Description:**
Sends the time in the format `%H:%M` to be parsed by the braze client to the users local time zone. 
It is only updating the task for the assignment reminders to run a stage test on the email campaign with the updated development email template.

**Jira:**
[ENT-8888](https://2u-internal.atlassian.net/browse/ENT-8888)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
