### PR TITLE
feat: support course run based assignments in credits_available, expiration, emails, etc.

### DIFF
--- a/enterprise_access/apps/api/v1/tests/test_allocation_view.py
+++ b/enterprise_access/apps/api/v1/tests/test_allocation_view.py
@@ -65,7 +65,8 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
     def setUpTestData(cls):
         super().setUpTestData()
         cls.enterprise_uuid = TEST_ENTERPRISE_UUID
-        cls.content_key = 'course-v1:edX+edXPrivacy101+3T2020'
+        cls.content_key = 'course-v1:edX+Privacy101+3T2020'
+        cls.parent_content_key = 'edX+Privacy101'
         cls.content_title = 'edx: Privacy 101'
 
         # Create a pair of AssignmentConfiguration + SubsidyAccessPolicy for the main test customer.
@@ -85,6 +86,8 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
             learner_email='alice@foo.com',
             lms_user_id=None,
             content_key=cls.content_key,
+            parent_content_key=cls.parent_content_key,
+            is_assigned_course_run=True,
             content_title=cls.content_title,
             content_quantity=-123,
             state=LearnerContentAssignmentStateChoices.ERRORED,
@@ -94,6 +97,8 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
             learner_email='bob@foo.com',
             lms_user_id=None,
             content_key=cls.content_key,
+            parent_content_key=cls.parent_content_key,
+            is_assigned_course_run=True,
             content_title=cls.content_title,
             content_quantity=-456,
             state=LearnerContentAssignmentStateChoices.ALLOCATED,
@@ -103,6 +108,8 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
             learner_email='carol@foo.com',
             lms_user_id=None,
             content_key=cls.content_key,
+            parent_content_key=cls.parent_content_key,
+            is_assigned_course_run=True,
             content_title=cls.content_title,
             content_quantity=-789,
             state=LearnerContentAssignmentStateChoices.ALLOCATED,
@@ -150,13 +157,13 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
         },
         {
             'learner_emails': ['everything-valid@example.com'],
-            'content_key': 'course-v1:edX+edXPrivacy101+3T2020',  # valid course run key
+            'content_key': 'course-v1:edX+Privacy101+3T2020',  # valid course run key
             'content_price_cents': 100,
             'error_regex': '',
         },
         {
             'learner_emails': ['everything-valid@example.com'],
-            'content_key': 'course-v1:edX+edXPrivacy101+3T2020',  # valid course run key
+            'content_key': 'course-v1:edX+Privacy101+3T2020',  # valid course run key
             'content_price_cents': -100,
             'error_regex': 'Ensure this value is greater than or equal to 0',
         },
@@ -221,7 +228,6 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
         }
 
         response = self.client.post(allocate_url, data=allocate_payload)
-
         self.assertEqual(status.HTTP_202_ACCEPTED, response.status_code)
         expected_response_payload = {
             'updated': [
@@ -230,8 +236,8 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
                     'learner_email': 'alice@foo.com',
                     'lms_user_id': None,
                     'content_key': self.content_key,
-                    'parent_content_key': None,
-                    'is_assigned_course_run': False,
+                    'parent_content_key': self.parent_content_key,
+                    'is_assigned_course_run': True,
                     'content_title': self.content_title,
                     'content_quantity': -123,
                     'state': LearnerContentAssignmentStateChoices.ERRORED,
@@ -252,8 +258,8 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
                     'learner_email': 'bob@foo.com',
                     'lms_user_id': None,
                     'content_key': self.content_key,
-                    'parent_content_key': None,
-                    'is_assigned_course_run': False,
+                    'parent_content_key': self.parent_content_key,
+                    'is_assigned_course_run': True,
                     'content_title': self.content_title,
                     'content_quantity': -456,
                     'state': LearnerContentAssignmentStateChoices.ALLOCATED,
@@ -274,8 +280,8 @@ class TestSubsidyAccessPolicyAllocationView(APITestWithMocks):
                     'learner_email': 'carol@foo.com',
                     'lms_user_id': None,
                     'content_key': self.content_key,
-                    'parent_content_key': None,
-                    'is_assigned_course_run': False,
+                    'parent_content_key': self.parent_content_key,
+                    'is_assigned_course_run': True,
                     'content_title': self.content_title,
                     'content_quantity': -789,
                     'state': LearnerContentAssignmentStateChoices.ALLOCATED,

--- a/enterprise_access/apps/api/v1/tests/test_assignment_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_assignment_views.py
@@ -823,6 +823,14 @@ class TestAdminAssignmentAuthorizedCRUD(CRUDViewTestMixin, APITest):
                     'enroll_by_date': enrollment_end.strftime("%Y-%m-%dT%H:%M:%SZ"),
                     'content_price': self.content_metadata_one['content_quantity'],
                 },
+                'normalized_metadata_by_run': {
+                    self.content_metadata_one['content_key']: {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        'end_date': end_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        'enroll_by_date': enrollment_end.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        'content_price': self.content_metadata_one['content_quantity'],
+                    },
+                },
                 'course_type': 'executive-education-2u',
             },
         }

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -1097,7 +1097,7 @@ class TestPolicyRedemptionAuthNAndPermissionChecks(APITestWithMocks):
         url = reverse('api:v1:policy-redemption-redeem', kwargs={'policy_uuid': self.redeemable_policy.uuid})
         payload = {
             'lms_user_id': 1234,
-            'content_key': 'course-v1:edX+edXPrivacy101+3T2020',
+            'content_key': 'course-v1:edX+Privacy101+3T2020',
         }
         response = self.client.post(url, payload)
         self.assertEqual(response.status_code, expected_response_code)
