### PR TITLE
fix: send geag terms acceptd at in correct format

### DIFF
--- a/enterprise_access/apps/subsidy_access_policy/admin/__init__.py
+++ b/enterprise_access/apps/subsidy_access_policy/admin/__init__.py
@@ -42,6 +42,7 @@ FORCED_REDEMPTION_GEAG_KEYS = ('geag_first_name', 'geag_last_name', 'geag_date_o
 FORCED_REDEMPTION_CURRENT_TIME_KEY = 'geag_terms_accepted_at'
 FORCED_REDEMPTION_DATA_SHARE_CONSENT_KEY = 'geag_data_share_consent'
 FORCED_REDEMPTION_EMAIL_KEY = 'geag_email'
+GEAG_DATETIME_FMT = '%Y-%m-%dT%H:%M:%SZ'
 
 
 def super_admin_enabled():
@@ -454,7 +455,7 @@ class ForcedPolicyRedemptionAdmin(DjangoQLSearchMixin, SimpleHistoryAdmin):
             }
             if extra_metadata:
                 user_record = User.objects.get(lms_user_id=form.cleaned_data.get('lms_user_id'))
-                extra_metadata[FORCED_REDEMPTION_CURRENT_TIME_KEY] = str(timezone.now())
+                extra_metadata[FORCED_REDEMPTION_CURRENT_TIME_KEY] = timezone.now().strftime(GEAG_DATETIME_FMT)
                 extra_metadata[FORCED_REDEMPTION_DATA_SHARE_CONSENT_KEY] = True
                 extra_metadata[FORCED_REDEMPTION_EMAIL_KEY] = user_record.email
                 obj.force_redeem(extra_metadata=extra_metadata)

--- a/enterprise_access/apps/subsidy_access_policy/tests/test_admin.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/test_admin.py
@@ -1,14 +1,14 @@
 """
 Tests for the admin module.
 """
-from datetime import date
+from datetime import date, datetime
 from unittest import mock
 
 from django.contrib.admin.sites import AdminSite
 from django.test import TestCase
 
 from ...core.tests.factories import UserFactory
-from ..admin import ForcedPolicyRedemptionAdmin, ForcedPolicyRedemptionForm
+from ..admin import GEAG_DATETIME_FMT, ForcedPolicyRedemptionAdmin, ForcedPolicyRedemptionForm
 from ..models import ForcedPolicyRedemption
 
 
@@ -52,3 +52,9 @@ class ForcedPolicyRedemptionAdminTests(TestCase):
                 'geag_email': 'foo@bar.com',
             }
         )
+        terms_accepted_value =\
+            forced_redemption_obj.force_redeem.call_args_list[0][1]['extra_metadata']['geag_terms_accepted_at']
+        # we don't really care about the value, but
+        # we want to know that parsing the value matches the datetime
+        # format accepted by GEAG.
+        assert datetime.strptime(terms_accepted_value, GEAG_DATETIME_FMT)


### PR DESCRIPTION
**Description:**
Use a good datetime format for force redeeming with GEAG "terms accepted at".

**Jira:**
ENT-9137

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
