### PR TITLE
fix: assignment reversal log info instead of error

### DIFF
--- a/enterprise_access/apps/content_assignments/signals.py
+++ b/enterprise_access/apps/content_assignments/signals.py
@@ -50,7 +50,7 @@ def update_assignment_status_for_reversed_transaction(**kwargs):
     try:
         assignment_to_update = LearnerContentAssignment.objects.get(transaction_uuid=transaction_uuid)
     except LearnerContentAssignment.DoesNotExist:
-        logger.error(f'No LearnerContentAssignment exists with transaction uuid: {transaction_uuid}')
+        logger.info(f'No LearnerContentAssignment exists with transaction uuid: {transaction_uuid}')
         return
 
     if assignment_to_update.state in LearnerContentAssignmentStateChoices.REVERSIBLE_STATES:


### PR DESCRIPTION
It's not an error if a transaction without a corresponding assignment is reversed, so we should log at INFO level when this happens, rather than at the ERROR level.

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