@@ -1116,7 +1116,7 @@ class TestPolicyRedemptionAuthNAndPermissionChecks(APITestWithMocks):
             kwargs={"enterprise_customer_uuid": self.enterprise_uuid},
         )
         query_params = {
-            'content_key': ['course-v1:edX+edXPrivacy101+3T2020', 'course-v1:edX+edXPrivacy101+3T2020_2'],
+            'content_key': ['course-v1:edX+Privacy101+3T2020', 'course-v1:edX+Privacy101+3T2020_2'],
         }
         response = self.client.get(url, query_params)
         self.assertEqual(response.status_code, expected_response_code)
@@ -1223,7 +1223,7 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
         self.redeemable_policy.subsidy_client.create_subsidy_transaction.return_value = mock_transaction_record
         payload = {
             'lms_user_id': 1234,
-            'content_key': 'course-v1:edX+edXPrivacy101+3T2020',
+            'content_key': 'course-v1:edX+Privacy101+3T2020',
         }
 
         response = self.client.post(self.subsidy_access_policy_redeem_endpoint, payload)
@@ -1261,7 +1261,7 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
         self.redeemable_policy.subsidy_client.create_subsidy_transaction.return_value = mock_transaction_record
         payload = {
             'lms_user_id': 1234,
-            'content_key': 'course-v1:edX+edXPrivacy101+3T2020',
+            'content_key': 'course-v1:edX+Privacy101+3T2020',
             'metadata': {
                 'geag_first_name': 'John'
             }
@@ -1335,7 +1335,7 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
         self.mock_get_content_metadata.return_value = {'content_price': 5000}
 
         lms_user_id = 1234
-        content_key = 'course-v1:edX+edXPrivacy101+3T2020'
+        content_key = 'course-v1:edX+Privacy101+3T2020'
         historical_redemption_uuid = str(uuid4())
         baseline_idempotency_key = create_idempotency_key_for_transaction(
             subsidy_uuid=str(self.redeemable_policy.subsidy_uuid),
@@ -1559,7 +1559,6 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
         Verify that SubsidyAccessPolicyViewset credits_available returns learner content assignments for assigned
         learner credit access policies.
         """
-        self.maxDiff = None
         parent_content_key = 'edX+DemoX'
         content_key = 'course-v1:edX+DemoX+T2024a'
         content_title = 'edx: Demo 101'
@@ -1621,12 +1620,20 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
         # Mock catalog content metadata results. See LearnerContentAssignmentWithContentMetadataResponseSerializer
         # for what we expect to be in the response payload w.r.t. content metadata.
         mock_content_metadata = {
-            'key': content_key,
+            'key': parent_content_key,
             'normalized_metadata': {
                 'start_date': '2020-01-01T12:00:00Z',
                 'end_date': '2022-01-01T12:00:00Z',
                 'enroll_by_date': '2021-01-01T12:00:00Z',
                 'content_price': content_price_cents,
+            },
+            'normalized_metadata_by_run': {
+                content_key: {
+                    'start_date': '2020-01-01T12:00:00Z',
+                    'end_date': '2022-01-01T12:00:00Z',
+                    'enroll_by_date': '2021-01-01T12:00:00Z',
+                    'content_price': content_price_cents,
+                },
             },
             'course_type': 'verified-audit',
             'owners': [
@@ -1835,8 +1842,8 @@ class TestSubsidyAccessPolicyCanRedeemView(BaseCanRedeemTestMixin, APITestWithMo
                 'total_quantity': 0,
             },
         }
-        test_content_key_1 = "course-v1:edX+edXPrivacy101+3T2020"
-        test_content_key_2 = "course-v1:edX+edXPrivacy101+3T2020_2"
+        test_content_key_1 = "course-v1:edX+Privacy101+3T2020"
+        test_content_key_2 = "course-v1:edX+Privacy101+3T2020_2"
         test_content_key_1_metadata_price = 29900
         test_content_key_2_metadata_price = 81900
         test_content_key_1_usd_price = 299
@@ -1947,8 +1954,8 @@ class TestSubsidyAccessPolicyCanRedeemView(BaseCanRedeemTestMixin, APITestWithMo
             'unit': 'usd_cents',
             'all_transactions': [],
         }
-        test_content_key_1 = "course-v1:edX+edXPrivacy101+3T2020"
-        test_content_key_2 = "course-v1:edX+edXPrivacy101+3T2020_2"
+        test_content_key_1 = "course-v1:edX+Privacy101+3T2020"
+        test_content_key_2 = "course-v1:edX+Privacy101+3T2020_2"
         test_content_key_1_metadata_price = 29900
         test_content_key_2_metadata_price = 81900
 

--- a/enterprise_access/apps/api_client/enterprise_catalog_client.py
+++ b/enterprise_access/apps/api_client/enterprise_catalog_client.py
@@ -65,7 +65,7 @@ class EnterpriseCatalogApiClient(BaseOAuthClient):
             'traverse_pagination': traverse_pagination,
             **kwargs,
         }
-        endpoint = f'{self.enterprise_catalog_endpoint}{str(catalog_uuid)}/get_content_metadata/'
+        endpoint = f'{self.enterprise_catalog_endpoint}{catalog_uuid}/get_content_metadata/'
 
         response = self.client.get(endpoint, params=query_params)
         response.raise_for_status()

--- a/enterprise_access/apps/api_client/enterprise_catalog_client.py
+++ b/enterprise_access/apps/api_client/enterprise_catalog_client.py
@@ -65,7 +65,7 @@ class EnterpriseCatalogApiClient(BaseOAuthClient):
             'traverse_pagination': traverse_pagination,
             **kwargs,
         }
-        endpoint = self.enterprise_catalog_endpoint + str(catalog_uuid) + '/get_content_metadata/'
+        endpoint = f'{self.enterprise_catalog_endpoint}{str(catalog_uuid)}/get_content_metadata/'
 
         response = self.client.get(endpoint, params=query_params)
         response.raise_for_status()

--- a/enterprise_access/apps/content_assignments/api.py
+++ b/enterprise_access/apps/content_assignments/api.py
@@ -23,7 +23,12 @@ from enterprise_access.apps.content_assignments.tasks import (
 )
 from enterprise_access.apps.core.models import User
 from enterprise_access.apps.subsidy_access_policy.content_metadata_api import get_and_cache_content_metadata
-from enterprise_access.utils import chunks, get_automatic_expiration_date_and_reason, localized_utcnow
+from enterprise_access.utils import (
+    chunks,
+    get_automatic_expiration_date_and_reason,
+    get_normalized_metadata_for_assignment,
+    localized_utcnow
+)
 
 from .constants import AssignmentAutomaticExpiredReason, LearnerContentAssignmentStateChoices
 from .models import AssignmentConfiguration, LearnerContentAssignment
@@ -761,8 +766,13 @@ def nudge_assignments(assignments, assignment_configuration_uuid, days_before_co
             enterprise_catalog_uuid,
             [assignment],
         )
+        print('content_metadata_for_assignments?!?!', content_metadata_for_assignments)
         content_metadata = content_metadata_for_assignments.get(assignment.content_key, {})
-        start_date = content_metadata.get('normalized_metadata', {}).get('start_date')
+        print('content_metadata?!?!', content_metadata)
+        normalized_metadata = get_normalized_metadata_for_assignment(assignment, content_metadata)
+        print('normalized_metadata?!?!', normalized_metadata)
+
+        start_date = normalized_metadata.get('start_date')
         course_type = content_metadata.get('course_type')
 
         # check if the course_type is an executive-education course

--- a/enterprise_access/apps/content_assignments/api.py
+++ b/enterprise_access/apps/content_assignments/api.py
@@ -766,11 +766,8 @@ def nudge_assignments(assignments, assignment_configuration_uuid, days_before_co
             enterprise_catalog_uuid,
             [assignment],
         )
-        print('content_metadata_for_assignments?!?!', content_metadata_for_assignments)
         content_metadata = content_metadata_for_assignments.get(assignment.content_key, {})
-        print('content_metadata?!?!', content_metadata)
         normalized_metadata = get_normalized_metadata_for_assignment(assignment, content_metadata)
-        print('normalized_metadata?!?!', normalized_metadata)
 
         start_date = normalized_metadata.get('start_date')
         course_type = content_metadata.get('course_type')

--- a/enterprise_access/apps/content_assignments/content_metadata_api.py
+++ b/enterprise_access/apps/content_assignments/content_metadata_api.py
@@ -17,23 +17,6 @@ DATE_INPUT_PATTERNS = [
 DEFAULT_STRFTIME_PATTERN = '%b %d, %Y'
 
 
-def _process_course_metadata(course_metadata, is_run_based_by_content_key, metadata_by_key):
-    """
-    Helper function to update the metadata_by_key dictionary with the course metadata based on
-    either a course run key (for run-based assignments) or a course key.
-    """
-    course_key = course_metadata.get('key')
-
-    # If a course run is assigned, update the metadata for the course run key. Otherwise,
-    # update the metadata for the course key.
-    for assignment_content_key, is_assigned_course_run in is_run_based_by_content_key.items():
-        if is_assigned_course_run:
-            metadata_by_key[assignment_content_key] = course_metadata
-        else:
-            # if not is_assigned_course_run, we can assume it's a (legacy) course-based assignment
-            metadata_by_key[course_key] = course_metadata
-
-
 def get_content_metadata_for_assignments(enterprise_catalog_uuid, assignments):
     """
     Fetches (from cache or enterprise-catalog API call) content metadata
@@ -48,18 +31,9 @@ def get_content_metadata_for_assignments(enterprise_catalog_uuid, assignments):
         to a content metadata dictionary, or null if no such dictionary
         could be found for a given key.
     """
-    is_run_based_by_content_key = {
-        assignment.content_key: assignment.is_assigned_course_run
-        for assignment in assignments
-    }
-    content_metadata_list = get_and_cache_catalog_content_metadata(
-        enterprise_catalog_uuid,
-        is_run_based_by_content_key.keys()
-    )
-    metadata_by_key = {}
-    for course_metadata in content_metadata_list:
-        _process_course_metadata(course_metadata, is_run_based_by_content_key, metadata_by_key)
-
+    content_keys = {assignment.content_key for assignment in assignments}
+    content_metadata_list = get_and_cache_catalog_content_metadata(enterprise_catalog_uuid, content_keys)
+    metadata_by_key = dict(zip(content_keys, content_metadata_list))
     return {
         assignment.content_key: metadata_by_key.get(assignment.content_key)
         for assignment in assignments

--- a/enterprise_access/apps/content_assignments/content_metadata_api.py
+++ b/enterprise_access/apps/content_assignments/content_metadata_api.py
@@ -54,10 +54,7 @@ def get_content_metadata_for_assignments(enterprise_catalog_uuid, assignments):
         assignment.content_key: _content_metadata_for_assignment(assignment, course_metadata_list)
         for assignment in assignments
     }
-    return {
-        assignment.content_key: metadata_by_key.get(assignment.content_key)
-        for assignment in assignments
-    }
+    return metadata_by_key
 
 
 def get_card_image_url(content_metadata):

--- a/enterprise_access/apps/content_assignments/content_metadata_api.py
+++ b/enterprise_access/apps/content_assignments/content_metadata_api.py
@@ -23,22 +23,28 @@ def get_content_metadata_for_assignments(enterprise_catalog_uuid, assignments):
     in bulk for the `content_keys` of the given assignments, provided
     such metadata is related to the given `enterprise_catalog_uuid`.
 
+    Note that the `content_keys` of the provided assignments may be
+    either course run keys or course keys.
+
     Returns:
         A dict mapping every content key of the provided assignments
         to a content metadata dictionary, or null if no such dictionary
         could be found for a given key.
     """
-    content_keys = {
-        (assignment.content_key, assignment.is_assigned_course_run)
+    is_run_based_by_content_key = {
+        assignment.content_key: assignment.is_assigned_course_run
         for assignment in assignments
     }
-    content_metadata_list = get_and_cache_catalog_content_metadata(enterprise_catalog_uuid, content_keys)
+    content_metadata_list = get_and_cache_catalog_content_metadata(
+        enterprise_catalog_uuid,
+        is_run_based_by_content_key.keys()
+    )
     metadata_by_key = {}
     for record in content_metadata_list:
         record_key = record.get('key')
 
         # Now, check if the record_key matches either the content_key or parent_content_key in the original content_keys
-        for content_key, is_assigned_course_run in content_keys:
+        for content_key, is_assigned_course_run in is_run_based_by_content_key.items():
             if is_assigned_course_run:
                 metadata_by_key.update({
                     content_key: record

--- a/enterprise_access/apps/content_assignments/content_metadata_api.py
+++ b/enterprise_access/apps/content_assignments/content_metadata_api.py
@@ -24,7 +24,8 @@ def get_content_metadata_for_assignments(enterprise_catalog_uuid, assignments):
     such metadata is related to the given `enterprise_catalog_uuid`.
 
     Note that the `content_keys` of the provided assignments may be
-    either course run keys or course keys.
+    either course run keys or course keys. Regardless of the type of key,
+    the content metadata API will return the metadata at the course-level.
 
     Returns:
         A dict mapping every content key of the provided assignments

--- a/enterprise_access/apps/content_assignments/management/commands/automatically_nudge_assignments.py
+++ b/enterprise_access/apps/content_assignments/management/commands/automatically_nudge_assignments.py
@@ -168,7 +168,7 @@ class Command(BaseCommand):
                             target_datetime=datetime_start_date,
                             num_days=days_before_course_start_date
                         )
-                        if start_date is not None
+                        if datetime_start_date is not None
                         else False
                     )
                     if not can_send_nudge_notification_in_advance:

--- a/enterprise_access/apps/content_assignments/management/commands/tests/test_automatically_nudge_assignments.py
+++ b/enterprise_access/apps/content_assignments/management/commands/tests/test_automatically_nudge_assignments.py
@@ -219,62 +219,74 @@ class TestAutomaticallyNudgeAssignmentCommand(TestCase):
         mock_content_metadata_for_assignments.return_value = {
             'edX+edXAccessibility101': {
                 'key': 'edX+edXAccessibility101',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXAccessibility101+1T2022',
-                        'start': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                'normalized_metadata': {
+                    'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXAccessibility101+1T2022': {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
                     },
-                ],
+                },
                 'course_type': 'executive-education-2u',
             },
             'edX+edXPrivacy101': {
                 'key': 'edX+edXPrivacy101',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXPrivacy101+1T2022',
-                        'start': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                'normalized_metadata': {
+                    'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXPrivacy101+1T2022': {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
                     },
-                ],
+                },
                 'course_type': 'executive-education-2u',
             },
             'edX+edXTesseract4D': {
                 'key': 'edX+edXTesseract4D',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXTesseract4D+1T2022',
-                        'start': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                'normalized_metadata': {
+                    'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXTesseract4D+1T2022': {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
                     },
-                ],
+                },
                 'course_type': 'executive-education-2u',
             },
             'edX+edXQuadrilateral306090': {
                 'key': 'edX+edXQuadrilateral306090',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXQuadrilateral306090+1T2022',
-                        'start': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                'normalized_metadata': {
+                    'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXQuadrilateral306090+1T2022': {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
                     },
-                ],
+                },
                 'course_type': 'executive-education-2u',
             },
             'edX+edXIsoscelesPyramid2012': {
                 'key': 'edX+edXIsoscelesPyramid2012',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXIsoscelesPyramid2012+1T2022',
-                        'start': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                'normalized_metadata': {
+                    'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXIsoscelesPyramid2012+1T2022': {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
                     },
-                ],
+                },
                 'course_type': 'executive-education-2u',
             },
             'edX+edXBeeHivesAlive0220': {
                 'key': 'edX+edXBeeHivesAlive0220',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXBeeHivesAlive0220+1T2022',
-                        'start': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                'normalized_metadata': {
+                    'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXBeeHivesAlive0220+1T2022': {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
                     },
-                ],
+                },
                 'course_type': 'executive-education-2u',
             },
         }
