### PR TITLE
fix: when fetching licenses, return revoked/expired

### DIFF
--- a/enterprise_access/apps/api_client/license_manager_client.py
+++ b/enterprise_access/apps/api_client/license_manager_client.py
@@ -78,7 +78,7 @@ class LicenseManagerUserApiClient(BaseUserApiClient):
     def auto_apply_license_endpoint(self, customer_agreement_uuid):
         return f"{self.api_base_url}customer-agreement/{customer_agreement_uuid}/auto-apply/"
 
-    def get_subscription_licenses_for_learner(self, enterprise_customer_uuid):
+    def get_subscription_licenses_for_learner(self, enterprise_customer_uuid, **kwargs):
         """
         Get subscription licenses for a learner.
 
@@ -89,6 +89,7 @@ class LicenseManagerUserApiClient(BaseUserApiClient):
         """
         query_params = {
             'enterprise_customer_uuid': enterprise_customer_uuid,
+            **kwargs,
         }
         url = self.learner_licenses_endpoint
         try:

--- a/enterprise_access/apps/bffs/handlers.py
+++ b/enterprise_access/apps/bffs/handlers.py
@@ -161,7 +161,9 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
         """
         try:
             subscriptions_result = self.license_manager_client.get_subscription_licenses_for_learner(
-                enterprise_customer_uuid=self.context.enterprise_customer_uuid
+                enterprise_customer_uuid=self.context.enterprise_customer_uuid,
+                include_revoked=True,
+                current_plans_only=False,
             )
             subscriptions_data = self.transform_subscriptions_result(subscriptions_result)
             self.context.data['enterprise_customer_user_subsidies'].update({


### PR DESCRIPTION
**Description:**

In testing on stage, it was observed the revoked licenses were not getting returned by the BFF. This PR ensures they are returned. 

**Jira:**
ENT-XXXX

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
