### PR TITLE
build: unpin DRF and rebuild deps

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -130,9 +130,8 @@ django-waffle==4.1.0
     #   edx-toggles
 djangoql==0.18.1
     # via -r requirements/base.in
-djangorestframework==3.14.0
+djangorestframework==3.15.2
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-rest-swagger
     #   djangorestframework-csv
@@ -274,7 +273,6 @@ python3-openid==3.2.0
 pytz==2024.1
     # via
     #   -r requirements/base.in
-    #   djangorestframework
     #   drf-yasg
 pyyaml==6.0.2
     # via
@@ -307,7 +305,7 @@ rules==3.4
     # via -r requirements/base.in
 semantic-version==2.10.0
     # via edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via django-rest-swagger
 six==1.16.0
     # via

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,10 +11,5 @@
 # Common constraints for edx repos
 -c common_constraints.txt
 
-# DRF 3.15.0 is providing some backwards-compatibility issues for us
-# around default model fields vs. the serializer field defs,
-# and the discontinued use of OrderedDict in serializers.
-djangorestframework<3.15
-
 # For python greater than or equal to 3.9 backports.zoneinfo causing failures
 backports.zoneinfo; python_version<'3.9'

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -38,7 +38,7 @@ build==1.2.1
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-cachetools==5.4.0
+cachetools==5.5.0
     # via
     #   -r requirements/validation.txt
     #   tox
@@ -211,7 +211,7 @@ django-waffle==4.1.0
     #   edx-toggles
 djangoql==0.18.1
     # via -r requirements/validation.txt
-djangorestframework==3.14.0
+djangorestframework==3.15.2
     # via
     #   -r requirements/validation.txt
     #   django-rest-swagger
@@ -291,9 +291,9 @@ edx-toggles==5.2.0
     # via
     #   -r requirements/validation.txt
     #   edx-event-bus-kafka
-factory-boy==3.3.0
+factory-boy==3.3.1
     # via -r requirements/validation.txt
-faker==26.3.0
+faker==27.0.0
     # via
     #   -r requirements/validation.txt
     #   factory-boy
@@ -563,7 +563,6 @@ python3-openid==3.2.0
 pytz==2024.1
     # via
     #   -r requirements/validation.txt
-    #   djangorestframework
     #   drf-yasg
 pyyaml==6.0.2
     # via
@@ -627,7 +626,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via
     #   -r requirements/validation.txt
     #   django-rest-swagger
@@ -673,11 +672,11 @@ text-unidecode==1.3
     # via
     #   -r requirements/validation.txt
     #   python-slugify
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via
     #   -r requirements/validation.txt
     #   pylint
-tox==4.17.1
+tox==4.18.0
     # via -r requirements/validation.txt
 twine==5.1.1
     # via -r requirements/validation.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -44,7 +44,7 @@ billiard==4.2.0
     # via
     #   -r requirements/test.txt
     #   celery
-cachetools==5.4.0
+cachetools==5.5.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -208,9 +208,8 @@ django-waffle==4.1.0
     #   edx-toggles
 djangoql==0.18.1
     # via -r requirements/test.txt
-djangorestframework==3.14.0
+djangorestframework==3.15.2
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   django-rest-swagger
     #   djangorestframework-csv
@@ -292,9 +291,9 @@ edx-toggles==5.2.0
     # via
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
-factory-boy==3.3.0
+factory-boy==3.3.1
     # via -r requirements/test.txt
-faker==26.3.0
+faker==27.0.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -508,7 +507,6 @@ python3-openid==3.2.0
 pytz==2024.1
     # via
     #   -r requirements/test.txt
-    #   djangorestframework
     #   drf-yasg
 pyyaml==6.0.2
     # via
@@ -554,7 +552,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
@@ -583,7 +581,7 @@ social-auth-core==4.5.4
     #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-app-django
-soupsieve==2.5
+soupsieve==2.6
     # via beautifulsoup4
 sphinx==8.0.2
     # via
@@ -619,11 +617,11 @@ text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via
     #   -r requirements/test.txt
     #   pylint
