### PR TITLE
feat: add response builder to the BFF

### DIFF
--- a/enterprise_access/apps/api_client/tests/test_utils.py
+++ b/enterprise_access/apps/api_client/tests/test_utils.py
@@ -1,10 +1,17 @@
 """
 Helper utilities for api_client tests.
 """
-import requests
+from django.test import TestCase
+from faker import Faker
+from requests import Response
+
+from enterprise_access.apps.api_client.constants import LicenseStatuses
+from enterprise_access.apps.api_client.tests.test_constants import DATE_FORMAT_ISO_8601, DATE_FORMAT_ISO_8601_MS
+from enterprise_access.apps.core.tests.factories import UserFactory
+from enterprise_access.utils import _days_from_now
 
 
-class MockResponse(requests.Response):
+class MockResponse(Response):
     """
     Useful for mocking HTTP responses, especially for code that relies on raise_for_status().
     """
@@ -15,3 +22,95 @@ class MockResponse(requests.Response):
 
     def json(self):  # pylint: disable=arguments-differ
         return self.json_data
+
+
+class MockEnterpriseMetadata(TestCase):
+    """
+    Mock enterprise metadata
+    """
+    def setUp(self):
+        super().setUp()
+        self.faker = Faker()
+
+        self.base_paginated_response = {
+            "next": None,
+            "previous": None,
+            "count": 0,
+            "results": [],
+        }
+
+        self.mock_enterprise_customer_uuid = self.faker.uuid4()
+        self.mock_enterprise_customer_slug = "test_slug"
+        self.mock_enterprise_catalog_uuid = self.faker.uuid4()
+        self.mock_user = UserFactory()
+        self.mock_user_email = self.mock_user.email
+
+
+class MockLicenseManagerMetadataMixin(MockEnterpriseMetadata):
+    """
+    Mixin for the TestLicenseManagerUserApiClient
+    """
+    def setUp(self):
+        super().setUp()
+
+        self.mock_learner_license_uuid = self.faker.uuid4()
+        self.mock_learner_license_activation_uuid = self.faker.uuid4()
+        self.mock_license_activation_key = self.faker.uuid4()
+        self.mock_auto_apply_uuid = self.faker.uuid4()
+        self.mock_subscription_plan_uuid = self.faker.uuid4()
+        self.mock_customer_agreement_uuid = self.faker.uuid4()
+
+        self.mock_subscription_plan = {
+            "title": "mock_title",
+            "uuid": self.mock_subscription_plan_uuid,
+            "start_date": _days_from_now(-50, DATE_FORMAT_ISO_8601),
+            "expiration_date": _days_from_now(50, DATE_FORMAT_ISO_8601),
+            "enterprise_customer_uuid": self.mock_enterprise_customer_uuid,
+            "enterprise_catalog_uuid": self.mock_enterprise_catalog_uuid,
+            "is_active": True,
+            "is_current": True,
+            "is_revocation_cap_enabled": False,
+            "days_until_expiration": 50,
+            "days_until_expiration_including_renewals": 50,
+            "is_locked_for_renewal_processing": False,
+            "should_auto_apply_licenses": False,
+            "created": _days_from_now(-60, DATE_FORMAT_ISO_8601)
+        }
+        self.mock_customer_agreement = {
+            "uuid": self.mock_customer_agreement_uuid,
+            "enterprise_customer_uuid": self.mock_enterprise_customer_uuid,
+            "enterprise_customer_slug": self.mock_enterprise_customer_slug,
+            "default_enterprise_catalog_uuid": self.mock_enterprise_catalog_uuid,
+            "disable_expiration_notifications": False,
+            "net_days_until_expiration": 50,
+            "subscription_for_auto_applied_licenses": self.mock_subscription_plan_uuid,
+            "available_subscription_catalogs": [
+                self.mock_enterprise_catalog_uuid,
+            ],
+            "enable_auto_applied_subscriptions_with_universal_link": False,
+            "has_custom_license_expiration_messaging": False,
+            "modal_header_text": None,
+            "expired_subscription_modal_messaging": None,
+            "button_label_in_modal": None,
+            "url_for_button_in_modal": None
+        }
+        self.mock_subscription_license = {
+            "uuid": self.mock_learner_license_activation_uuid,
+            "status": LicenseStatuses.ACTIVATED,
+            "user_email": self.mock_user_email,
+            "activation_date": _days_from_now(-10, DATE_FORMAT_ISO_8601_MS),
+            "last_remind_date": _days_from_now(-5, DATE_FORMAT_ISO_8601_MS),
+            "subscription_plan_uuid": self.mock_subscription_plan_uuid,
+            "revoked_date": None,
+            "activation_key": self.mock_license_activation_key,
+            "subscription_plan": self.mock_subscription_plan
+        }
+        self.mock_learner_license_activation_response = {
+            **self.mock_subscription_license,
+            "uuid": self.mock_learner_license_activation_uuid,
+        }
+        self.mock_learner_license_auto_apply_response = {
+            **self.mock_subscription_license,
+            'customer-agreement': self.mock_customer_agreement,
+            'subscription_plan': self.mock_subscription_plan,
+        }

