### PR TITLE
feat: failed notifications for assignments leave state as allocated

### DIFF
--- a/enterprise_access/apps/api/serializers/content_assignments/assignment.py
+++ b/enterprise_access/apps/api/serializers/content_assignments/assignment.py
@@ -184,8 +184,12 @@ class LearnerContentAssignmentAdminResponseSerializer(LearnerContentAssignmentRe
         Resolves the error reason for the assignment, if any, for display purposes based on
         any associated actions.
         """
-        # If the assignment is not in an errored state, there should be no error reason.
-        if assignment.state != LearnerContentAssignmentStateChoices.ERRORED:
+        # If the assignment is not in an errored or allocated state,
+        # there should be no error reason.
+        if assignment.state not in (
+            LearnerContentAssignmentStateChoices.ERRORED,
+            LearnerContentAssignmentStateChoices.ALLOCATED,
+        ):
             return None
 
         # Assignment is an errored state, so determine the appropriate error reason so clients don't need to.

--- a/enterprise_access/apps/content_assignments/tasks.py
+++ b/enterprise_access/apps/content_assignments/tasks.py
@@ -458,6 +458,14 @@ class SendNotificationEmailTask(BaseAssignmentRetryAndErrorActionTask):
     def add_errored_action(self, assignment, exc):
         assignment.add_errored_notified_action(exc)
 
+    def progress_state_on_failure(self, assignment):
+        """
+        Skip progressing the assignment state to `failed` (keeping it `allocated`)
+        so that the assignment remains functional and redeemable
+        for learners and appears as actionable to admins.
+        """
+        logger.info('NOT progressing the assignment state to failed for notification failures.')
+
 
 @shared_task(base=SendNotificationEmailTask)
 def send_email_for_new_assignment(new_assignment_uuid):


### PR DESCRIPTION
## Description
When the assignment email notification task fails, the corresponding assignment is now NOT moved to an errored state, but instead left in an allocated state. Furthermore, the admin-serializer for the assignment now indicates a "failed" _learner_ state, and an error reason related to the failed notification attempt.
ENT-9037

## Manual testing
Here's the new response from the serializer after an assignment was allocated, but the resulting notification task failed:
```
{
    "next": null,
    "previous": null,
    "count": 1,
    "num_pages": 1,
    "current_page": 1,
    "start": 0,
    "results": [
        {
            "uuid": "fdaeb538-2d9d-4875-87ca-2973754ed949",
            "assignment_configuration": "a9f97992-4894-4b80-9dde-b08ce3d7bff3",
            "learner_email": "test-failed-notification@example.com",
            "lms_user_id": null,
            "content_key": "edx+DemoX",
            "content_title": "Demonstration Course",
            "content_quantity": -14800,
            "state": "allocated",
            "transaction_uuid": null,
            "actions": [
                {
                    "created": "2024-09-03T19:42:04.877357Z",
                    "modified": "2024-09-03T19:42:04.877380Z",
                    "uuid": "fca9d15b-8a41-4353-a84e-5b9795f5f5a8",
                    "action_type": "notified",
                    "completed_at": null,
                    "error_reason": "email_error"
                },
                {
                    "created": "2024-09-03T19:42:04.898243Z",
                    "modified": "2024-09-03T19:42:04.898263Z",
                    "uuid": "525b77c0-9466-4faa-b729-055a8d73a40e",
                    "action_type": "learner_linked",
                    "completed_at": "2024-09-03T19:42:04.897991Z",
                    "error_reason": null
                }
            ],
            "earliest_possible_expiration": {
                "date": "2024-12-02T19:42:04Z",
                "reason": "NINETY_DAYS_PASSED"
            },
            "recent_action": {
                "action_type": "assigned",
                "timestamp": "2024-09-03T19:42:04Z"
            },
            "learner_state": "failed",
            "error_reason": {
                "action_type": "notified",
                "error_reason": "email_error"
            }
        }
    ],
    "learner_state_counts": [
        {
            "learner_state": "failed",
            "count": 1
        }
    ]
}
```
This leaves the admin-portal assignment table in a state where the assignment is visible to the admin with an indication of what has gone wrong and how to work around it:
![image](https://github.com/user-attachments/assets/a923a337-afe2-4838-a06d-47dd724f76d9)

Furthermore, since the assignment record's state is still `allocated`, the assigned course is visible and actionable to the learner from the learner portal MFE:
<img width="1458" alt="image" src="https://github.com/user-attachments/assets/e1b24a39-0353-411b-88b7-cc2307c4f2f5">


**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
