### PR TITLE
feat: add Exec Ed support for ForcedPolicyRedemption

### DIFF
--- a/enterprise_access/apps/subsidy_access_policy/admin/forms.py
+++ b/enterprise_access/apps/subsidy_access_policy/admin/forms.py
@@ -5,6 +5,8 @@ from django import forms
 from django.conf import settings
 from django.utils.translation import gettext as _
 
+from ..models import ForcedPolicyRedemption
+
 
 class LateRedemptionDaysFromNowChoices:
     """
@@ -61,3 +63,32 @@ class DepositFundsForm(forms.Form):
             "required": 'Salesforce Opportunity Line Item ID is required.',
         }
     )
+
+
+class ForcedPolicyRedemptionForm(forms.ModelForm):
+    """
+    Admin form for the ForcedPolicyRedemption model.
+    """
+    geag_first_name = forms.CharField(
+        label=_("Learner First Name (EE-only)"),
+        help_text=_(
+            "First name of learner, only used for Exec Ed Redemptions. "
+            "This value (along with last name and D.O.B.) are not persisted; "
+            "if you select 'Wait to redeem', the values will be gone when you try to save later."
+        ),
+        required=False,
+    )
+    geag_last_name = forms.CharField(
+        label=_("Learner Last Name (EE-only)"),
+        help_text=_("Last name of learner, only used for Exec Ed Redemptions"),
+        required=False,
+    )
+    geag_date_of_birth = forms.DateField(
+        label=_("Learner Date of Birth (EE-only)"),
+        help_text=_("Learner date of birth, only used for Exec Ed Redemptions"),
+        required=False,
+    )
+
+    class Meta:
+        model = ForcedPolicyRedemption
+        fields = '__all__'

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -1717,7 +1717,7 @@ class ForcedPolicyRedemption(TimeStampedModel):
             self.content_price_cents,
         )
 
-    def force_redeem(self):
+    def force_redeem(self, extra_metadata=None):
         """
         Forces redemption for the requested course run key in the associated policy.
         """
@@ -1733,6 +1733,7 @@ class ForcedPolicyRedemption(TimeStampedModel):
                 can_redeem, reason, existing_transactions = self.subsidy_access_policy.can_redeem(
                     self.lms_user_id, self.course_run_key,
                 )
+                extra_metadata = extra_metadata or {}
                 if can_redeem:
                     result = self.subsidy_access_policy.redeem(
                         self.lms_user_id,
@@ -1740,6 +1741,7 @@ class ForcedPolicyRedemption(TimeStampedModel):
                         existing_transactions,
                         metadata={
                             FORCE_ENROLLMENT_KEYWORD: True,
+                            **extra_metadata,
                         },
                     )
                     self.transaction_uuid = result['uuid']

--- a/enterprise_access/apps/subsidy_access_policy/tests/test_forced_redemption.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/test_forced_redemption.py
@@ -106,7 +106,8 @@ class ForcedPolicyRedemptionPerLearnerSpendTests(BaseForcedRedemptionTestCase):
             content_price_cents=self.default_content_price,
         )
 
-        forced_redemption_record.force_redeem()
+        extra_metadata = {'foo': 1, 'bar': 2}
+        forced_redemption_record.force_redeem(extra_metadata=extra_metadata)
 
         forced_redemption_record.refresh_from_db()
         self.assertEqual(MOCK_DATETIME_1, forced_redemption_record.redeemed_at)
@@ -117,7 +118,7 @@ class ForcedPolicyRedemptionPerLearnerSpendTests(BaseForcedRedemptionTestCase):
             lms_user_id=self.lms_user_id,
             content_key=self.course_run_key,
             subsidy_access_policy_uuid=str(policy.uuid),
-            metadata={FORCE_ENROLLMENT_KEYWORD: True},
+            metadata={FORCE_ENROLLMENT_KEYWORD: True, **extra_metadata},
             idempotency_key=mock.ANY,
         )
 


### PR DESCRIPTION
Add some non-persisted admin model fields for `ForcedPolicyRedemption` so that we can pass along the required GEAG key/value pairs in our forced redeem call. ENT-9137

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
