### PR TITLE
feat: add license manager base user client

### DIFF
--- a/enterprise_access/apps/api_client/base_user.py
+++ b/enterprise_access/apps/api_client/base_user.py
@@ -1,0 +1,56 @@
+"""
+Base user api client
+"""
+import crum
+import requests
+from django.conf import settings
+from edx_django_utils.monitoring import set_custom_attribute
+from edx_rest_framework_extensions.auth.jwt.cookies import jwt_cookie_name
+
+
+def get_request_id():
+    """
+    Helper to get the request id - usually set via an X-Request-ID header
+    """
+    request = crum.get_current_request()
+    if request is not None and request.headers is not None:
+        return request.headers.get('X-Request-ID')
+    else:
+        return None
+
+
+class BaseUserApiClient(requests.Session):
+    """
+    A requests Session that includes the Authorization and User-Agent headers from the original request.
+    """
+    def __init__(self, original_request, **kwargs):
+        super().__init__(**kwargs)
+        self.original_request = original_request
+
+        self.headers = {}
+
+        if self.original_request:
+            # If Authorization header is present in the original request, pass through to subsequent request headers
+            if 'Authorization' in self.original_request.headers:
+                self.headers['Authorization'] = self.original_request.headers['Authorization']
+
+            # If no Authorization header, check for JWT in cookies
+            jwt_token = self.original_request.COOKIES.get(jwt_cookie_name())
+            if 'Authorization' not in self.headers and jwt_token is not None:
+                self.headers['Authorization'] = f'JWT {jwt_token}'
+
+            # Add X-Request-ID header if applicable
+            request_id = get_request_id()
+            if self.headers.get(settings.REQUEST_ID_RESPONSE_HEADER) is None and request_id is not None:
+                self.headers[settings.REQUEST_ID_RESPONSE_HEADER] = request_id
+
+    def request(self, method, url, headers=None, **kwargs):  # pylint: disable=arguments-differ
+        if headers:
+            headers.update(self.headers)
+        else:
+            headers = self.headers
+
+        # Set `api_client` as a custom attribute for monitoring, reflecting the API client's module path
+        set_custom_attribute('api_client', 'enterprise_access.apps.api_client.base_user.BaseUserApiClient')
+
+        return super().request(method, url, headers=headers, **kwargs)

--- a/enterprise_access/apps/api_client/constants.py
+++ b/enterprise_access/apps/api_client/constants.py
@@ -8,3 +8,14 @@ autoretry_for_exceptions = (
     RequestsConnectionError,
     RequestsTimeoutError,
 )
+
+
+class LicenseStatuses:
+    """
+    Statuses defined for the "status" field in the License model.
+    """
+    ACTIVATED = 'activated'
+    ASSIGNED = 'assigned'
+    UNASSIGNED = 'unassigned'
+    REVOKED = 'revoked'
+    REVOCABLE_STATUSES = [ACTIVATED, ASSIGNED]

--- a/enterprise_access/apps/api_client/license_manager_client.py
+++ b/enterprise_access/apps/api_client/license_manager_client.py
@@ -7,6 +7,7 @@ import requests
 from django.conf import settings
 
 from enterprise_access.apps.api_client.base_oauth import BaseOAuthClient
+from enterprise_access.apps.api_client.base_user import BaseUserApiClient
 
 logger = logging.getLogger(__name__)
 
@@ -61,4 +62,73 @@ class LicenseManagerApiClient(BaseOAuthClient):
             return response.json()
         except requests.exceptions.HTTPError as exc:
             logger.exception(exc)