@@ -321,32 +333,38 @@ class TestAutomaticallyNudgeAssignmentCommand(TestCase):
         mock_content_metadata_for_assignments.return_value = {
             'edX+edXAccessibility101': {
                 'key': 'edX+edXAccessibility101',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXAccessibility101+1T2022',
-                        'start': start_date_between_30_and_14_days.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    },
-                ],
                 'course_type': 'executive-education-2u',
+                'normalized_metadata': {
+                    'start_date': start_date_between_30_and_14_days.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXAccessibility101+1T2022': {
+                        'start_date': start_date_between_30_and_14_days.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    },
+                },
             },
             'edX+edXTesseract4D': {
                 'key': 'edX+edXTesseract4D',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXTesseract4D+1T2022',
-                        'start': start_date_already_started.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    },
-                ],
                 'course_type': 'executive-education-2u',
+                'normalized_metadata': {
+                    'start_date': start_date_already_started.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXTesseract4D+1T2022': {
+                        'start_date': start_date_already_started.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    },
+                },
             },
             'edX+edXQuadrilateral306090': {
                 'key': 'edX+edXQuadrilateral306090',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXQuadrilateral306090+1T2022',
-                        'start': start_date_beyond_30_days.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                'normalized_metadata': {
+                    'start_date': start_date_beyond_30_days.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXQuadrilateral306090+1T2022': {
+                        'start_date': start_date_beyond_30_days.strftime("%Y-%m-%dT%H:%M:%SZ"),
                     },
-                ],
+                },
                 'course_type': 'executive-education-2u',
             },
             'edX+edXPrivacy101': {
@@ -358,16 +376,26 @@ class TestAutomaticallyNudgeAssignmentCommand(TestCase):
                     },
                 ],
                 'course_type': 'executive-education-2u',
