### PR TITLE
feat: include created time in policy api response

### DIFF
--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -190,6 +190,7 @@ class SubsidyAccessPolicyResponseSerializer(serializers.ModelSerializer):
             'group_associations',
             'late_redemption_allowed_until',
             'is_late_redemption_allowed',
+            'created',
         ]
         read_only_fields = fields
 

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -313,6 +313,7 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
             'group_associations': [str(enterprise_group_uuid)],
             'late_redemption_allowed_until': None,
             'is_late_redemption_allowed': False,
+            'created': self.redeemable_policy.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
         }, response.json())
 
     @ddt.data(
@@ -408,6 +409,7 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
                 'group_associations': [],
                 'late_redemption_allowed_until': None,
                 'is_late_redemption_allowed': False,
+                'created': self.non_redeemable_policy.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
             },
             {
                 'access_method': 'direct',
@@ -439,6 +441,7 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
                 'group_associations': [],
                 'late_redemption_allowed_until': None,
                 'is_late_redemption_allowed': False,
+                'created': self.redeemable_policy.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
             },
         ]
 
@@ -540,6 +543,7 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
             'group_associations': [],
             'late_redemption_allowed_until': None,
             'is_late_redemption_allowed': False,
+            'created': self.redeemable_policy.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
         }
         self.assertEqual(expected_response, response.json())
 
@@ -655,6 +659,7 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
             'assignment_configuration': None,
             'group_associations': [],
             'is_late_redemption_allowed': False,
+            'created': policy_for_edit.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
         }
 
         if 'retired' in request_payload:


### PR DESCRIPTION
## Description
include created time in policy api response `api/v1/subsidy-access-policies/?enterprise_customer_uuid=<uuid>`

## Testing instructions
1. Follow the set up steps here https://github.com/openedx/enterprise-access to get the server running
2. checkout this branch with `git fetch -a` and `git checkout knguyen2/ent-9374`
3. visit http://localhost:18270/admin/  and click on any learner credit to get the customer uuid i.e. http://localhost:18270/admin/subsidy_access_policy/assignedlearnercreditaccesspolicy/22424a81-ddda-4af0-a122-aa32b5d624c9/change/
5. copy the customer uuid and paste in the following link: http://localhost:18270/api/v1/subsidy-access-policies/?enterprise_customer_uuid=<CUSTOMER_UUID>
6. verify that you see the created date
![Screenshot 2024-08-19 at 11 08 17 AM](https://github.com/user-attachments/assets/7236573e-3ab9-4c43-890b-c22e2e37fdf6)

**Jira:**
[ENT-9374](https://2u-internal.atlassian.net/browse/ENT-9374)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
