### PR TITLE
fix: use allocated_at to determine recent_action time

### DIFF
--- a/enterprise_access/apps/api/v1/tests/test_assignment_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_assignment_views.py
@@ -429,7 +429,7 @@ class TestAdminAssignmentAuthorizedCRUD(CRUDViewTestMixin, APITest):
             'error_reason': None,
             'recent_action': {
                 'action_type': AssignmentRecentActionTypes.ASSIGNED,
-                'timestamp': self.assignment_allocated_pre_link.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                'timestamp': self.assignment_allocated_pre_link.allocated_at.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
             },
             'learner_state': AssignmentLearnerStates.NOTIFYING,
             'earliest_possible_expiration': {

--- a/enterprise_access/apps/content_assignments/models.py
+++ b/enterprise_access/apps/content_assignments/models.py
@@ -740,8 +740,8 @@ class LearnerContentAssignment(TimeStampedModel):
             recent_action_time=Coalesce(
                 # Time of most recent reminder.
                 Max('actions__completed_at', filter=Q(actions__action_type=AssignmentActions.REMINDED)),
-                # Fallback to created time.
-                F('created'),
+                # Fallback to allocation time
+                F('allocated_at'),
                 # Coerce CreationDateTimeField into a compatible field.
                 output_field=DateTimeField(),
             )


### PR DESCRIPTION
This is an easy change since we previously backfilled `allocated_at` and set it to be NOT NULL via
* https://github.com/openedx/enterprise-access/pull/506
* https://github.com/openedx/enterprise-access/pull/509
ENT-9038

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
