### PR TITLE
refactor: add core.apps file to fix django warnings

### DIFF
--- a/enterprise_access/apps/core/apps.py
+++ b/enterprise_access/apps/core/apps.py
@@ -1,0 +1,8 @@
+""" App config for the core module. """
+
+from django.apps import AppConfig
+
+
+class CoreAppConfig(AppConfig):
+    default_auto_field = 'django.db.models.AutoField'
+    name = 'enterprise_access.apps.core'


### PR DESCRIPTION
Easy fix of the only warnings in enterprise-access.

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