+            raise
+
+
+class LicenseManagerUserApiClient(BaseUserApiClient):
+    """
+    API client for calls to the license-manager service. This client is used for user-specific calls,
+    passing the original Authorization header from the originating request.
+    """
+
+    api_base_url = f"{settings.LICENSE_MANAGER_URL}/api/v1/"
+    learner_licenses_endpoint = f"{api_base_url}learner-licenses/"
+    license_activation_endpoint = f"{api_base_url}license-activation/"
+
+    def auto_apply_license_endpoint(self, customer_agreement_uuid):
+        return f"{self.api_base_url}customer-agreement/{customer_agreement_uuid}/auto-apply/"
+
+    def get_subscription_licenses_for_learner(self, enterprise_customer_uuid):
+        """
+        Get subscription licenses for a learner.
+
+        Arguments:
+            enterprise_customer_uuid (str): UUID of the enterprise customer
+        Returns:
+            dict: Dictionary representation of json returned from API
+        """
+        query_params = {
+            'enterprise_customer_uuid': enterprise_customer_uuid,
+        }
+        url = self.learner_licenses_endpoint
+        try:
+            response = self.get(url, params=query_params, timeout=settings.LICENSE_MANAGER_CLIENT_TIMEOUT)
+            return response.json()
+        except requests.exceptions.HTTPError as exc:
+            logger.exception(f"Failed to get subscription licenses for learner: {exc}")
+            raise
+
+    def activate_license(self, activation_key):
+        """
+        Activate a license.
+
+        Arguments:
+            license_uuid (str): UUID of the license to activate
+        """
+        try:
+            url = self.license_activation_endpoint
+            query_params = {
+                'activation_key': activation_key,
+            }
+            response = self.post(url, params=query_params, timeout=settings.LICENSE_MANAGER_CLIENT_TIMEOUT)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.HTTPError as exc:
+            logger.exception(f"Failed to activate license: {exc}")
+            raise
+
+    def auto_apply_license(self, customer_agreement_uuid):
+        """
+        Activate a license.
+
+        Arguments:
+            license_uuid (str): UUID of the license to activate
+        """
+        try:
+            url = self.auto_apply_license_endpoint(customer_agreement_uuid=customer_agreement_uuid)
+            response = self.post(url, timeout=settings.LICENSE_MANAGER_CLIENT_TIMEOUT)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.HTTPError as exc:
+            logger.exception(f"Failed to auto-apply license: {exc}")
             raise

--- a/enterprise_access/apps/api_client/tests/test_constants.py
+++ b/enterprise_access/apps/api_client/tests/test_constants.py
@@ -1,0 +1,6 @@
+"""
+Constants for api client tests
+"""
+
+DATE_FORMAT_ISO_8601 = "%Y-%m-%dT%H:%M:%SZ"
+DATE_FORMAT_ISO_8601_MS = '%Y-%m-%dT%H:%M:%S.%fZ'