--- a/enterprise_access/apps/bffs/context.py
+++ b/enterprise_access/apps/bffs/context.py
@@ -2,6 +2,8 @@
 HandlerContext for bffs app.
 """
 
+from rest_framework import status
+
 from enterprise_access.apps.api_client.lms_client import LmsApiClient, LmsUserApiClient
 from enterprise_access.apps.bffs import serializers
 
@@ -30,13 +32,13 @@ class HandlerContext:
             request: The incoming HTTP request.
         """
         self._request = request
+        self._status_code = status.HTTP_200_OK
         self._errors = []  # Stores any errors that occur during processing
         self._warnings = []  # Stores any warnings that occur during processing
         self._enterprise_customer_uuid = None
         self._enterprise_customer_slug = None
         self._lms_user_id = getattr(self.user, 'lms_user_id', None)
         self._enterprise_features = {}
-
         self.data = {}  # Stores processed data for the response
 
         # API clients
@@ -49,6 +51,10 @@ class HandlerContext:
     @property
     def request(self):
         return self._request
+
+    @property
+    def status_code(self):
+        return self._status_code
 
     @property
     def user(self):

--- a/enterprise_access/apps/bffs/response_builder.py
+++ b/enterprise_access/apps/bffs/response_builder.py
@@ -1,0 +1,130 @@
+"""
+Response Builder Module for bffs app
+"""
+from enterprise_access.apps.bffs.serializers import LearnerDashboardResponseSerializer
+
+
+class BaseResponseBuilder:
+    """
+    A base response builder class that provides shared core functionality for different response builders.
+
+    The `BaseResponseBuilder` includes methods for building response data and can be extended by specific
+    response builders like `LearnerDashboardResponseBuilder` or `CourseResponseBuilder`.
+    """
+
+    def __init__(self, context):
+        """
+        Initializes the BaseResponseBuilder with a HandlerContext.
+
+        Args:
+            context (HandlerContext): The context object containing data, errors, and request information.
+        """
+        self.context = context
+
+    def build(self):
+        """
+        Builds the response data. This method should be overridden by subclasses to implement
+        specific response formatting logic.
+
+        Returns:
+            dict: A dictionary containing the response data.
+        """
+        raise NotImplementedError("Subclasses must implement the `build` method.")
+
+    def add_errors_warnings_to_response(self, response_data):
+        """
+        Adds any errors to the response data.
+        """
+        response_data['errors'] = self.context.errors
+        response_data['warnings'] = self.context.warnings
+        return response_data
+
+    # TODO Revisit this function in ENT-9633 to determine if 200 is ok for a nested errored response
+    def get_status_code(self):
+        """
+        Gets the current status code from the context.
+
+        Returns:
+            int: The HTTP status code.
+        """
+        return self.context.status_code
+
+
+class BaseLearnerResponseBuilder(BaseResponseBuilder):
+    """
+    A base response builder class for learner-focused routes.
+
+    The `BaseLearnerResponseBuilder` extends `BaseResponseBuilder` and provides shared core functionality
+    for building responses across all learner-focused page routes.
+    """
+
+    def common_response_logic(self, response_data=None):
+        """
+        Applies common response logic for learner-related responses.
+
+        Args:
+            response_data (dict): The initial response data.
+
+        Returns:
+            dict: The modified response data with common logic applied.
+        """
+        if not response_data:
+            response_data = {}
+        response_data['enterprise_customer_user_subsidies'] =\
+            self.context.data.get('enterprise_customer_user_subsidies', {})
+        return response_data
+
+    def build(self):
+        """
+        Builds the base response data for learner routes.
+
+        This method can be overridden by subclasses to provide route-specific logic.
+
+        Returns:
+            dict: A tuple containing the base response data and status code.
+        """
+        # Initialize response data with common learner-related logic
+        response_data = self.common_response_logic()
+
+        # Add any errors, etc.
+        response_data = self.add_errors_warnings_to_response(response_data)
+
+        # Return the response data and status code
+        return response_data, self.get_status_code()
+
+
+class LearnerDashboardResponseBuilder(BaseLearnerResponseBuilder):
+    """
+    A response builder for the learner dashboard route.
+
+    The `LearnerDashboardResponseBuilder` extends `BaseLearnerResponseBuilder` to extract and format data
+    relevant to the learner dashboard page.
+    """
+
+    def build(self):
+        """
+        Builds the response data for the learner dashboard route.
+
+        This method overrides the `build` method in `BaseResponseBuilder`.
+
+        Returns:
+            dict: A tuple containing the learner dashboard serialized response data and status code.
+        """
+        # Initialize the response data with common learner-related fields
+        response_data = self.common_response_logic()
+
+        # Add specific fields related to the learner dashboard
+        response_data.update({
+            'enterprise_course_enrollments': self.context.data.get('enterprise_course_enrollments', []),
+        })
+
+        # Add any errors and warnings to the response
+        response_data = self.add_errors_warnings_to_response(response_data)
+
+        # Serialize and validate the response
+        serializer = LearnerDashboardResponseSerializer(data=response_data)
+        serializer.is_valid(raise_exception=True)
+        serialized_data = serializer.validated_data
+
+        # Return the response data and status code
+        return serialized_data, self.get_status_code()

