### PR TITLE
feat: support run-based assignments in `can-redeem`; ensure assigned policies have highest priority

### DIFF
--- a/enterprise_access/apps/content_assignments/api.py
+++ b/enterprise_access/apps/content_assignments/api.py
@@ -216,9 +216,16 @@ def get_assignment_for_learner(
             f'No assignment found with content_key or parent_content_key {content_key} '
             f'for {assignment_configuration} and lms_user_id {lms_user_id}',
         )
+    except LearnerContentAssignment.MultipleObjectsReturned as exc:
+        logger.error(
+            f'Multiple assignments found with content_key or parent_content_key {content_key} '
+            f'for {assignment_configuration} and lms_user_id {lms_user_id}',
+        )
+        raise exc
 
     # If no exact match was found, try to normalize the content key and find a match. This happens when
-    # the content_key is a course run key and the assignment's content_key is a course key
+    # the content_key is a course run key and the assignment's content_key is a course key, as depicted
+    # by row 2 in the above docstring matrix.
     content_key_to_match = _normalize_course_key_from_metadata(assignment_configuration, content_key)
     if not content_key_to_match:
         logger.error(f'Unable to normalize content_key {content_key} for {assignment_configuration} and {lms_user_id}')

--- a/enterprise_access/apps/content_assignments/tests/test_api.py
+++ b/enterprise_access/apps/content_assignments/tests/test_api.py
@@ -116,49 +116,136 @@ class TestContentAssignmentApi(TestCase):
         return_value=mock.MagicMock(),
     )
     @ddt.data(
-        # Standard happy path.
+        # [course run] Standard happy path.
         {
-            'assignment_content_key': 'test+course',
+            'assignment_content_key': 'course-v1:test+course+run',
+            'assignment_parent_content_key': 'test+course',
+            'assignment_is_course_run': True,
             'assignment_lms_user_id': 1,
             'request_default_assignment_configuration': True,
             'request_lms_user_id': 1,
             'request_content_key': 'course-v1:test+course+run',
             'expect_assignment_found': True,
         },
-        # Happy path, requested content is a course (with prefix).
+        # [course] Standard happy path.
         {
             'assignment_content_key': 'test+course',
+            'assignment_parent_content_key': None,
+            'assignment_is_course_run': False,
             'assignment_lms_user_id': 1,
             'request_default_assignment_configuration': True,
             'request_lms_user_id': 1,
-            'request_content_key': 'course-v1:test+course',  # This is a course! With a prefix!
+            'request_content_key': 'course-v1:test+course+run',
             'expect_assignment_found': True,
         },
-        # Happy path, requested content is a course (without prefix).
+        # [course run] Happy path, requested content is a course
         {
-            'assignment_content_key': 'test+course',
+            'assignment_content_key': 'course-v1:test+course+run',
+            'assignment_parent_content_key': 'test+course',
+            'assignment_is_course_run': True,
             'assignment_lms_user_id': 1,
             'request_default_assignment_configuration': True,
             'request_lms_user_id': 1,
-            'request_content_key': 'test+course',  # This is a course! Without a prefix!
+            'request_content_key': 'test+course',
             'expect_assignment_found': True,
         },
-        # Different lms_user_id.
+        # [course] Happy path, requested content is a course
         {
             'assignment_content_key': 'test+course',
+            'assignment_parent_content_key': None,
+            'assignment_is_course_run': False,
+            'assignment_lms_user_id': 1,
+            'request_default_assignment_configuration': True,
+            'request_lms_user_id': 1,
+            'request_content_key': 'test+course',
+            'expect_assignment_found': True,
+        },
+        # [course run] Different lms_user_id, requested content is a course
+        {
+            'assignment_content_key': 'course-v1:test+course+run',
+            'assignment_parent_content_key': 'test+course',
+            'assignment_is_course_run': True,
             'assignment_lms_user_id': 1,
             'request_default_assignment_configuration': True,
             'request_lms_user_id': 2,  # Different lms_user_id!
             'request_content_key': 'test+course',
             'expect_assignment_found': False,
         },
-        # Different customer.
+        # [course] Different lms_user_id, requested content is a course
         {
             'assignment_content_key': 'test+course',
+            'assignment_parent_content_key': None,
+            'assignment_is_course_run': False,
+            'assignment_lms_user_id': 1,
+            'request_default_assignment_configuration': True,
+            'request_lms_user_id': 2,  # Different lms_user_id!
+            'request_content_key': 'test+course',
+            'expect_assignment_found': False,
+        },
+        # [course run] Different lms_user_id
+        {
+            'assignment_content_key': 'course-v1:test+course+run',
+            'assignment_parent_content_key': 'test+course',
+            'assignment_is_course_run': True,
+            'assignment_lms_user_id': 1,
+            'request_default_assignment_configuration': True,
+            'request_lms_user_id': 2,  # Different lms_user_id!
+            'request_content_key': 'course-v1:test+course+run',
+            'expect_assignment_found': False,
+        },
+        # [course] Different lms_user_id
+        {
+            'assignment_content_key': 'test+course',
+            'assignment_parent_content_key': None,
+            'assignment_is_course_run': False,
+            'assignment_lms_user_id': 1,
+            'request_default_assignment_configuration': True,
+            'request_lms_user_id': 2,  # Different lms_user_id!
+            'request_content_key': 'course-v1:test+course+run',
+            'expect_assignment_found': False,
+        },
+        # [course run] Different customer, requested content is a course
+        {
+            'assignment_content_key': 'course-v1:test+course+run',
+            'assignment_parent_content_key': 'test+course',
+            'assignment_is_course_run': True,
             'assignment_lms_user_id': 1,
             'request_default_assignment_configuration': False,  # Different customer!
             'request_lms_user_id': 1,
             'request_content_key': 'test+course',
+            'expect_assignment_found': False,
+        },
+        # [course] Different customer, requested content is a course
+        {
+            'assignment_content_key': 'test+course',
+            'assignment_parent_content_key': None,
+            'assignment_is_course_run': False,
+            'assignment_lms_user_id': 1,
+            'request_default_assignment_configuration': False,  # Different customer!
+            'request_lms_user_id': 1,
+            'request_content_key': 'test+course',
+            'expect_assignment_found': False,
+        },
+        # [course run] Different customer
+        {
+            'assignment_content_key': 'course-v1:test+course+run',
+            'assignment_parent_content_key': 'test+course',
+            'assignment_is_course_run': True,
+            'assignment_lms_user_id': 1,
+            'request_default_assignment_configuration': False,  # Different customer!
+            'request_lms_user_id': 1,
+            'request_content_key': 'course-v1:test+course+run',
+            'expect_assignment_found': False,
+        },
+        # [course] Different customer
+        {
+            'assignment_content_key': 'test+course',
+            'assignment_parent_content_key': None,
+            'assignment_is_course_run': False,
+            'assignment_lms_user_id': 1,
+            'request_default_assignment_configuration': False,  # Different customer!
+            'request_lms_user_id': 1,
+            'request_content_key': 'course-v1:test+course+run',
             'expect_assignment_found': False,
         },
     )