-tox==4.17.1
+tox==4.18.0
     # via -r requirements/test.txt
 typing-extensions==4.12.2
     # via

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.44.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via -r requirements/pip.in
-setuptools==72.1.0
+setuptools==72.2.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -157,7 +157,7 @@ django-waffle==4.1.0
     #   edx-toggles
 djangoql==0.18.1
     # via -r requirements/base.txt
-djangorestframework==3.14.0
+djangorestframework==3.15.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
@@ -367,7 +367,6 @@ python3-openid==3.2.0
 pytz==2024.1
     # via
     #   -r requirements/base.txt
-    #   djangorestframework
     #   drf-yasg
 pyyaml==6.0.2
     # via
@@ -409,7 +408,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -34,7 +34,7 @@ billiard==4.2.0
     # via
     #   -r requirements/test.txt
     #   celery
-cachetools==5.4.0
+cachetools==5.5.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -199,9 +199,8 @@ django-waffle==4.1.0
     #   edx-toggles
 djangoql==0.18.1
     # via -r requirements/test.txt
-djangorestframework==3.14.0
+djangorestframework==3.15.2
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   django-rest-swagger
     #   djangorestframework-csv
@@ -278,9 +277,9 @@ edx-toggles==5.2.0
     # via
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
-factory-boy==3.3.0
+factory-boy==3.3.1
     # via -r requirements/test.txt
-faker==26.3.0
+faker==27.0.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -513,7 +512,6 @@ python3-openid==3.2.0
 pytz==2024.1
     # via
     #   -r requirements/test.txt
-    #   djangorestframework
     #   drf-yasg
 pyyaml==6.0.2
     # via
@@ -566,7 +564,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
@@ -609,11 +607,11 @@ text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via
     #   -r requirements/test.txt
     #   pylint
-tox==4.17.1
+tox==4.18.0
     # via -r requirements/test.txt
 twine==5.1.1
     # via -r requirements/quality.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -33,7 +33,7 @@ billiard==4.2.0
     # via
     #   -r requirements/base.txt
     #   celery
-cachetools==5.4.0
+cachetools==5.5.0
     # via tox
 celery==5.4.0
     # via
@@ -185,9 +185,8 @@ django-waffle==4.1.0
     #   edx-toggles
 djangoql==0.18.1
     # via -r requirements/base.txt
-djangorestframework==3.14.0
+djangorestframework==3.15.2
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django-rest-swagger
     #   djangorestframework-csv
@@ -260,9 +259,9 @@ edx-toggles==5.2.0
     # via
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
-factory-boy==3.3.0
+factory-boy==3.3.1
     # via -r requirements/test.in
-faker==26.3.0
+faker==27.0.0
     # via factory-boy
 fastavro==1.9.5
     # via
@@ -441,7 +440,6 @@ python3-openid==3.2.0
 pytz==2024.1
     # via
     #   -r requirements/base.txt
-    #   djangorestframework
     #   drf-yasg
 pyyaml==6.0.2
     # via
@@ -482,7 +480,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
@@ -523,9 +521,9 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via pylint
-tox==4.17.1
+tox==4.18.0
     # via -r requirements/test.in
 typing-extensions==4.12.2
     # via

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -42,7 +42,7 @@ billiard==4.2.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
-cachetools==5.4.0
+cachetools==5.5.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -254,7 +254,7 @@ djangoql==0.18.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-djangorestframework==3.14.0
+djangorestframework==3.15.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -364,11 +364,11 @@ edx-toggles==5.2.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
-factory-boy==3.3.0
+factory-boy==3.3.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-faker==26.3.0
+faker==27.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -674,7 +674,6 @@ pytz==2024.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   djangorestframework
     #   drf-yasg
 pyyaml==6.0.2
     # via
@@ -747,7 +746,7 @@ semantic-version==2.10.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -800,12 +799,12 @@ text-unidecode==1.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   python-slugify
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
-tox==4.17.1
+tox==4.18.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
**Description:**
We had pinned DRF because version 3.15.0 was problematic/non-backwards-compatible. That's been fixed in DRF >= 3.15.1

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
