### PR TITLE
fix: forced assignment redemption assigns course run key

### DIFF
--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -1744,11 +1744,11 @@ class ForcedPolicyRedemption(TimeStampedModel):
         before redemption can occur.
         """
         assignment_configuration = self.subsidy_access_policy.assignment_configuration
-        content_metadata = get_and_cache_content_metadata(
+        # Ensure that the requested content key is available for the related customer.
+        _ = get_and_cache_content_metadata(
             assignment_configuration.enterprise_customer_uuid,
             self.course_run_key,
         )
-        content_key = content_metadata.get('content_key')
         user_record = User.objects.filter(lms_user_id=self.lms_user_id).first()
         if not user_record:
             raise Exception(f'No email could be found for lms_user_id {self.lms_user_id}')
@@ -1756,7 +1756,7 @@ class ForcedPolicyRedemption(TimeStampedModel):
         return assignments_api.allocate_assignments(
             assignment_configuration,
             [user_record.email],
-            content_key,
+            self.course_run_key,
             self.content_price_cents,
         )
 

--- a/enterprise_access/apps/subsidy_access_policy/tests/test_forced_redemption.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/test_forced_redemption.py
@@ -254,5 +254,6 @@ class ForcedPolicyRedemptionAssignmentTests(BaseForcedRedemptionTestCase):
         )
 
         assignment = LearnerContentAssignment.objects.filter(lms_user_id=user.lms_user_id).first()
+        self.assertEqual(assignment.content_key, self.course_run_key)
         mock_send_email.delay.assert_called_once_with(assignment.uuid)
         mock_pending_learner_task.delay.assert_called_once_with(assignment.uuid)


### PR DESCRIPTION
**Description:**
Currently, the forced redemption model persists a course run key to force redeem. It also creates an assignment if in an assignment-based policy. However, it creates the assignment with a course key, and not the run key.

Instead of doing this, we should simply fetch the metadata for the course run key that’s persisted in the forced redemption instance. As long as we get something back, we should just use this persisted value when creating the related assignment record.

**Jira:**
https://2u-internal.atlassian.net/browse/ENT-9562

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