--- a/enterprise_access/apps/bffs/serializers.py
+++ b/enterprise_access/apps/bffs/serializers.py
@@ -28,3 +28,183 @@ class ErrorSerializer(BaseBFFMessageSerializer):
 
 class WarningSerializer(BaseBFFMessageSerializer):
     pass
+
+
+class BaseResponseSerializer(serializers.Serializer):
+    """
+    Serializer for base response.
+    """
+
+    errors = ErrorSerializer(many=True, required=False, default=list)
+    warnings = WarningSerializer(many=True, required=False, default=list)
+
+    def create(self, validated_data):
+        return validated_data
+
+    def update(self, instance, validated_data):
+        return validated_data
+
+
+class CustomerAgreementSerializer(serializers.Serializer):
+    """
+    Serializer for customer agreement.
+    """
+
+    uuid = serializers.UUIDField()
+    available_subscription_catalogs = serializers.ListField(child=serializers.UUIDField())
+    default_enterprise_catalog_uuid = serializers.UUIDField()
+    net_days_until_expiration = serializers.IntegerField()
+    disable_expiration_notifications = serializers.BooleanField()
+    enable_auto_applied_subscriptions_with_universal_link = serializers.BooleanField()
+    subscription_for_auto_applied_licenses = serializers.UUIDField(allow_null=True)
+
+    def create(self, validated_data):
+        return validated_data
+
+    def update(self, instance, validated_data):
+        return validated_data
+
+
+class SubscriptionPlanSerializer(serializers.Serializer):
+    """
+    Serializer for subscription plan.
+    """
+
+    uuid = serializers.UUIDField()
+    title = serializers.CharField()
+    enterprise_catalog_uuid = serializers.UUIDField()
+    is_active = serializers.BooleanField()
+    is_current = serializers.BooleanField()
+    start_date = serializers.DateTimeField()
+    expiration_date = serializers.DateTimeField()
+    days_until_expiration = serializers.IntegerField()
+    days_until_expiration_including_renewals = serializers.IntegerField()
+    should_auto_apply_licenses = serializers.BooleanField()
+
+    def create(self, validated_data):
+        return validated_data
+
+    def update(self, instance, validated_data):
+        return validated_data
+
+
+class SubscriptionLicenseSerializer(serializers.Serializer):
+    """
+    Serializer for subscription license.
+    """
+
+    uuid = serializers.UUIDField()
+    status = serializers.CharField()
+    user_email = serializers.EmailField()
+    activation_date = serializers.DateTimeField(allow_null=True)
+    last_remind_date = serializers.DateTimeField(allow_null=True)
+    revoked_date = serializers.DateTimeField(allow_null=True)
+    activation_key = serializers.CharField()
+    subscription_plan = SubscriptionPlanSerializer()
+
+    def create(self, validated_data):
+        return validated_data
+
+    def update(self, instance, validated_data):
+        return validated_data
+
+
+class SubscriptionLicenseStatusSerializer(serializers.Serializer):
+    """
+    Serializer for subscription license status.
+    """
+
+    activated = SubscriptionLicenseSerializer(many=True, required=False, default=list)
+    assigned = SubscriptionLicenseSerializer(many=True, required=False, default=list)
+    expired = SubscriptionLicenseSerializer(many=True, required=False, default=list)
+    revoked = SubscriptionLicenseSerializer(many=True, required=False, default=list)
+
+    def create(self, validated_data):
+        return validated_data
+
+    def update(self, instance, validated_data):
+        return validated_data
+
+
+class SubscriptionsSerializer(serializers.Serializer):
+    """
+    Serializer for enterprise customer user subsidies.
+    """
+
+    customer_agreement = CustomerAgreementSerializer(
+        required=False,
+    )
+    subscription_licenses = SubscriptionLicenseSerializer(
+        many=True,
+        required=False,
+        default=list
+    )
+    subscription_licenses_by_status = SubscriptionLicenseStatusSerializer()
+
+    def create(self, validated_data):
+        return validated_data
+
+    def update(self, instance, validated_data):
+        return validated_data
+
+
+class EnterpriseCustomerUserSubsidiesSerializer(serializers.Serializer):
+    """
+    Serializer for enterprise customer user subsidies.
+    """
+
+    subscriptions = SubscriptionsSerializer()
+
+    def create(self, validated_data):
+        return validated_data
+
+    def update(self, instance, validated_data):
+        return validated_data
+
+
+class BaseLearnerPortalResponseSerializer(BaseResponseSerializer, serializers.Serializer):
+    """
+    Serializer for base learner portal response.
+    """
+
+    enterprise_customer_user_subsidies = EnterpriseCustomerUserSubsidiesSerializer()
+
+
+class EnterpriseCourseEnrollmentSerializer(serializers.Serializer):
+    """
+    Serializer for enterprise course enrollment.
+    """
+
+    course_run_id = serializers.CharField()
+    course_key = serializers.CharField()
+    course_type = serializers.CharField()
+    org_name = serializers.CharField()
+    course_run_status = serializers.CharField()
+    display_name = serializers.CharField()
+    emails_enabled = serializers.BooleanField()
+    certificate_download_url = serializers.URLField(allow_null=True)
+    created = serializers.DateTimeField()
+    start_date = serializers.DateTimeField()
+    end_date = serializers.DateTimeField()
+    mode = serializers.CharField()
+    is_enrollment_active = serializers.BooleanField()
+    product_source = serializers.CharField()
+    enroll_by = serializers.DateTimeField()
+    pacing = serializers.CharField()
+    course_run_url = serializers.URLField()
+    resume_course_run_url = serializers.URLField(allow_null=True)
+    is_revoked = serializers.BooleanField()
+
+    def create(self, validated_data):
+        return validated_data
+
+    def update(self, instance, validated_data):
+        return validated_data
+
+
+class LearnerDashboardResponseSerializer(BaseLearnerPortalResponseSerializer, serializers.Serializer):
+    """
+    Serializer for the learner dashboard response.
+    """
+
+    enterprise_course_enrollments = EnterpriseCourseEnrollmentSerializer(many=True)

