### PR TITLE
fix: remove disable_onboarding_notifications

### DIFF
--- a/enterprise_access/apps/bffs/serializers.py
+++ b/enterprise_access/apps/bffs/serializers.py
@@ -56,7 +56,6 @@ class CustomerAgreementSerializer(serializers.Serializer):
     default_enterprise_catalog_uuid = serializers.UUIDField(allow_null=True)
     net_days_until_expiration = serializers.IntegerField()
     disable_expiration_notifications = serializers.BooleanField()
-    disable_onboarding_notifications = serializers.BooleanField()
     enable_auto_applied_subscriptions_with_universal_link = serializers.BooleanField()
     subscription_for_auto_applied_licenses = serializers.UUIDField(allow_null=True)
 


### PR DESCRIPTION
**Description:**

The `MinimalCustomerAgreementSerializer` does not expose the `disable_onboarding_notifications`. It was incorrectly added, and thus removed.

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