+                'normalized_metadata': {
+                    'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXPrivacy101+1T2022': {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    },
+                },
             },
             'edX+edXIsoscelesPyramid2012': {
                 'key': 'edX+edXIsoscelesPyramid2012',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXIsoscelesPyramid2012+1T2022',
-                        'start': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    },
-                ],
                 'course_type': 'executive-education-2u',
+                'normalized_metadata': {
+                    'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXIsoscelesPyramid2012+1T2022': {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    },
+                },
             },
             'edX+edXBeeHivesAlive0220': {
                 'key': 'edX+edXBeeHivesAlive0220',
@@ -378,6 +406,14 @@ class TestAutomaticallyNudgeAssignmentCommand(TestCase):
                     },
                 ],
                 'course_type': 'executive-education-2u',
+                'normalized_metadata': {
+                    'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXBeeHivesAlive0220+1T2022': {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    },
+                },
             },
         }
 
@@ -412,63 +448,75 @@ class TestAutomaticallyNudgeAssignmentCommand(TestCase):
         mock_content_metadata_for_assignments.return_value = {
             'edX+edXAccessibility101': {
                 'key': 'edX+edXAccessibility101',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXAccessibility101+1T2022',
-                        'start': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    },
-                ],
                 'course_type': 'verified-audit',
