### PR TITLE
fix: removing redundant group membership check

### DIFF
--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -689,9 +689,6 @@ class SubsidyAccessPolicy(TimeStampedModel):
         # learner not associated to enterprise
         if not skip_customer_user_check:
             enterprise_user_record = self.enterprise_user_record(lms_user_id)
-            if not enterprise_user_record:
-                self._log_redeemability(False, REASON_LEARNER_NOT_IN_ENTERPRISE, lms_user_id, content_key)
-                return (False, REASON_LEARNER_NOT_IN_ENTERPRISE, [])
             included_in_policy, reason = self.includes_learner(
                 lms_user_id,
                 enterprise_user_record


### PR DESCRIPTION
**Description:**
We're already doing the check of if the user is in the enterprise in a method that we call right after this check. 

**Jira:**
[ENT-9011](https://2u-internal.atlassian.net/browse/ENT-9011)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
