### PR TITLE
feat: introduce `LmsUserApiClient`, method to fetch enrollment intentions for learner

### DIFF
--- a/enterprise_access/apps/api_client/base_user.py
+++ b/enterprise_access/apps/api_client/base_user.py
@@ -44,6 +44,13 @@ class BaseUserApiClient(requests.Session):
             if self.headers.get(settings.REQUEST_ID_RESPONSE_HEADER) is None and request_id is not None:
                 self.headers[settings.REQUEST_ID_RESPONSE_HEADER] = request_id
 
+    @property
+    def request_user(self):
+        """
+        Returns the user associated with the original request.
+        """
+        return self.original_request.user
+
     def request(self, method, url, headers=None, **kwargs):  # pylint: disable=arguments-differ
         if headers:
             headers.update(self.headers)

--- a/enterprise_access/apps/api_client/license_manager_client.py
+++ b/enterprise_access/apps/api_client/license_manager_client.py
@@ -93,6 +93,7 @@ class LicenseManagerUserApiClient(BaseUserApiClient):
         url = self.learner_licenses_endpoint
         try:
             response = self.get(url, params=query_params, timeout=settings.LICENSE_MANAGER_CLIENT_TIMEOUT)
+            response.raise_for_status()
             return response.json()
         except requests.exceptions.HTTPError as exc:
             logger.exception(f"Failed to get subscription licenses for learner: {exc}")