+                'normalized_metadata': {
+                    'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXAccessibility101+1T2022': {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    },
+                },
             },
             'edX+edXPrivacy101': {
                 'key': 'edX+edXPrivacy101',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXPrivacy101+1T2022',
-                        'start': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    },
-                ],
                 'course_type': 'executive-education-2u',
+                'normalized_metadata': {
+                    'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXPrivacy101+1T2022': {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    },
+                },
             },
             'edX+edXTesseract4D': {
                 'key': 'edX+edXTesseract4D',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXTesseract4D+1T2022',
-                        'start': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    },
-                ],
                 'course_type': 'professional',
+                'normalized_metadata': {
+                    'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXTesseract4D+1T2022': {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    },
+                },
             },
             'edX+edXQuadrilateral306090': {
                 'key': 'edX+edXQuadrilateral306090',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXQuadrilateral306090+1T2022',
-                        'start': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    },
-                ],
                 'course_type': 'bootcamp-2u',
+                'normalized_metadata': {
+                    'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXQuadrilateral306090+1T2022': {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    },
+                },
             },
             'edX+edXIsoscelesPyramid2012': {
                 'key': 'edX+edXIsoscelesPyramid2012',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXIsoscelesPyramid2012+1T2022',
-                        'start': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    },
-                ],
                 'course_type': 'executive-education-2u',