--- a/enterprise_access/apps/bffs/tests/test_context.py
+++ b/enterprise_access/apps/bffs/tests/test_context.py
@@ -1,5 +1,5 @@
 """
-Text for the BFF context
+Tests for the BFF context
 """
 
 from unittest import mock

--- a/enterprise_access/apps/bffs/tests/test_handlers.py
+++ b/enterprise_access/apps/bffs/tests/test_handlers.py
@@ -1,4 +1,9 @@
+"""
+Tests for BFF handlers
+"""
 from unittest import mock
+
+from rest_framework import status
 
 from enterprise_access.apps.bffs.context import HandlerContext
 from enterprise_access.apps.bffs.handlers import BaseHandler, BaseLearnerPortalHandler, DashboardHandler
@@ -21,36 +26,28 @@ class TestBaseHandler(TestHandlerContextMixin):
         mock_get_enterprise_customers_for_user.return_value = {'results': []}
         context = HandlerContext(self.request)
         base_handler = BaseHandler(context)
-        expected_output = {
-            "developer_message": "No enterprise uuid associated to the user mock-uuid",
-            "user_message": "You may not be associated with the enterprise.",
-        }
         # Define kwargs for add_error
         arguments = {
-            **expected_output,
-            "status": 403  # Add an attribute that is not explicitly defined in the serializer to verify
+            **self.mock_error,
+            "status_code": status.HTTP_400_BAD_REQUEST
         }
         base_handler.add_error(
             **arguments
         )