--- a/enterprise_access/apps/api_client/tests/test_license_manager_client.py
+++ b/enterprise_access/apps/api_client/tests/test_license_manager_client.py
@@ -3,15 +3,23 @@ Tests for License Manager client.
 """
 
 from unittest import mock
+from urllib.parse import parse_qs, urlparse
 
 from django.conf import settings
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
+from faker import Faker
 from requests import Response
 
-from enterprise_access.apps.api_client.license_manager_client import LicenseManagerApiClient
+from enterprise_access.apps.api_client.constants import LicenseStatuses
+from enterprise_access.apps.api_client.license_manager_client import (
+    LicenseManagerApiClient,
+    LicenseManagerUserApiClient
+)
+from enterprise_access.apps.api_client.tests.test_constants import DATE_FORMAT_ISO_8601, DATE_FORMAT_ISO_8601_MS
+from enterprise_access.utils import _days_from_now
 
 
-class TestLicenseManagerClient(TestCase):
+class TestLicenseManagerApiClient(TestCase):
     """
     Test License Manager client.
     """
@@ -38,3 +46,268 @@ class TestLicenseManagerClient(TestCase):
             expected_url,
             timeout=settings.LICENSE_MANAGER_CLIENT_TIMEOUT,
         )
+
+
+class TestLicenseManagerUserApiClient(TestCase):
+    """
+     Test License Manager with BaseUserApiClient.
+     """
+    def setUp(self):
+        super().setUp()
+        self.api_base_url = LicenseManagerUserApiClient.api_base_url
+        self.factory = RequestFactory()
+        self.faker = Faker()
+        self.request_id_key = settings.REQUEST_ID_RESPONSE_HEADER
+
+        self.mock_enterprise_customer_uuid = self.faker.uuid4()
+        self.mock_enterprise_customer_slug = "test_slug"
+        self.mock_enterprise_catalog_uuid = self.faker.uuid4()
+        self.mock_user_email = self.faker.email()
+        self.mock_learner_license_uuid = self.faker.uuid4()
+        self.mock_learner_license_activation_uuid = self.faker.uuid4()
+        self.mock_license_activation_key = self.faker.uuid4()
+        self.mock_auto_apply_uuid = self.faker.uuid4()
+        self.mock_subscription_plan_uuid = self.faker.uuid4()
+        self.mock_customer_agreement_uuid = self.faker.uuid4()
+
+        self.base_paginated_response = {
+            "next": None,
+            "previous": None,
+            "count": 0,
+            "results": [],
+        }
+        self.mock_subscription_plan = {
+            "title": "mock_title",
+            "uuid": self.mock_subscription_plan_uuid,
+            "start_date": _days_from_now(-50, DATE_FORMAT_ISO_8601),
+            "expiration_date": _days_from_now(50, DATE_FORMAT_ISO_8601),
+            "enterprise_customer_uuid": self.mock_enterprise_customer_uuid,
+            "enterprise_catalog_uuid": self.mock_enterprise_catalog_uuid,
+            "is_active": True,
+            "is_current": True,
+            "is_revocation_cap_enabled": False,
+            "days_until_expiration": _days_from_now(50, DATE_FORMAT_ISO_8601),
+            "days_until_expiration_including_renewals": _days_from_now(50, DATE_FORMAT_ISO_8601),
+            "is_locked_for_renewal_processing": False,
+            "should_auto_apply_licenses": False,
+            "created": _days_from_now(-60, DATE_FORMAT_ISO_8601)
+        }
+        self.mock_customer_agreement = {
+            "uuid": self.mock_customer_agreement_uuid,
+            "enterprise_customer_uuid": self.mock_enterprise_customer_uuid,
+            "enterprise_customer_slug": "mock_slug",
+            "default_enterprise_catalog_uuid": self.mock_enterprise_catalog_uuid,
+            "disable_expiration_notifications": False,
+            "net_days_until_expiration": _days_from_now(50, DATE_FORMAT_ISO_8601),
+            "subscription_for_auto_applied_licenses": self.mock_subscription_plan_uuid,
+            "available_subscription_catalogs": [
+                self.mock_enterprise_catalog_uuid,
+            ],
+            "enable_auto_applied_subscriptions_with_universal_link": False,
+            "has_custom_license_expiration_messaging": False,
+            "modal_header_text": None,
+            "expired_subscription_modal_messaging": None,
+            "button_label_in_modal": None,
+            "url_for_button_in_modal": None
+        }
+        self.mock_learner_license_result_response = {
+            "uuid": self.mock_learner_license_uuid,
+            "status": LicenseStatuses.ACTIVATED,
+            "user_email": self.mock_user_email,
+            "activation_date": _days_from_now(-10, DATE_FORMAT_ISO_8601_MS),
+            "last_remind_date": _days_from_now(-5, DATE_FORMAT_ISO_8601_MS),
+            "subscription_plan_uuid": self.mock_subscription_plan_uuid,
+            "revoked_date": None,
+            "activation_key": self.mock_license_activation_key,
+            "subscription_plan": self.mock_subscription_plan
+        }
+        self.mock_learner_license_activation_response = {
+            "uuid": self.mock_learner_license_activation_uuid,
+            "status": LicenseStatuses.ACTIVATED,
+            "user_email": self.mock_user_email,
+            "activation_date": _days_from_now(-10, DATE_FORMAT_ISO_8601_MS),
+            "last_remind_date": _days_from_now(-5, DATE_FORMAT_ISO_8601_MS),
+            "subscription_plan_title": "mock_subscription_plan_title",
+            "subscription_plan_expiration_date": _days_from_now(50, DATE_FORMAT_ISO_8601),
+            "activation_link": self.faker.url()
+        }
+        self.mock_auto_apply_response = {
+            "uuid": self.mock_auto_apply_uuid,
+            "enterprise_customer_uuid": self.mock_enterprise_customer_uuid,
+            "enterprise_customer_slug": self.mock_enterprise_customer_slug,
+            "default_enterprise_catalog_uuid": self.mock_enterprise_catalog_uuid,
+            "disable_expiration_notifications": True,
+            "net_days_until_expiration": _days_from_now(50, DATE_FORMAT_ISO_8601),
+            "subscription_for_auto_applied_licenses": self.mock_subscription_plan_uuid,
+            "available_subscription_catalogs": [
+                self.mock_enterprise_catalog_uuid,
+            ],
+            "enable_auto_applied_subscriptions_with_universal_link": False,
+            "has_custom_license_expiration_messaging": False,
+            "modal_header_text": None,
+            "expired_subscription_modal_messaging": None,
+            "button_label_in_modal": None,
+            "url_for_button_in_modal": None,
+            "subscriptions": [
+                self.mock_subscription_plan
+            ]
+        }
+
+    @mock.patch('requests.Session.send')
+    @mock.patch('crum.get_current_request')
+    def test_get_subscription_licenses_for_learner(self, mock_crum_get_current_request, mock_send):
+        expected_result = {
+            **self.base_paginated_response,
+            "count": 1,
+            "num_pages": 1,
+            "current_page": 1,
+            "start": 0,
+            "results": [
+                self.mock_learner_license_result_response,
+            ],
+            "customer_agreement": self.mock_customer_agreement,
+        }
+        expected_url = LicenseManagerUserApiClient.learner_licenses_endpoint
+
+        request = self.factory.get(expected_url)
+
+        request.headers = {
+            "Authorization": 'test-auth',
+            self.request_id_key: 'test-request-id'
+        }
+        context = {
+            "request": request
+        }
+
+        mock_request = mock.MagicMock()
+        mock_request.headers.get.return_value = request.headers.get(self.request_id_key)
+        mock_crum_get_current_request.return_value = mock_request
+
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = expected_result
+
+        mock_send.return_value = mock_response
+
+        lm_client = LicenseManagerUserApiClient(context['request'])
+        result = lm_client.get_subscription_licenses_for_learner(self.mock_enterprise_customer_uuid)
+
+        mock_send.assert_called_once()
+
+        prepared_request = mock_send.call_args[0][0]
+        prepared_request_kwargs = mock_send.call_args[1]
+
+        # Assert base request URL/method is correct
+        parsed_url = urlparse(prepared_request.url)
+        self.assertEqual(f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}", expected_url)
+        self.assertEqual(prepared_request.method, 'GET')
+
+        # Assert query parameters are correctly set
+        parsed_params = parse_qs(parsed_url.query)
+        expected_params = {'enterprise_customer_uuid': [self.mock_enterprise_customer_uuid]}
+        self.assertEqual(parsed_params, expected_params)
+
+        self.assertEqual(prepared_request.headers['Authorization'], 'test-auth')
+        self.assertEqual(prepared_request.headers[self.request_id_key], 'test-request-id')
+
+        self.assertIn('timeout', prepared_request_kwargs)
+        self.assertEqual(prepared_request_kwargs['timeout'], settings.LICENSE_MANAGER_CLIENT_TIMEOUT)
+
+        self.assertEqual(result, expected_result)
+
+    @mock.patch('requests.Session.send')
+    @mock.patch('crum.get_current_request')
+    def test_activate_license(self, mock_crum_get_current_request, mock_send):
+        expected_result = self.mock_learner_license_activation_response
+        expected_url = LicenseManagerUserApiClient.license_activation_endpoint
+
+        request = self.factory.post(expected_url)
+        request.headers = {
+            "Authorization": 'test-auth',
+            self.request_id_key: "test-request-id"
+        }
+        context = {
+            "request": request
+        }
+
+        mock_request = mock.MagicMock()
+        mock_request.headers.get.return_value = request.headers.get(self.request_id_key)
+        mock_crum_get_current_request.return_value = mock_request
+
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = expected_result
+
+        mock_send.return_value = mock_response
+
+        lm_client = LicenseManagerUserApiClient(context['request'])
+        result = lm_client.activate_license(self.mock_license_activation_key)
+
+        mock_send.assert_called_once()
+
+        prepared_request = mock_send.call_args[0][0]
+        prepared_request_kwargs = mock_send.call_args[1]
+
+        # Assert base request URL/method is correct
+        parsed_url = urlparse(prepared_request.url)
+        self.assertEqual(f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}", expected_url)
+        self.assertEqual(prepared_request.method, 'POST')
+
+        # Assert query parameters are correctly set
+        parsed_params = parse_qs(parsed_url.query)
+        expected_params = {'activation_key': [self.mock_license_activation_key]}
+        self.assertEqual(parsed_params, expected_params)
+
+        self.assertEqual(prepared_request.headers['Authorization'], 'test-auth')
+        self.assertEqual(prepared_request.headers[self.request_id_key], 'test-request-id')
+
+        self.assertIn('timeout', prepared_request_kwargs)
+        self.assertEqual(prepared_request_kwargs['timeout'], settings.LICENSE_MANAGER_CLIENT_TIMEOUT)
+
+        self.assertEqual(result, expected_result)
+
+    @mock.patch('requests.Session.send')
+    @mock.patch('crum.get_current_request')
+    def test_auto_apply_license(self, mock_crum_get_current_request, mock_send):
+        expected_result = self.mock_auto_apply_response
+        expected_url = LicenseManagerUserApiClient.auto_apply_license_endpoint(self, self.mock_customer_agreement_uuid)
+
+        request = self.factory.post(expected_url)
+        request.headers = {
+            "Authorization": 'test-auth',
+            self.request_id_key: "test-request-id"
+        }
+        context = {
+            "request": request
+        }
+
+        mock_request = mock.MagicMock()
+        mock_request.headers.get.return_value = request.headers.get(self.request_id_key)
+        mock_crum_get_current_request.return_value = mock_request
+
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = expected_result
+
+        mock_send.return_value = mock_response
+
+        lm_client = LicenseManagerUserApiClient(context['request'])
+        result = lm_client.auto_apply_license(self.mock_customer_agreement_uuid)
+
+        mock_send.assert_called_once()
+
+        prepared_request = mock_send.call_args[0][0]
+        prepared_request_kwargs = mock_send.call_args[1]
+
+        # Assert base request URL/method is correct
+        parsed_url = urlparse(prepared_request.url)
+        self.assertEqual(f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}", expected_url)
+        self.assertEqual(prepared_request.method, 'POST')
+
+        self.assertEqual(prepared_request.headers['Authorization'], 'test-auth')
+        self.assertEqual(prepared_request.headers[self.request_id_key], 'test-request-id')
+
+        self.assertIn('timeout', prepared_request_kwargs)
+        self.assertEqual(prepared_request_kwargs['timeout'], settings.LICENSE_MANAGER_CLIENT_TIMEOUT)
+
+        self.assertEqual(result, expected_result)

--- a/enterprise_access/apps/content_assignments/tests/test_utils.py
+++ b/enterprise_access/apps/content_assignments/tests/test_utils.py
@@ -1,11 +1,9 @@
 """
 Tests for Enterprise Access content_assignments utils.
 """
-from datetime import datetime, timedelta
 
 import ddt
 from django.test import TestCase
-from pytz import UTC
 
 from enterprise_access.apps.content_assignments.constants import BRAZE_ACTION_REQUIRED_BY_TIMESTAMP_FORMAT
 from enterprise_access.apps.content_assignments.utils import (
@@ -13,20 +11,7 @@ from enterprise_access.apps.content_assignments.utils import (
     has_time_to_complete,
     is_within_minimum_start_date_threshold
 )
-
-
-def _curr_date(date_format=None):
-    curr_date = datetime.now()
-    if not date_format:
-        return curr_date
-    return curr_date.strftime(date_format)
-
-
-def _days_from_now(days_from_now=0, date_format=None):
-    date = datetime.now().replace(tzinfo=UTC) + timedelta(days=days_from_now)
-    if not date_format:
-        return date
-    return date.strftime(date_format)
+from enterprise_access.utils import _curr_date, _days_from_now
 
 
 @ddt.ddt

--- a/enterprise_access/utils.py
+++ b/enterprise_access/utils.py
@@ -229,3 +229,17 @@ def get_normalized_metadata_for_assignment(assignment, content_metadata):
 
     normalized_metadata_by_run = content_metadata.get('normalized_metadata_by_run', {})
     return normalized_metadata_by_run.get(assignment.content_key, {})
+
+
+def _curr_date(date_format=None):
+    curr_date = datetime.now()
+    if not date_format:
+        return curr_date
+    return curr_date.strftime(date_format)
+
+
+def _days_from_now(days_from_now=0, date_format=None):
+    date = datetime.now().replace(tzinfo=UTC) + timedelta(days=days_from_now)
+    if not date_format:
+        return date
+    return date.strftime(date_format)


### PR DESCRIPTION
**Description:**
Adds license manager api client utilizing the base user client. The `BaseUserClient` is intended to be used in conjuction with the BFF (backend for frontend) layer when making API calls.

Adds API calls to `license_manager_client` which utilizes the new `BaseUserClient`, `LicenseManagerUserApiClient`.

Adds tests for the new set of end points along with data reflective of the serializer from license manager.

**Jira:**
ENT-XXXX

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