+                'normalized_metadata': {
+                    'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXIsoscelesPyramid2012+1T2022': {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    },
+                },
             },
             'edX+edXBeeHivesAlive0220': {
                 'key': 'edX+edXBeeHivesAlive0220',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXBeeHivesAlive0220+1T2022',
-                        'start': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    },
-                ],
                 'course_type': 'executive-education-2u',
+                'normalized_metadata': {
+                    'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXBeeHivesAlive0220+1T2022': {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    },
+                },
             },
         }
 
@@ -505,63 +553,75 @@ class TestAutomaticallyNudgeAssignmentCommand(TestCase):
         mock_content_metadata_for_assignments.return_value = {
             'edX+edXAccessibility101': {
                 'key': 'edX+edXAccessibility101',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXAccessibility101+1T2022',
-                        'start': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    },
-                ],
                 'course_type': 'executive-education-2u',
+                'normalized_metadata': {
+                    'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXAccessibility101+1T2022': {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    },
+                },
             },
             'edX+edXTesseract4D': {
                 'key': 'edX+edXTesseract4D',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXTesseract4D+1T2022',
-                        'start': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    },
-                ],
                 'course_type': 'executive-education-2u',
+                'normalized_metadata': {
+                    'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXTesseract4D+1T2022': {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    },
+                },
             },
             'edX+edXQuadrilateral306090': {
                 'key': 'edX+edXQuadrilateral306090',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXQuadrilateral306090+1T2022',
-                        'start': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    },
-                ],
                 'course_type': 'executive-education-2u',
+                'normalized_metadata': {
+                    'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXQuadrilateral306090+1T2022': {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    },
+                },
             },
             'edX+edXPrivacy101': {
                 'key': 'edX+edXPrivacy101',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXPrivacy101+1T2022',
-                        'start': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    },
-                ],
                 'course_type': 'executive-education-2u',
+                'normalized_metadata': {
+                    'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXPrivacy101+1T2022': {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    },
+                },
             },
             'edX+edXIsoscelesPyramid2012': {
                 'key': 'edX+edXIsoscelesPyramid2012',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXIsoscelesPyramid2012+1T2022',
-                        'start': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    },
-                ],
                 'course_type': 'executive-education-2u',
+                'normalized_metadata': {
+                    'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXIsoscelesPyramid2012+1T2022': {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    },
+                },
             },
             'edX+edXBeeHivesAlive0220': {
                 'key': 'edX+edXBeeHivesAlive0220',
-                'course_runs': [
-                    {
-                        'key': 'course-v1:edX+edXBeeHivesAlive0220+1T2022',
-                        'start': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    },
-                ],
                 'course_type': 'executive-education-2u',
+                'normalized_metadata': {
+                    'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                'normalized_metadata_by_run': {
+                    'course-v1:edX+edXBeeHivesAlive0220+1T2022': {
+                        'start_date': start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    },
+                },
             },
         }
 
@@ -688,6 +748,7 @@ class TestAutomaticallyNudgeAssignmentCommand2(TestCase):
             learner_email='alice@foo.com',
             lms_user_id=None,
             content_key=self.COURSE_KEY,
+            is_assigned_course_run=False,
             preferred_course_run_key=assignment_preferred_course_run_key,
             content_title='edx: Privacy 101',
             content_quantity=-123,