-        self.assertEqual(expected_output, base_handler.context.errors[0])
+        self.assertEqual(self.mock_error, base_handler.context.errors[0])
 
     def test_base_handler_add_warning(self):
         context = HandlerContext(self.request)
         base_handler = BaseHandler(context)
-        expected_output = {
-            "developer_message": "Heuristic Expiration",
-            "user_message": "The data received might be out-dated",
-        }
         # Define kwargs for add_warning
         arguments = {
-            **expected_output,
+            **self.mock_warning,
             "status": 113  # Add an attribute that is not explicitly defined in the serializer to verify
         }
         base_handler.add_warning(
             **arguments
         )
-        self.assertEqual(expected_output, base_handler.context.warnings[0])
+        self.assertEqual(self.mock_warning, base_handler.context.warnings[0])
 
 
 class TestBaseLearnerPortalHandler(TestHandlerContextMixin):
@@ -150,7 +147,7 @@ class TestBaseLearnerPortalHandler(TestHandlerContextMixin):
         self.assertEqual(actual_staff_enterprise_customer, expected_staff_enterprise_customer)
 
         # Base subscriptions related assertions
-        actual_subscriptions = handler.context.data.get('subscriptions')
+        actual_subscriptions = handler.context.data['enterprise_customer_user_subsidies']['subscriptions']
         expected_subscriptions = {
             'customer_agreement': None,
             'subscription_licenses': [],

--- a/enterprise_access/apps/bffs/tests/test_response_builders.py
+++ b/enterprise_access/apps/bffs/tests/test_response_builders.py
@@ -1,0 +1,152 @@
+from unittest import mock
+
+import ddt
+from rest_framework import status
+
+from enterprise_access.apps.api_client.tests.test_license_manager_client import MockLicenseManagerMetadataMixin
+from enterprise_access.apps.bffs.response_builder import BaseLearnerResponseBuilder, BaseResponseBuilder
+from enterprise_access.apps.bffs.serializers import (
+    EnterpriseCustomerUserSubsidiesSerializer,
+    SubscriptionLicenseStatusSerializer
+)
+from enterprise_access.apps.bffs.tests.utils import TestHandlerContextMixin
+
+
+@ddt.ddt
+class TestBaseResponseBuilder(TestHandlerContextMixin):
+
+    @mock.patch('enterprise_access.apps.bffs.context.HandlerContext')
+    def test_base_build_error(self, mock_handler_context):
+        mock_handler_context.return_value = self.mock_handler_context
+        base_response_builder = BaseResponseBuilder(mock_handler_context)
+        with self.assertRaises(NotImplementedError):
+            base_response_builder.build()
+
+    @ddt.data(
+        {
+            'errors': True,
+            'warnings': True,
+        },
+        {
+            'errors': True,
+            'warnings': False,
+        },
+        {
+            'errors': False,
+            'warnings': True,
+        },
+        {
+            'errors': False,
+            'warnings': False,
+        }
+    )
+    @mock.patch('enterprise_access.apps.bffs.context.HandlerContext')
+    @ddt.unpack
+    def test_add_errors_warnings_to_response(self, mock_handler_context, errors, warnings):
+        mock_handler_context.return_value = self.mock_handler_context
+        mock_handler_context_instance = mock_handler_context.return_value
+        base_response_builder = BaseResponseBuilder(mock_handler_context_instance)
+        sample_response = {
+            "some_existing_metadata": "should_still_exist"
+        }
+        expected_output = {
+            **sample_response,
+            'errors': [],
+            'warnings': [],
+        }
+
+        if errors:
+            mock_handler_context_instance.errors.append(self.mock_error)
+            expected_output['errors'] = [self.mock_error]
+        if warnings:
+            mock_handler_context_instance.warnings.append(self.mock_warning)
+            expected_output['warnings'] = [self.mock_warning]
+        response_data = base_response_builder.add_errors_warnings_to_response(sample_response)
+        self.assertEqual(response_data, expected_output)
+
+    # TODO Revisit this function in ENT-9633 to determine if 200 is ok for a nested errored response
+    @ddt.data(
+        {
+            'status_code': status.HTTP_400_BAD_REQUEST
+        },
+        {
+            'status_code': None
+        }
+    )
+    @mock.patch('enterprise_access.apps.bffs.context.HandlerContext')
+    @ddt.unpack
+    def test_get_status_code(self, mock_handler_context, status_code):
+        if status_code:
+            mock_handler_context.return_value = self.get_mock_handler_context(
+                _status_code=status_code
+            )
+        else:
+            mock_handler_context.return_value = self.mock_handler_context
+        mock_handler_context_instance = mock_handler_context.return_value
+        base_response_builder = BaseResponseBuilder(mock_handler_context_instance)
+        expected_output = status_code if status_code else status.HTTP_200_OK
+        response_status_code = base_response_builder.get_status_code()
+        self.assertEqual(response_status_code, expected_output)
+
+
+@ddt.ddt
+class TestBaseLearnerResponseBuilder(TestBaseResponseBuilder, MockLicenseManagerMetadataMixin):
+    def setUp(self):
+        super().setUp()
+        self.mock_enterprise_catalog_uuid_1 = self.faker.uuid4()
+        self.mock_enterprise_catalog_uuid_2 = self.faker.uuid4()
+
+        self.mock_subscription_plan_uuid_1 = self.faker.uuid4()
+        self.mock_subscription_plan_uuid_2 = self.faker.uuid4()
+
+        self.mock_customer_agreement_uuid_1 = self.faker.uuid4()
+        self.mock_customer_agreement_uuid_2 = self.faker.uuid4()
+
+    @ddt.data(
+        {'has_subscriptions_data': True},
+        {'has_subscriptions_data': False}
+    )
+    @mock.patch('enterprise_access.apps.bffs.context.HandlerContext')
+    @ddt.unpack
+    def test_build(self, mock_handler_context, has_subscriptions_data):
+        mock_handler_context.return_value = self.mock_handler_context
+        mock_handler_context_instance = mock_handler_context.return_value
+
+        base_learner_response_builder = BaseLearnerResponseBuilder(mock_handler_context_instance)
+        mock_subscriptions_data = {
+            "customer_agreement": None,
+            "subscription_licenses": [],
+            "subscription_licenses_by_status": {
+                'activated': [],
+                'assigned': [],
+                'expired': [],
+                'revoked': [],
+            },
+        }
+
+        if has_subscriptions_data:
+            mock_subscriptions_data.update({
+                "customer_agreement": self.mock_customer_agreement,
+                "subscription_licenses": [self.mock_subscription_license],
+                "subscription_licenses_by_status": {
+                    **mock_subscriptions_data['subscription_licenses_by_status'],
+                    'activated': [self.mock_subscription_license],
+                },
+            })
+
+        mock_handler_context_instance.data['enterprise_customer_user_subsidies'] = {
+            'subscriptions': mock_subscriptions_data,
+        }
+
+        expected_response = {
+            'enterprise_customer_user_subsidies': {
+                'subscriptions': mock_subscriptions_data,
+            },
+            'errors': [],
+            'warnings': [],
+        }
+
+        response_data, status_code = base_learner_response_builder.build()
+
+        self.assertEqual(response_data, expected_response)
+        self.assertEqual(status_code, status.HTTP_200_OK)

--- a/enterprise_access/apps/bffs/tests/utils.py
+++ b/enterprise_access/apps/bffs/tests/utils.py
@@ -1,10 +1,13 @@
 """
 Test utilities for BFFs.
 """
+from unittest import mock
 
 from django.test import RequestFactory, TestCase
 from faker import Faker
+from rest_framework import status
 
+from enterprise_access.apps.content_assignments.tests.test_utils import mock_course_run_1
 from enterprise_access.apps.core.tests.factories import UserFactory
 
 
@@ -34,6 +37,9 @@ class TestHandlerContextMixin(TestCase):
         }
         self.request.data = {}
 