@@ -167,6 +254,8 @@ class TestContentAssignmentApi(TestCase):
         self,
         mock_get_and_cache_content_metadata,
         assignment_content_key,
+        assignment_parent_content_key,
+        assignment_is_course_run,
         assignment_lms_user_id,
         request_default_assignment_configuration,
         request_lms_user_id,
@@ -182,6 +271,8 @@ class TestContentAssignmentApi(TestCase):
         LearnerContentAssignmentFactory.create(
             assignment_configuration=self.assignment_configuration,
             content_key=assignment_content_key,
+            parent_content_key=assignment_parent_content_key,
+            is_assigned_course_run=assignment_is_course_run,
             lms_user_id=assignment_lms_user_id,
             state=LearnerContentAssignmentStateChoices.ALLOCATED,
         )

--- a/enterprise_access/apps/subsidy_access_policy/constants.py
+++ b/enterprise_access/apps/subsidy_access_policy/constants.py
@@ -30,6 +30,7 @@ class SegmentEvents:
 
 # Configure the priority of each policy type here.  When given multiple redeemable policies to select for redemption,
 # the policy resolution engine will select policies with the lowest priority number.
+ASSIGNED_CREDIT_POLICY_TYPE_PRIORITY = 0
 CREDIT_POLICY_TYPE_PRIORITY = 1
 SUBSCRIPTION_POLICY_TYPE_PRIORITY = 2
 

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -25,6 +25,7 @@ from enterprise_access.utils import format_traceback, is_none, is_not_none, loca
 
 from ..content_assignments.models import AssignmentConfiguration
 from .constants import (
+    ASSIGNED_CREDIT_POLICY_TYPE_PRIORITY,
     CREDIT_POLICY_TYPE_PRIORITY,
     FORCE_ENROLLMENT_KEYWORD,
     REASON_BEYOND_ENROLLMENT_DEADLINE,
@@ -1107,6 +1108,16 @@ class CreditPolicyMixin:
         return CREDIT_POLICY_TYPE_PRIORITY
 
 
+class AssignedCreditPolicyMixin:
+    """
+    Mixin class for assigned credit type policies.
+    """
+
+    @property
+    def priority(self):
+        return ASSIGNED_CREDIT_POLICY_TYPE_PRIORITY
+
+
 class PerLearnerEnrollmentCreditAccessPolicy(CreditPolicyMixin, SubsidyAccessPolicy):
     """
     Policy that limits the number of enrollments transactions for a learner in a subsidy.
@@ -1273,7 +1284,7 @@ class PerLearnerSpendCreditAccessPolicy(CreditPolicyMixin, SubsidyAccessPolicy):
         return self.per_learner_spend_limit - positive_spent_amount
 
 
-class AssignedLearnerCreditAccessPolicy(CreditPolicyMixin, SubsidyAccessPolicy):
+class AssignedLearnerCreditAccessPolicy(AssignedCreditPolicyMixin, SubsidyAccessPolicy):
     """
     Policy based on LearnerContentAssignments, backed by a learner credit type of subsidy.
 
@@ -1737,7 +1748,7 @@ class ForcedPolicyRedemption(TimeStampedModel):
             assignment_configuration.enterprise_customer_uuid,
             self.course_run_key,
         )