@@ -700,11 +761,15 @@ class TestAutomaticallyNudgeAssignmentCommand2(TestCase):
             mock_content_metadata_for_assignments.return_value = {
                 self.COURSE_KEY: {
                     'key': self.COURSE_KEY,
-                    'course_runs': [{
-                        'key': self.COURSE_RUN_KEY,
-                        'start': course_start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    }],
                     'course_type': course_type,
+                    'normalized_metadata': {
+                        'start_date': course_start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    },
+                    'normalized_metadata_by_run': {
+                        self.COURSE_RUN_KEY: {
+                            'start_date': course_start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        },
+                    },
                 },
             }
         call_command(self.command, days_before_course_start_date=14)

--- a/enterprise_access/apps/content_assignments/tests/factories.py
+++ b/enterprise_access/apps/content_assignments/tests/factories.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 import factory
 from faker import Faker
 
-from test_utils import random_content_key
+from test_utils import random_content_key, random_parent_content_key
 
 from ..models import AssignmentConfiguration, LearnerContentAssignment
 
@@ -37,5 +37,6 @@ class LearnerContentAssignmentFactory(factory.django.DjangoModelFactory):
     learner_email = factory.LazyAttribute(lambda _: FAKER.email())
     lms_user_id = factory.LazyAttribute(lambda _: FAKER.pyint())
     content_key = factory.LazyAttribute(lambda _: random_content_key())
+    parent_content_key = factory.LazyAttribute(lambda _: random_parent_content_key())
     content_title = factory.LazyAttribute(lambda _: f'{FAKER.word()}: a master class')
     content_quantity = factory.LazyAttribute(lambda _: FAKER.pyfloat(positive=False, right_digits=0))

--- a/enterprise_access/apps/content_assignments/tests/test_api.py
+++ b/enterprise_access/apps/content_assignments/tests/test_api.py
@@ -626,7 +626,7 @@ class TestAssignmentExpiration(TestCase):
             spend_limit=1000000,
         )
 
-    def mock_content_metadata(self, content_key, enroll_by_date):
+    def mock_content_metadata(self, content_key, course_run_key, enroll_by_date):
         """
         Helper to produce content metadata with a given enroll_by_date.
         """
@@ -634,6 +634,11 @@ class TestAssignmentExpiration(TestCase):
             'key': content_key,
             'normalized_metadata': {
                 'enroll_by_date': enroll_by_date,
+            },
+            'normalized_metadata_by_run': {
+                course_run_key: {
+                    'enroll_by_date': enroll_by_date,
+                },
             },
         }
 
@@ -652,7 +657,7 @@ class TestAssignmentExpiration(TestCase):
         with mock.patch.object(self.policy, 'subsidy_record', return_value=mock_subsidy_record):
             expire_assignment(
                 assignment,
-                content_metadata=self.mock_content_metadata('edX+DemoX', None),
+                content_metadata=self.mock_content_metadata('edX+DemoX', 'course-v1:edX+DemoX+T2024', None),
                 modify_assignment=True,
             )
 
@@ -682,7 +687,11 @@ class TestAssignmentExpiration(TestCase):
         with mock.patch.object(self.policy, 'subsidy_record', return_value=mock_subsidy_record):
             expire_assignment(
                 assignment,
-                content_metadata=self.mock_content_metadata('edX+DemoX', delta_t(days=100, as_string=True)),
+                content_metadata=self.mock_content_metadata(
+                    'edX+DemoX',
+                    'course-v1:edX+DemoX+T2024',
+                    delta_t(days=100, as_string=True)
+                ),
                 modify_assignment=True,
             )
 
@@ -719,7 +728,7 @@ class TestAssignmentExpiration(TestCase):
         with mock.patch.object(self.policy, 'subsidy_record', return_value=mock_subsidy_record):
             expire_assignment(
                 assignment,
-                content_metadata=self.mock_content_metadata('edX+DemoX', None),
+                content_metadata=self.mock_content_metadata('edX+DemoX', 'course-v1:edX+DemoX+T2024', None),
                 modify_assignment=True,
             )
 
@@ -747,7 +756,8 @@ class TestAssignmentExpiration(TestCase):
         """
         Tests that we expire assignments with a passed enroll_by_date
         """
