### PR TITLE
refactor: Remove usage of `action_required_by`

### DIFF
--- a/enterprise_access/apps/content_assignments/tasks.py
+++ b/enterprise_access/apps/content_assignments/tasks.py
@@ -58,7 +58,6 @@ class BrazeCampaignSender:
         'course_partner',
         'course_card_image',
         'learner_portal_link',
-        'action_required_by',
         'action_required_by_timestamp'
     }
 
@@ -203,16 +202,6 @@ class BrazeCampaignSender:
         return get_human_readable_date(
             self.course_metadata.get('normalized_metadata', {}).get('start_date')
         )
-
-    def get_action_required_by(self):
-        """
-        Returns the minimum of this assignment's auto-expiration date,
-        the content's enrollment deadline, and the related policy's expiration datetime.
-        """
-        action_required_by = get_automatic_expiration_date_and_reason(self.assignment)
-        if not action_required_by:
-            return None
-        return format_datetime_obj(action_required_by['date'])
 
     def get_action_required_by_timestamp(self):
         """
@@ -447,7 +436,6 @@ def send_reminder_email_for_pending_assignment(assignment_uuid):
         'course_partner',
         'course_card_image',
         'learner_portal_link',
-        'action_required_by',
         'action_required_by_timestamp'
     )
     campaign_uuid = settings.BRAZE_ASSIGNMENT_REMINDER_NOTIFICATION_CAMPAIGN
@@ -491,7 +479,6 @@ def send_email_for_new_assignment(new_assignment_uuid):
         'course_partner',
         'course_card_image',
         'learner_portal_link',
-        'action_required_by',
         'action_required_by_timestamp'
     )
     campaign_uuid = settings.BRAZE_ASSIGNMENT_NOTIFICATION_CAMPAIGN

--- a/enterprise_access/apps/content_assignments/tests/test_tasks.py
+++ b/enterprise_access/apps/content_assignments/tests/test_tasks.py
@@ -15,6 +15,7 @@ from rest_framework import status
 from enterprise_access.apps.api_client.braze_client import ENTERPRISE_BRAZE_ALIAS_LABEL
 from enterprise_access.apps.api_client.tests.test_utils import MockResponse
 from enterprise_access.apps.content_assignments.constants import (
+    BRAZE_ACTION_REQUIRED_BY_TIMESTAMP_FORMAT,
     AssignmentActionErrors,
     AssignmentActions,
     LearnerContentAssignmentStateChoices
@@ -367,7 +368,6 @@ class TestBrazeEmailTasks(APITestWithMocks):
                 'course_partner': 'Smart Folks, Good People, and Fast Learners',
                 'course_card_image': 'https://itsanimage.com',
                 'learner_portal_link': 'http://enterprise-learner-portal.example.com/test-slug',
-                'action_required_by': 'Jan 01, 2021',
                 'action_required_by_timestamp': '2021-01-01T12:00:00Z'
             },
         )
@@ -448,7 +448,6 @@ class TestBrazeEmailTasks(APITestWithMocks):
                 'course_partner': 'Smart Folks and Good People',
                 'course_card_image': 'https://itsanimage.com',
                 'learner_portal_link': '{}/{}'.format(settings.ENTERPRISE_LEARNER_PORTAL_URL, 'test-slug'),
-                'action_required_by': 'Jan 01, 2021',
                 'action_required_by_timestamp': '2021-01-01T12:00:00Z'
             },
         )
@@ -532,9 +531,9 @@ class TestBrazeEmailTasks(APITestWithMocks):
         self.assignment.add_successful_notified_action()
 
         sender = BrazeCampaignSender(self.assignment)
-        action_required_by = sender.get_action_required_by()
-
-        self.assertEqual(format_datetime_obj(yesterday), action_required_by)
+        action_required_by = sender.get_action_required_by_timestamp()
+        expected_result = format_datetime_obj(yesterday, output_pattern=BRAZE_ACTION_REQUIRED_BY_TIMESTAMP_FORMAT)
+        self.assertEqual(expected_result, action_required_by)
 
     @mock.patch('enterprise_access.apps.content_assignments.tasks.LmsApiClient')
     @mock.patch('enterprise_access.apps.content_assignments.tasks.BrazeApiClient')
@@ -573,9 +572,9 @@ class TestBrazeEmailTasks(APITestWithMocks):
         self.assignment.add_successful_notified_action()
 
         sender = BrazeCampaignSender(self.assignment)
-        action_required_by = sender.get_action_required_by()
-
-        self.assertEqual(format_datetime_obj(yesterday), action_required_by)
+        action_required_by = sender.get_action_required_by_timestamp()
+        expected_result = format_datetime_obj(yesterday, output_pattern=BRAZE_ACTION_REQUIRED_BY_TIMESTAMP_FORMAT)
+        self.assertEqual(expected_result, action_required_by)
 
     @mock.patch('enterprise_access.apps.content_assignments.tasks.LmsApiClient')
     @mock.patch('enterprise_access.apps.content_assignments.tasks.BrazeApiClient')
@@ -617,9 +616,10 @@ class TestBrazeEmailTasks(APITestWithMocks):
         self.assignment.add_successful_notified_action()
 
         sender = BrazeCampaignSender(self.assignment)
-        action_required_by = sender.get_action_required_by()
+        action_required_by = sender.get_action_required_by_timestamp()
 
         expected_result = format_datetime_obj(
-            get_automatic_expiration_date_and_reason(self.assignment)['date']
+            get_automatic_expiration_date_and_reason(self.assignment)['date'],
+            output_pattern=BRAZE_ACTION_REQUIRED_BY_TIMESTAMP_FORMAT
         )
         self.assertEqual(expected_result, action_required_by)


### PR DESCRIPTION
**Description:**
Removes `action_required_by` trigger property helper function and usage in favor of `action_required_by_timestamp`.
This is the final step in ensuring a smooth transition between switching attributes used in Braze campaigns.

PRs that added `action_required_by_timestamp`
https://github.com/openedx/enterprise-access/pull/488
https://github.com/openedx/enterprise-access/pull/482

**Jira:**
ENT-8888

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