-        course_key = content_metadata.get('content_key')
+        content_key = content_metadata.get('content_key')
         user_record = User.objects.filter(lms_user_id=self.lms_user_id).first()
         if not user_record:
             raise Exception(f'No email could be found for lms_user_id {self.lms_user_id}')
@@ -1745,7 +1756,7 @@ class ForcedPolicyRedemption(TimeStampedModel):
         return assignments_api.allocate_assignments(
             assignment_configuration,
             [user_record.email],
-            course_key,
+            content_key,
             self.content_price_cents,
         )
 


### PR DESCRIPTION
# Description

## Make run-based assignments discoverable in `can-redeem`

In `get_assignment_for_learner`, we perform a lookup of assignments based on a top-level course key, even for run-based assignments. Given this, a run-based assignment would never be found. To mitigate, the queryset `get` now considered the assignment's `parent_content_key` as well.

## Ensuring assignment-based policies have highest priority

When a learner can redeem with both a `PerLearnerEnrollmentCreditAccessPolicy` _and_ a `AssignedLearnerCreditAccessPolicy`, the `can-redeem` API response does not prioritize the assignment-based policy for redemption over other policy types.

The lack of priority for assignment-based policies was noticed when performing stage QA and observed that the learner portal Course page was suggesting the course was assigned (via a badge and the assignment-specific price messaging), but the redemption was attempting to go through the `PerLearnerEnrollmentCreditAccessPolicy` instead of the expected `AssignedLearnerCreditAccessPolicy`, not quite matching the UX.

**Jira:**
N/A

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