-        content_key = 'demoX'
+        content_key = 'edX+DemoX'
+        course_run_key = 'course-v1:edX+DemoX+T2024'
         assignment = LearnerContentAssignmentFactory.create(
             content_key='demoX',
             assignment_configuration=self.assignment_configuration,
@@ -760,6 +770,7 @@ class TestAssignmentExpiration(TestCase):
         # create expired content metadata
         mock_content_metadata = self.mock_content_metadata(
             content_key=content_key,
+            course_run_key=course_run_key,
             enroll_by_date=delta_t(days=-1, as_string=True),
         )
 
@@ -792,7 +803,8 @@ class TestAssignmentExpiration(TestCase):
         """
         Tests that we expire assignments with an underlying subsidy that has expired.
         """
-        content_key = 'demoX'
+        content_key = 'edX+DemoX'
+        course_run_key = 'course-v1:edX+DemoX+T2024'
         assignment = LearnerContentAssignmentFactory.create(
             assignment_configuration=self.assignment_configuration,
             content_key=content_key,
@@ -805,6 +817,7 @@ class TestAssignmentExpiration(TestCase):
         # create non-expired content metadata
         mock_content_metadata = self.mock_content_metadata(
             content_key=content_key,
+            course_run_key=course_run_key,
             enroll_by_date=delta_t(days=100, as_string=True),
         )
 

--- a/enterprise_access/utils.py
+++ b/enterprise_access/utils.py
@@ -120,7 +120,7 @@ def get_automatic_expiration_date_and_reason(
 
     Arguments:
         assignment (LearnerContentAssignment): The assignment to check for expiration.
-        [metadata_for_assignment] (dict): Content metadata for the assignment's content key. If not provided, it will be
+        [content_metadata] (dict): Content metadata for the assignment's content key. If not provided, it will be
             fetched and subsequently cached from the content metadata API.
     """
     assignment_configuration = assignment.assignment_configuration

--- a/enterprise_access/utils.py
+++ b/enterprise_access/utils.py
@@ -83,14 +83,14 @@ def _get_subsidy_expiration(assignment):
     return subsidy_expiration_datetime
 
 
-def _get_enrollment_deadline_date(content_metadata):
+def _get_enrollment_deadline_date(assignment, content_metadata):
     """
     Helper to get the enrollment end date from a content metadata record.
     """
     if not content_metadata:
         return None
 
-    normalized_metadata = content_metadata.get('normalized_metadata') or {}
+    normalized_metadata = get_normalized_metadata_for_assignment(assignment, content_metadata)
     enrollment_end_date_str = normalized_metadata.get('enroll_by_date')
     try:
         datetime_obj = parse_datetime_string(enrollment_end_date_str)
@@ -120,7 +120,7 @@ def get_automatic_expiration_date_and_reason(
 
     Arguments:
         assignment (LearnerContentAssignment): The assignment to check for expiration.
-        [content_metadata] (dict): Content metadata for the assignment's content key. If not provided, it will be
+        [metadata_for_assignment] (dict): Content metadata for the assignment's content key. If not provided, it will be
             fetched and subsequently cached from the content metadata API.
     """
     assignment_configuration = assignment.assignment_configuration
@@ -138,7 +138,7 @@ def get_automatic_expiration_date_and_reason(
             assignments=[assignment],
         )
         content_metadata = content_metadata_by_key.get(content_key)
-    enrollment_deadline_datetime = _get_enrollment_deadline_date(content_metadata)
+    enrollment_deadline_datetime = _get_enrollment_deadline_date(assignment, content_metadata)
     if enrollment_deadline_datetime:
         enrollment_deadline_datetime = enrollment_deadline_datetime.replace(tzinfo=UTC)
 
@@ -209,3 +209,23 @@ def should_send_email_to_pecu(recent_action):
         is_65_days_since_invited or
         is_85_days_since_invited
     )
+
+
+def get_normalized_metadata_for_assignment(assignment, content_metadata):
+    """
+    Retrieve normalized metadata for a given object. If the object is associated
+    with a specific course run, return the metadata for that run. If metadata
+    for the run is missing, log a warning and return an empty dictionary.
+
+    Args:
+        assignment (dict): The assignment object.
+        content_metadata (dict): The content metadata object
+
+    Returns:
+        dict: Normalized metadata, either for a specific course run or the advertised course run, if any.
+    """
+    if not assignment.is_assigned_course_run:
+        return content_metadata.get('normalized_metadata', {})
+
+    normalized_metadata_by_run = content_metadata.get('normalized_metadata_by_run', {})
+    return normalized_metadata_by_run.get(assignment.content_key, {})

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -78,6 +78,17 @@ def random_content_key():
     return 'course-v1:{}+{}+{}'.format(*fake_words)
 
 
+def random_parent_content_key():
+    """
+    Helper to craft a random content key.
+    """
+    fake_words = [
+        FAKER.word() + str(FAKER.random_int())
+        for _ in range(2)
+    ]
+    return '{}+{}'.format(*fake_words)
+
+
 @mark.django_db
 class APITest(APITestCase):
     """


### PR DESCRIPTION
**Description:**

Relying on the update to enterprise-catalog's `get_content_metadata` REST API to return the top-level course object when passing course run key(s) to the `?content_keys` query parameter and the addition of `normalized_metadata_by_run`, this PR updates the `get_content_metadata_for_assignments` method and where it's consumed to support `credits_available`, expiration management commands, and email notifications related to assignments.

**Jira:**
[ENT-8876](https://2u-internal.atlassian.net/browse/ENT-8876)

**Merge checklist:**
- [x] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
