### PR TITLE
fix: Check preferred_course_run_key for normalized_metadata

### DIFF
--- a/enterprise_access/apps/api_client/tests/test_constants.py
+++ b/enterprise_access/apps/api_client/tests/test_constants.py
@@ -1,6 +1,5 @@
 """
 Constants for api client tests
 """
-
 DATE_FORMAT_ISO_8601 = "%Y-%m-%dT%H:%M:%SZ"
 DATE_FORMAT_ISO_8601_MS = '%Y-%m-%dT%H:%M:%S.%fZ'

--- a/enterprise_access/utils.py
+++ b/enterprise_access/utils.py
@@ -214,8 +214,8 @@ def should_send_email_to_pecu(recent_action):
 def get_normalized_metadata_for_assignment(assignment, content_metadata):
     """
     Retrieve normalized metadata for a given object. If the object is associated
-    with a specific course run, return the metadata for that run. If metadata
-    for the run is missing, log a warning and return an empty dictionary.
+    with a specific course run or a preferred course run key, return the metadata for that run.
+    If metadata for the run is missing, return the normalized metadata for the advertised run.
 
     Args:
         assignment (dict): The assignment object.
@@ -224,11 +224,13 @@ def get_normalized_metadata_for_assignment(assignment, content_metadata):
     Returns:
         dict: Normalized metadata, either for a specific course run or the advertised course run, if any.
     """
-    if not assignment.is_assigned_course_run:
-        return content_metadata.get('normalized_metadata', {})
-
     normalized_metadata_by_run = content_metadata.get('normalized_metadata_by_run', {})
-    return normalized_metadata_by_run.get(assignment.content_key, {})
+    # Return the content metadata for a specific course run based on the preferred_course_run_key
+    if preferred_course_run_key := assignment.preferred_course_run_key:
+        return normalized_metadata_by_run.get(preferred_course_run_key, {})
+    # Return current advertised course run metadata if preferred_course_run_key is NULL (i.e.,
+    # impacting legacy course-based assignments created pre-May 2024).
+    return content_metadata.get('normalized_metadata', {})
 
 
 def _curr_date(date_format=None):


### PR DESCRIPTION
**Description:**
Takes into account the `preferred_course_run_key` when extracting the `normalized_metadata` from assignments.

**Jira:**
ENT-9688

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