--- a/enterprise_access/apps/api_client/lms_client.py
+++ b/enterprise_access/apps/api_client/lms_client.py
@@ -419,6 +419,7 @@ class LmsUserApiClient(BaseUserApiClient):
             dict: Dictionary representation of the JSON response from the API
         """
         query_params = {'enterprise_customer_uuid': enterprise_customer_uuid}
+        response = None
         try:
             response = self.get(
                 self.default_enterprise_enrollment_intentions_learner_status_endpoint,
@@ -431,6 +432,6 @@ class LmsUserApiClient(BaseUserApiClient):
             logger.exception(
                 f"Failed to fetch default enterprise enrollment intentions for enterprise customer "
                 f"{enterprise_customer_uuid} and learner {self.request_user.lms_user_id}: {exc} "
-                f"Response content: {response.content}"
+                f"Response content: {response.content if response else None}"
             )
             raise

--- a/enterprise_access/apps/api_client/lms_client.py
+++ b/enterprise_access/apps/api_client/lms_client.py
@@ -10,6 +10,7 @@ from edx_django_utils.cache import TieredCache
 from rest_framework import status
 
 from enterprise_access.apps.api_client.base_oauth import BaseOAuthClient
+from enterprise_access.apps.api_client.base_user import BaseUserApiClient
 from enterprise_access.apps.api_client.exceptions import FetchGroupMembersConflictingParamsException
 from enterprise_access.apps.enterprise_groups.constants import GROUP_MEMBERSHIP_EMAIL_ERROR_STATUS
 from enterprise_access.cache_utils import versioned_cache_key
@@ -396,3 +397,39 @@ class LmsApiClient(BaseOAuthClient):
         except KeyError:
             logger.exception('failed to update group membership status. [%s]', url)
         return None
+
+
+class LmsUserApiClient(BaseUserApiClient):
+    """
+    API client for user-specific calls to the LMS service.
+    """
+    enterprise_api_base_url = f"{settings.LMS_URL}/enterprise/api/v1/"
+    default_enterprise_enrollment_intentions_learner_status_endpoint = (
+        f'{enterprise_api_base_url}default-enterprise-enrollment-intentions/learner-status/'
+    )
+
+    def get_default_enterprise_enrollment_intentions_learner_status(self, enterprise_customer_uuid):
+        """
+        Fetches learner status from the default enterprise enrollment intentions endpoint.
+
+        Arguments:
+            enterprise_customer_uuid (str): UUID of the enterprise customer
+
+        Returns:
+            dict: Dictionary representation of the JSON response from the API
+        """
+        query_params = {'enterprise_customer_uuid': enterprise_customer_uuid}
+        try:
+            response = self.get(
+                self.default_enterprise_enrollment_intentions_learner_status_endpoint,
+                params=query_params,
+                timeout=settings.LMS_CLIENT_TIMEOUT
+            )
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.HTTPError as exc:
+            logger.exception(
+                f"Failed to fetch default enterprise enrollment intentions for enterprise customer "
+                f"{enterprise_customer_uuid} and learner {self.request_user.lms_user_id}: {exc}"
+            )
+            raise

--- a/enterprise_access/apps/api_client/lms_client.py
+++ b/enterprise_access/apps/api_client/lms_client.py
@@ -430,6 +430,7 @@ class LmsUserApiClient(BaseUserApiClient):
         except requests.exceptions.HTTPError as exc:
             logger.exception(
                 f"Failed to fetch default enterprise enrollment intentions for enterprise customer "
-                f"{enterprise_customer_uuid} and learner {self.request_user.lms_user_id}: {exc}"
+                f"{enterprise_customer_uuid} and learner {self.request_user.lms_user_id}: {exc} "
+                f"Response content: {response.content}"
             )
             raise

--- a/enterprise_access/apps/api_client/tests/test_license_manager_client.py
+++ b/enterprise_access/apps/api_client/tests/test_license_manager_client.py
@@ -179,9 +179,7 @@ class TestLicenseManagerUserApiClient(TestCase):
             "request": request
         }
 
-        mock_request = mock.MagicMock()
-        mock_request.headers.get.return_value = request.headers.get(self.request_id_key)
-        mock_crum_get_current_request.return_value = mock_request
+        mock_crum_get_current_request.return_value = request
 
         mock_response = mock.Mock()
         mock_response.status_code = 200
@@ -207,12 +205,15 @@ class TestLicenseManagerUserApiClient(TestCase):
         expected_params = {'enterprise_customer_uuid': [self.mock_enterprise_customer_uuid]}
         self.assertEqual(parsed_params, expected_params)
 
+        # Assert headers are correctly set
         self.assertEqual(prepared_request.headers['Authorization'], 'test-auth')
         self.assertEqual(prepared_request.headers[self.request_id_key], 'test-request-id')
 
+        # Assert timeout is set
         self.assertIn('timeout', prepared_request_kwargs)
         self.assertEqual(prepared_request_kwargs['timeout'], settings.LICENSE_MANAGER_CLIENT_TIMEOUT)
 
+        # Assert result is as expected
         self.assertEqual(result, expected_result)
 
     @mock.patch('requests.Session.send')
@@ -230,9 +231,7 @@ class TestLicenseManagerUserApiClient(TestCase):
             "request": request
         }
 
-        mock_request = mock.MagicMock()
-        mock_request.headers.get.return_value = request.headers.get(self.request_id_key)
-        mock_crum_get_current_request.return_value = mock_request
+        mock_crum_get_current_request.return_value = request
 
         mock_response = mock.Mock()
         mock_response.status_code = 200
@@ -281,9 +280,7 @@ class TestLicenseManagerUserApiClient(TestCase):
             "request": request
         }
 
-        mock_request = mock.MagicMock()
-        mock_request.headers.get.return_value = request.headers.get(self.request_id_key)
-        mock_crum_get_current_request.return_value = mock_request
+        mock_crum_get_current_request.return_value = request
 
         mock_response = mock.Mock()
         mock_response.status_code = 200

--- a/enterprise_access/apps/api_client/tests/test_lms_client.py
+++ b/enterprise_access/apps/api_client/tests/test_lms_client.py
@@ -468,5 +468,6 @@ class TestLmsUserApiClient(TestCase):
         # Verify that logger.exception was called with the expected message
         mock_logger.exception.assert_called_once_with(
             f"Failed to fetch default enterprise enrollment intentions for enterprise customer "
-            f"{self.mock_enterprise_customer_uuid} and learner {self.user.lms_user_id}: HTTPError"
+            f"{self.mock_enterprise_customer_uuid} and learner {self.user.lms_user_id}: HTTPError "
+            f"Response content: {mock_response.content}"
         )


### PR DESCRIPTION
**Description:**

1. Adds `LmsUserApiClient`, extending `BaseUserApiClient` to pass-thru the requesting user's JWT token and `X-Request-ID` headers.
2. Implements `get_default_enterprise_enrollment_intentions_learner_status` within `LmsUserApiClient` to fetch the API endpoint introduced via https://github.com/openedx/edx-enterprise/pull/2274.
3. Tests.

**Jira:**
[ENT-9690](https://2u-internal.atlassian.net/browse/ENT-9690)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
