### PR TITLE
Adding Autocomplete field for Subsidy Access Policy field

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - enterprise_access_mysql80:/var/lib/mysql
 
   memcache:
-    image: memcached:1.4.24
+    image: memcached:1.6.28
     container_name: enterprise_access.memcache
     networks:
       - devstack_default

--- a/enterprise_access/apps/subsidy_access_policy/admin/__init__.py
+++ b/enterprise_access/apps/subsidy_access_policy/admin/__init__.py
@@ -342,6 +342,10 @@ class PolicyGroupAssociationAdmin(admin.ModelAdmin):
         'enterprise_group_uuid',
     )
 
+    autocomplete_fields = [
+        'subsidy_access_policy',
+    ]
+
 
 @admin.register(models.SubsidyAccessPolicy)
 class SubsidAccessPolicyAdmin(admin.ModelAdmin):


### PR DESCRIPTION
**Description:**
Adding Autocomplete field for Subsidy Access Policy field in Policy Group Association creation form. Note that I did not have to make any changes as laid out in the ticket related to creating access policy screen and hiding it in the left side bar 

In order to provision enterprise-access, I had to bump the memcache version in the docker config to a more recent version, which is included in the changes. 

**Jira:**
[ENT-9059](https://2u-internal.atlassian.net/browse/ENT-9059)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
**P**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance

Autocomplete field:
<img width="820" alt="Policy Association Autocomplete" src="https://github.com/openedx/enterprise-access/assets/171080149/ac9720a0-d99c-4d49-bdf3-7064a322fb8b">

Filter tests:
1. Filter by UUID:
<img width="501" alt="filter by uuid" src="https://github.com/openedx/enterprise-access/assets/171080149/b781643d-1ed6-4ef4-a1e3-ee36916ac214">

2. Filter by name:
<img width="529" alt="filter positive" src="https://github.com/openedx/enterprise-access/assets/171080149/a5319f6c-ece5-495b-91ff-157ad18a2daf">

3. Negative test:
<img width="500" alt="filter negative" src="https://github.com/openedx/enterprise-access/assets/171080149/569fb2bd-a84c-409c-a400-48c136cdf8a2">



