### PR TITLE
feat: can_redeem checks for enrollment deadline

### DIFF
--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -37,6 +37,7 @@ from enterprise_access.apps.events.signals import SUBSIDY_REDEEMED
 from enterprise_access.apps.events.utils import send_subsidy_redemption_event_to_event_bus
 from enterprise_access.apps.subsidy_access_policy.constants import (
     GROUP_MEMBERS_WITH_AGGREGATES_DEFAULT_PAGE_SIZE,
+    REASON_BEYOND_ENROLLMENT_DEADLINE,
     REASON_CONTENT_NOT_IN_CATALOG,
     REASON_LEARNER_ASSIGNMENT_CANCELLED,
     REASON_LEARNER_ASSIGNMENT_FAILED,
@@ -224,6 +225,7 @@ def _get_user_message_for_reason(reason_slug, enterprise_admin_users):
         REASON_LEARNER_MAX_SPEND_REACHED: MissingSubsidyAccessReasonUserMessages.LEARNER_LIMITS_REACHED,
         REASON_LEARNER_MAX_ENROLLMENTS_REACHED: MissingSubsidyAccessReasonUserMessages.LEARNER_LIMITS_REACHED,
         REASON_CONTENT_NOT_IN_CATALOG: MissingSubsidyAccessReasonUserMessages.CONTENT_NOT_IN_CATALOG,
+        REASON_BEYOND_ENROLLMENT_DEADLINE: MissingSubsidyAccessReasonUserMessages.BEYOND_ENROLLMENT_DEADLINE,
         REASON_LEARNER_NOT_ASSIGNED_CONTENT: MissingSubsidyAccessReasonUserMessages.LEARNER_NOT_ASSIGNED_CONTENT,
         REASON_LEARNER_ASSIGNMENT_CANCELLED: MissingSubsidyAccessReasonUserMessages.LEARNER_ASSIGNMENT_CANCELED,
         REASON_LEARNER_ASSIGNMENT_FAILED: MissingSubsidyAccessReasonUserMessages.LEARNER_NOT_ASSIGNED_CONTENT,
@@ -768,7 +770,7 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
                     enterprise_customer_uuid, lms_user_id, content_key
                 )
 
-            if not redemptions and not redeemable_policies:
+            if not successful_redemptions and not redeemable_policies:
                 reasons.extend(_get_reasons_for_no_redeemable_policies(
                     enterprise_customer_uuid,
                     non_redeemable_policies

--- a/enterprise_access/apps/subsidy_access_policy/constants.py
+++ b/enterprise_access/apps/subsidy_access_policy/constants.py
@@ -93,6 +93,8 @@ class MissingSubsidyAccessReasonUserMessages:
     LEARNER_LIMITS_REACHED = "You can't enroll right now because of limits set by your organization."
     CONTENT_NOT_IN_CATALOG = \
         "You can't enroll right now because this course is no longer available in your organization's catalog."
+    BEYOND_ENROLLMENT_DEADLINE = \
+        "You can't enroll right now because the enrollment deadline for this course has passed."
     LEARNER_NOT_IN_ENTERPRISE = \
         "You can't enroll right now because your account is no longer associated with the organization."
     LEARNER_NOT_ASSIGNED_CONTENT = \
@@ -104,6 +106,7 @@ class MissingSubsidyAccessReasonUserMessages:
 REASON_POLICY_EXPIRED = "policy_expired"
 REASON_SUBSIDY_EXPIRED = "subsidy_expired"
 REASON_CONTENT_NOT_IN_CATALOG = "content_not_in_catalog"
+REASON_BEYOND_ENROLLMENT_DEADLINE = "beyond_enrollment_deadline"
 REASON_LEARNER_NOT_IN_ENTERPRISE = "learner_not_in_enterprise"
 REASON_LEARNER_NOT_IN_ENTERPRISE_GROUP = "learner_not_in_enterprise_group"
 REASON_NOT_ENOUGH_VALUE_IN_SUBSIDY = "not_enough_value_in_subsidy"

--- a/enterprise_access/apps/subsidy_access_policy/content_metadata_api.py
+++ b/enterprise_access/apps/subsidy_access_policy/content_metadata_api.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 
 import requests
 from django.conf import settings
+from django.utils.dateparse import parse_datetime
 from edx_django_utils.cache import TieredCache
 from requests.exceptions import HTTPError
 
@@ -125,3 +126,13 @@ def list_price_dict_from_usd_cents(list_price_integer_cents):
         "usd": list_price_decimal_dollars,
         "usd_cents": list_price_integer_cents,
     }
+
+
+def enroll_by_datetime(content_metadata):
+    """
+    Helper to return a datetime object representing
+    the enrollment deadline for a content_metdata record.
+    """
+    if enroll_by_date := content_metadata.get('enroll_by_date'):
+        return parse_datetime(enroll_by_date)
+    return None


### PR DESCRIPTION
**Description:**
We want the `can_redeem` query to return false for a given (user, content key)
if the enrollment deadline for the content key is in the past. This is necessary because
some courses have runs with an advertised run for which the deadline is in the future,
but also have available recent runs where the upgrade deadline is in the past.

Depends on https://github.com/openedx/enterprise-catalog/pull/909 and https://github.com/openedx/enterprise-subsidy/pull/286 

A `can_redeem` false payload for a passed enroll by date will have a `reasons` value like this: 
```
"reasons": [
            {
                "reason": "beyond_enrollment_deadline",
                "user_message": "You can't enroll right now because the enrollment deadline for this course has passed.",
                "policy_uuids": [
                    "3cc0ad2c-ede1-476c-8271-97683855e41d"
                ],
                "metadata": {
                    "enterprise_administrators": [
                        {
                            "email": "enterprise_admin_test-enterprise@example.com",
                            "lms_user_id": 145
                        }
                    ]
                }
            }
        ]
```

**Jira:**
ENT-7472

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
