### PR TITLE
fix: prefer allocated_at when determining assignment expiration

### DIFF
--- a/enterprise_access/apps/api/v1/tests/test_allocation_view.py
+++ b/enterprise_access/apps/api/v1/tests/test_allocation_view.py
@@ -234,7 +234,7 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
                     'actions': [],
                     'earliest_possible_expiration': {
                         'date': (
-                            self.alice_assignment.created + timedelta(days=NUM_DAYS_BEFORE_AUTO_EXPIRATION)
+                            self.alice_assignment.allocated_at + timedelta(days=NUM_DAYS_BEFORE_AUTO_EXPIRATION)
                         ).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
                         'reason': AssignmentAutomaticExpiredReason.NINETY_DAYS_PASSED
                     }
@@ -254,7 +254,7 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
                     'actions': [],
                     'earliest_possible_expiration': {
                         'date': (
-                            self.bob_assignment.created + timedelta(days=NUM_DAYS_BEFORE_AUTO_EXPIRATION)
+                            self.bob_assignment.allocated_at + timedelta(days=NUM_DAYS_BEFORE_AUTO_EXPIRATION)
                         ).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
                         'reason': AssignmentAutomaticExpiredReason.NINETY_DAYS_PASSED
                     }
@@ -274,7 +274,7 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
                     'actions': [],
                     'earliest_possible_expiration': {
                         'date': (
-                            self.carol_assignment.created + timedelta(days=NUM_DAYS_BEFORE_AUTO_EXPIRATION)
+                            self.carol_assignment.allocated_at + timedelta(days=NUM_DAYS_BEFORE_AUTO_EXPIRATION)
                         ).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
                         'reason': AssignmentAutomaticExpiredReason.NINETY_DAYS_PASSED
                     }
@@ -559,7 +559,7 @@ class TestSubsidyAccessPolicyAllocationEndToEnd(APITestWithMocks):
                     'actions': [],
                     'earliest_possible_expiration': {
                         'date': (
-                            new_allocation.created + timedelta(days=NUM_DAYS_BEFORE_AUTO_EXPIRATION)
+                            new_allocation.allocated_at + timedelta(days=NUM_DAYS_BEFORE_AUTO_EXPIRATION)
                         ).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
                         'reason': AssignmentAutomaticExpiredReason.NINETY_DAYS_PASSED
                     }

--- a/enterprise_access/apps/api/v1/tests/test_assignment_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_assignment_views.py
@@ -434,7 +434,7 @@ class TestAdminAssignmentAuthorizedCRUD(CRUDViewTestMixin, APITest):
             'learner_state': AssignmentLearnerStates.NOTIFYING,
             'earliest_possible_expiration': {
                 'date': (
-                    self.assignment_allocated_pre_link.created + timedelta(days=NUM_DAYS_BEFORE_AUTO_EXPIRATION)
+                    self.assignment_allocated_pre_link.allocated_at + timedelta(days=NUM_DAYS_BEFORE_AUTO_EXPIRATION)
                 ).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
                 'reason': AssignmentAutomaticExpiredReason.NINETY_DAYS_PASSED,
             },
@@ -1035,7 +1035,6 @@ class TestAssignmentAuthorizedCRUD(CRUDViewTestMixin, APITest):
         response = self.client.get(detail_url)
 
         assert response.status_code == status.HTTP_200_OK
-        last_notified_action = self.requester_assignment_accepted.get_last_successful_notified_action()
         assert response.json() == {
             'uuid': str(self.requester_assignment_accepted.uuid),
             'assignment_configuration': str(self.requester_assignment_accepted.assignment_configuration.uuid),
@@ -1059,7 +1058,7 @@ class TestAssignmentAuthorizedCRUD(CRUDViewTestMixin, APITest):
             ],
             'earliest_possible_expiration': {
                 'date': (
-                    last_notified_action.completed_at + timedelta(days=NUM_DAYS_BEFORE_AUTO_EXPIRATION)
+                    self.requester_assignment_accepted.allocated_at + timedelta(days=NUM_DAYS_BEFORE_AUTO_EXPIRATION)
                 ).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
                 'reason': AssignmentAutomaticExpiredReason.NINETY_DAYS_PASSED,
             }

--- a/enterprise_access/apps/content_assignments/models.py
+++ b/enterprise_access/apps/content_assignments/models.py
@@ -460,15 +460,7 @@ class LearnerContentAssignment(TimeStampedModel):
         sending a reminder notification for an assignment does not
         reset the auto-expiration date.
         """
-        last_notification = self.get_last_successful_notified_action()
-        # If we're currently sending the first notification message,
-        # we won't yet have a successful action, so use the created time of
-        # the assignment as the starting_point
-        if not last_notification:
-            starting_point = self.created
-        else:
-            starting_point = last_notification.completed_at
-        allocation_timeout_expiration = starting_point + timezone.timedelta(days=NUM_DAYS_BEFORE_AUTO_EXPIRATION)
+        allocation_timeout_expiration = self.allocated_at + timezone.timedelta(days=NUM_DAYS_BEFORE_AUTO_EXPIRATION)
         allocation_timeout_expiration = allocation_timeout_expiration.replace(tzinfo=UTC)
         return allocation_timeout_expiration
 

--- a/enterprise_access/apps/content_assignments/tests/test_api.py
+++ b/enterprise_access/apps/content_assignments/tests/test_api.py
@@ -762,17 +762,15 @@ class TestAssignmentExpiration(TestCase):
         Test that we expire an assignment and clear
         its PII, as long the state is not "accepted".
         """
+        # set the allocation time to be more than the threshold number of days ago
+        enough_days_to_be_cancelled = NUM_DAYS_BEFORE_AUTO_EXPIRATION + 1
         assignment = LearnerContentAssignmentFactory.create(
             assignment_configuration=self.assignment_configuration,
             state=assignment_state,
             learner_email='larry@stooges.com',
             lms_user_id=12345,
+            allocated_at=delta_t(days=-enough_days_to_be_cancelled),
         )
-        action = assignment.add_successful_notified_action()
-        # set the last notified action to be more than the threshold number of days ago
-        enough_days_to_be_cancelled = NUM_DAYS_BEFORE_AUTO_EXPIRATION + 1
-        action.completed_at = delta_t(days=-enough_days_to_be_cancelled)
-        action.save()
 
         # set a policy-subsidy expiration date in the future
         mock_subsidy_record = {'expiration_datetime': delta_t(days=100, as_string=True)}


### PR DESCRIPTION
Helps address
* https://2u-internal.atlassian.net/browse/ENT-9190 (assignment expiration job looks at created instead of allocated_at for many assignments)

Note that we recently backfilled `allocated_at` via a data migration - there should be no assignment records with a null value for this field anymore.

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