+        # Mock HandlerContext
+        self.mock_handler_context = self.get_mock_handler_context()
+
         # Mock enterprise customer data
         self.mock_enterprise_customer = {
             'uuid': self.mock_enterprise_customer_uuid,
@@ -58,3 +64,57 @@ class TestHandlerContextMixin(TestCase):
             ],
             'enterprise_features': {'feature_flag': True}
         }
+        self.mock_error = {
+            "developer_message": "No enterprise uuid associated to the user mock-uuid",
+            "user_message": "You may not be associated with the enterprise.",
+        }
+        self.mock_warning = {
+            "developer_message": "Heuristic Expiration",
+            "user_message": "The data received might be out-dated",
+        }
+
+    def get_mock_handler_context(self, **kwargs):
+        """
+        Returns a mock handler context with optional overrides.
+        Any attribute in the context can be overridden by passing it as a keyword argument.
+        """
+        # Create default values for the mock HandlerContext
+        default_values = {
+            '_request': self.request,
+            '_status_code': status.HTTP_200_OK,
+            '_errors': [],
+            '_warnings': [],
+            '_enterprise_customer_uuid': self.mock_enterprise_customer_uuid,
+            '_enterprise_customer_slug': self.mock_enterprise_customer_slug,
+            '_lms_user_id': self.request.user.lms_user_id,
+            '_enterprise_features': {'feature_a': True},
+            'data': {},
+        }
+
+        # Update default values with any overrides provided via kwargs
+        default_values.update(kwargs)
+
+        # Create the mock HandlerContext
+        mock_handler_context = mock.MagicMock(**default_values)
+
+        # Define a dictionary of private attributes to property names
+        property_mocks = {
+            'request': getattr(mock_handler_context, '_request'),
+            'status_code': getattr(mock_handler_context, '_status_code'),
+            'errors': getattr(mock_handler_context, '_errors'),
+            'warnings': getattr(mock_handler_context, '_warnings'),
+            'enterprise_customer_uuid': getattr(mock_handler_context, '_enterprise_customer_uuid'),
+            'enterprise_customer_slug': getattr(mock_handler_context, '_enterprise_customer_slug'),
+            'lms_user_id': getattr(mock_handler_context, '_lms_user_id'),
+            'enterprise_features': getattr(mock_handler_context, '_enterprise_features'),
+        }
+
+        # Override the property getters
+        for property_name, private_attr in property_mocks.items():
+            setattr(
+                type(mock_handler_context),  # The class of the mock object
+                property_name,
+                mock.PropertyMock(return_value=private_attr)
+            )
+
+        return mock_handler_context


### PR DESCRIPTION
**Description:**
Adds the response builder to the BFF app. The response builders main responsibility is to take the now loaded data from the context layer, and serialize it in preparation to be returned to the user. This includes adding warnings, errors and status codes.

**Jira:**
ENT-XXXX

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
