### PR TITLE
chore: increase max_retries and retry_backoff for tasks

### DIFF
--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -411,7 +411,7 @@ CELERY_BROKER_TRANSPORT_OPTIONS = {
     'fanout_prefix': True,
 }
 
-TASK_MAX_RETRIES = 3
+TASK_MAX_RETRIES = 5
 """############################# END CELERY CONFIG ##################################"""
 
 

--- a/enterprise_access/tasks.py
+++ b/enterprise_access/tasks.py
@@ -32,5 +32,10 @@ class LoggedTaskWithRetry(LoggedTask):  # pylint: disable=abstract-method
     # see https://docs.celeryq.dev/en/stable/userguide/tasks.html#Task.retry_backoff
     # First retry will delay 60 seconds, second will delay 120 seconds, third 240 seconds.
     retry_backoff = 60
+    # If retry_backoff is enabled, this option will set a maximum delay in seconds between task autoretries. 
+    # https://docs.celeryq.dev/en/stable/userguide/tasks.html#Task.retry_backoff_max
+    # Since our retry_backoff is 60 seconds, the final retry delay will exceed the default value of 600 seconds
+    # 2⁴ × 60 seconds = 960 -> 16 minutes
+    retry_backoff_max = 960
     # Add randomness to backoff delays to prevent all tasks in queue from executing simultaneously
     retry_jitter = True

--- a/enterprise_access/tasks.py
+++ b/enterprise_access/tasks.py
@@ -24,8 +24,13 @@ class LoggedTaskWithRetry(LoggedTask):  # pylint: disable=abstract-method
         OperationalError,
         BrazeClientError,
     )
+    # The default number of max_retries is 3, but Braze times out a lot so we will use 5 instead.
+    # 5 retries means retrying potentially up to ~31 minutes:
+    # (2⁰ + 2¹ + 2² + 2³ + 2⁴) × (60 seconds) = 31 min
     retry_kwargs = {'max_retries': settings.TASK_MAX_RETRIES}
     # Use exponential backoff for retrying tasks
-    retry_backoff = 5  # delay factor of 5 seconds
+    # see https://docs.celeryq.dev/en/stable/userguide/tasks.html#Task.retry_backoff
+    # First retry will delay 60 seconds, second will delay 120 seconds, third 240 seconds.
+    retry_backoff = 60
     # Add randomness to backoff delays to prevent all tasks in queue from executing simultaneously
     retry_jitter = True

--- a/enterprise_access/tasks.py
+++ b/enterprise_access/tasks.py
@@ -31,11 +31,9 @@ class LoggedTaskWithRetry(LoggedTask):  # pylint: disable=abstract-method
     # Use exponential backoff for retrying tasks
     # see https://docs.celeryq.dev/en/stable/userguide/tasks.html#Task.retry_backoff
     # First retry will delay 60 seconds, second will delay 120 seconds, third 240 seconds.
-    retry_backoff = 60
-    # If retry_backoff is enabled, this option will set a maximum delay in seconds between task autoretries.
+    # The retry_backoff_max default value is 600 seconds -> 10 minutes
     # https://docs.celeryq.dev/en/stable/userguide/tasks.html#Task.retry_backoff_max
-    # Since our retry_backoff is 60 seconds, the final retry delay will exceed the default value of 600 seconds
-    # 2⁴ × 60 seconds = 960 -> 16 minutes
-    retry_backoff_max = 960
+    # This will result in the final backoff time reducing from 2⁴ × 60 seconds = 960 seconds to 600 seconds
+    retry_backoff = 60
     # Add randomness to backoff delays to prevent all tasks in queue from executing simultaneously
     retry_jitter = True

--- a/enterprise_access/tasks.py
+++ b/enterprise_access/tasks.py
@@ -32,7 +32,7 @@ class LoggedTaskWithRetry(LoggedTask):  # pylint: disable=abstract-method
     # see https://docs.celeryq.dev/en/stable/userguide/tasks.html#Task.retry_backoff
     # First retry will delay 60 seconds, second will delay 120 seconds, third 240 seconds.
     retry_backoff = 60
-    # If retry_backoff is enabled, this option will set a maximum delay in seconds between task autoretries. 
+    # If retry_backoff is enabled, this option will set a maximum delay in seconds between task autoretries.
     # https://docs.celeryq.dev/en/stable/userguide/tasks.html#Task.retry_backoff_max
     # Since our retry_backoff is 60 seconds, the final retry delay will exceed the default value of 600 seconds
     # 2⁴ × 60 seconds = 960 -> 16 minutes


### PR DESCRIPTION
**Description:**
The changes made to the `max_retries` and `retry_backoff` are in parity with changes in license-manager related tasks.
https://github.com/openedx/license-manager/pull/658
**Jira:**
ENT-9039

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
