### PR TITLE
fix: fixing next property in pagination

### DIFF
--- a/enterprise_access/settings/production.py
+++ b/enterprise_access/settings/production.py
@@ -8,6 +8,14 @@ from enterprise_access.settings.utils import get_env_setting
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 
+# IMPORTANT: With this enabled, the server must always be behind a proxy that
+# strips the header HTTP_X_FORWARDED_PROTO from client requests. Otherwise,
+# a user can fool our server into thinking it was an https connection.
+# See
+# https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header
+# for other warnings.
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 ALLOWED_HOSTS = ['*']
 
 LOGGING = get_logger_config()


### PR DESCRIPTION
**Description:**
By adding the variable in production, we are making sure that the "next" variable that shows up when an API response is paginated defaults to HTTPS instead of HTTP.

**Jira:**
[ENT-9225](https://2u-internal.atlassian.net/browse/ENT-9225)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
