### PR TITLE
chore: add tests around BFF viewset; cleanup and minor fixes

### DIFF
--- a/enterprise_access/apps/api/utils.py
+++ b/enterprise_access/apps/api/utils.py
@@ -81,7 +81,7 @@ def get_assignment_config_customer_uuid(assignment_configuration_uuid):
     return None
 
 
-def get_bff_enterprise_customer_uuid(request):
+def get_or_fetch_enterprise_uuid_for_bff_request(request):
     """
     Extracts enterprise_customer_uuid from query params or request data.
     """

--- a/enterprise_access/apps/api/v1/tests/test_bff_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_bff_views.py
@@ -125,6 +125,25 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             },
         }
 
+        # Mock base response data
+        self.mock_dashboard_route_response_data = {
+            'enterprise_customer_user_subsidies': {
+                'subscriptions': {
+                    'customer_agreement': None,
+                    'subscription_licenses': [],
+                    'subscription_licenses_by_status': {
+                        'activated': [],
+                        'assigned': [],
+                        'expired': [],
+                        'revoked': [],
+                    },
+                },
+            },
+            'enterprise_course_enrollments': [],
+            'errors': [],
+            'warnings': [],
+        }
+
     @ddt.data(
         {
             'system_wide_role': SYSTEM_ENTERPRISE_LEARNER_ROLE,
@@ -195,23 +214,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
         expected_status_code = status.HTTP_200_OK
         if is_linked_user or system_wide_role == SYSTEM_ENTERPRISE_OPERATOR_ROLE:
             self.assertEqual(response.status_code, status.HTTP_200_OK)
-            expected_response_data = {
-                'enterprise_customer_user_subsidies': {
-                    'subscriptions': {
-                        'customer_agreement': None,
-                        'subscription_licenses': [],
-                        'subscription_licenses_by_status': {
-                            'activated': [],
-                            'assigned': [],
-                            'expired': [],
-                            'revoked': [],
-                        },
-                    },
-                },
-                'enterprise_course_enrollments': [],
-                'errors': [],
-                'warnings': [],
-            }
+            expected_response_data = self.mock_dashboard_route_response_data
         else:
             expected_status_code = status.HTTP_403_FORBIDDEN
             expected_response_data = {
@@ -254,7 +257,8 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
 
         response = self.client.post(dashboard_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        expected_response_data = {
+        expected_response_data = self.mock_dashboard_route_response_data.copy()
+        expected_response_data.update({
             'enterprise_customer_user_subsidies': {
                 'subscriptions': {
                     'customer_agreement': self.expected_customer_agreement,
@@ -267,10 +271,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                     },
                 },
             },
-            'enterprise_course_enrollments': [],
-            'errors': [],
-            'warnings': [],
-        }
+        })
         self.assertEqual(response.json(), expected_response_data)
 
     @mock_dashboard_dependencies
@@ -325,7 +326,8 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             'status': 'activated',
             'activation_date': '2024-01-01T00:00:00Z',
         }
-        expected_response_data = {
+        expected_response_data = self.mock_dashboard_route_response_data.copy()
+        expected_response_data.update({
             'enterprise_customer_user_subsidies': {
                 'subscriptions': {
                     'customer_agreement': self.expected_customer_agreement,
@@ -338,10 +340,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                     },
                 },
             },
-            'enterprise_course_enrollments': [],
-            'errors': [],
-            'warnings': [],
-        }
+        })
         self.assertEqual(response.json(), expected_response_data)
 
     @ddt.data(
@@ -493,7 +492,8 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             'activation_date': '2024-01-01T00:00:00Z',
         }
         expected_licenses = [expected_activated_subscription_license] if should_auto_apply else []
-        expected_response_data = {
+        expected_response_data = self.mock_dashboard_route_response_data.copy()
+        expected_response_data.update({
             'enterprise_customer_user_subsidies': {
                 'subscriptions': {
                     'customer_agreement': expected_customer_agreement,
@@ -506,10 +506,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                     },
                 },
             },
-            'enterprise_course_enrollments': [],
-            'errors': [],
-            'warnings': [],
-        }
+        })
         self.assertEqual(response.json(), expected_response_data)
 
     @mock_dashboard_dependencies
@@ -541,23 +538,10 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
 
         response = self.client.post(dashboard_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        expected_response_data = {
-            'enterprise_customer_user_subsidies': {
-                'subscriptions': {
-                    'customer_agreement': None,
-                    'subscription_licenses': [],
-                    'subscription_licenses_by_status': {
-                        'activated': [],
-                        'assigned': [],
-                        'expired': [],
-                        'revoked': [],
-                    },
-                },
-            },
+        expected_response_data = self.mock_dashboard_route_response_data.copy()
+        expected_response_data.update({
             'enterprise_course_enrollments': [
                 self.mock_enterprise_course_enrollment,
             ],
-            'errors': [],
-            'warnings': [],
-        }
+        })
         self.assertEqual(response.json(), expected_response_data)

--- a/enterprise_access/apps/api/v1/tests/test_bff_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_bff_views.py
@@ -31,7 +31,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
         Set up the tests.
         """
         super().setUp()
-        self.addCleanup(django_cache.clear)  # clear any leftover policy locks.
+        self.addCleanup(django_cache.clear)
         self.mock_subscription_licenses_data = {
             'customer_agreement': None,
             'results': [],

--- a/enterprise_access/apps/api/v1/tests/test_bff_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_bff_views.py
@@ -284,7 +284,8 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
         mock_activate_license,
     ):
         """
-        Test the dashboard route with subscriptions.
+        Test the dashboard route with subscriptions, handling
+        activation of assigned licenses.
         """
         self.set_jwt_cookie([{
             'system_wide_role': SYSTEM_ENTERPRISE_LEARNER_ROLE,
@@ -427,7 +428,8 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
         should_auto_apply,
     ):
         """
-        Test the dashboard route with subscriptions.
+        Test the dashboard route with subscriptions, auto-applying a subscription
+        license based on the customer agreement and enterprise customer settings.
         """
         self.set_jwt_cookie([{
             'system_wide_role': SYSTEM_ENTERPRISE_LEARNER_ROLE,

--- a/enterprise_access/apps/api/v1/tests/test_bff_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_bff_views.py
@@ -1,0 +1,556 @@
+"""
+Tests for bffs app API v1 views.
+"""
+from unittest import mock
+from urllib.parse import urlencode
+
+import ddt
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from enterprise_access.apps.api_client.tests.test_utils import MockLicenseManagerMetadataMixin
+from enterprise_access.apps.bffs.tests.utils import TestHandlerContextMixin
+from enterprise_access.apps.core.constants import (
+    SYSTEM_ENTERPRISE_ADMIN_ROLE,
+    SYSTEM_ENTERPRISE_LEARNER_ROLE,
+    SYSTEM_ENTERPRISE_OPERATOR_ROLE
+)
+from test_utils import APITest
+
+
+@ddt.ddt
+class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMetadataMixin, APITest):
+    """
+    Tests for the LearnerPortalBFFViewSet.
+    """
+
+    def setUp(self):
+        """
+        TODO
+        """
+        super().setUp()
+        self.mock_subscription_licenses_data = {
+            'customer_agreement': None,
+            'results': [],
+        }
+        self.mock_default_enterprise_enrollment_intentions_learner_status_data = {
+            "lms_user_id": self.mock_user.id,
+            "user_email": self.mock_user.email,
+            "enterprise_customer_uuid": self.mock_enterprise_customer_uuid,
+            "enrollment_statuses": {
+                "needs_enrollment": {
+                    "enrollable": [],
+                    "not_enrollable": [],
+                },
+                'already_enrolled': [],
+            },
+            "metadata": {
+                "total_default_enterprise_enrollment_intentions": 0,
+                "total_needs_enrollment": {
+                    "enrollable": 0,
+                    "not_enrollable": 0
+                },
+                "total_already_enrolled": 0
+            }
+        }
+        self.mock_enterprise_course_enrollment = {
+            "certificate_download_url": None,
+            "emails_enabled": False,
+            "course_run_id": "course-v1:BabsonX+MIS01x+1T2019",
+            "course_run_status": "in_progress",
+            "created": "2023-03-01T00:00:00Z",
+            "start_date": "2023-03-19T10:00:00Z",
+            "end_date": "2024-12-31T04:30:00Z",
+            "display_name": "AI for Leaders",
+            "course_run_url": "https://learning.edx.org/course/course-v1:BabsonX+MIS01x+1T2019/home",
+            "due_dates": [],
+            "pacing": "self",
+            "org_name": "BabsonX",
+            "is_revoked": False,
+            "is_enrollment_active": True,
+            "mode": "verified",
+            "resume_course_run_url": None,
+            "course_key": "BabsonX+MIS01x",
+            "course_type": "verified-audit",
+            "product_source": "edx",
+            "enroll_by": "2024-12-21T23:59:59Z",
+        }
+        self.mock_enterprise_course_enrollments = []
+
+        self.expected_customer_agreement = {
+            'uuid': self.mock_customer_agreement_uuid,
+            'available_subscription_catalogs': self.mock_customer_agreement.get('available_subscription_catalogs'),
+            'default_enterprise_catalog_uuid': self.mock_customer_agreement.get('default_enterprise_catalog_uuid'),
+            'net_days_until_expiration': self.mock_customer_agreement.get('net_days_until_expiration'),
+            'disable_expiration_notifications': self.mock_customer_agreement.get('disable_expiration_notifications'),
+            'enable_auto_applied_subscriptions_with_universal_link': self.mock_customer_agreement.get(
+                'enable_auto_applied_subscriptions_with_universal_link'
+            ),
+            'subscription_for_auto_applied_licenses': self.mock_customer_agreement.get(
+                'subscription_for_auto_applied_licenses'
+            ),
+            'has_custom_license_expiration_messaging_v2': self.mock_customer_agreement.get(
+                'has_custom_license_expiration_messaging_v2'
+            ),
+            'button_label_in_modal_v2': self.mock_customer_agreement.get('button_label_in_modal_v2'),
+            'expired_subscription_modal_messaging_v2': self.mock_customer_agreement.get(
+                'expired_subscription_modal_messaging_v2'
+            ),
+            'modal_header_text_v2': self.mock_customer_agreement.get('modal_header_text_v2'),
+        }
+        self.expected_subscription_license = {
+            'uuid': self.mock_subscription_license.get('uuid'),
+            'status': self.mock_subscription_license.get('status'),
+            'user_email': self.mock_subscription_license.get('user_email'),
+            'activation_date': self.mock_subscription_license.get('activation_date'),
+            'last_remind_date': self.mock_subscription_license.get('last_remind_date'),
+            'revoked_date': self.mock_subscription_license.get('revoked_date'),
+            'activation_key': self.mock_subscription_license.get('activation_key'),
+            'subscription_plan': {
+                'uuid': self.mock_subscription_plan_uuid,
+                'title': self.mock_subscription_plan.get('title'),
+                'enterprise_catalog_uuid': self.mock_subscription_plan.get('enterprise_catalog_uuid'),
+                'is_active': self.mock_subscription_plan.get('is_active'),
+                'is_current': self.mock_subscription_plan.get('is_current'),
+                'start_date': self.mock_subscription_plan.get('start_date'),
+                'expiration_date': self.mock_subscription_plan.get('expiration_date'),
+                'days_until_expiration': self.mock_subscription_plan.get('days_until_expiration'),
+                'days_until_expiration_including_renewals': self.mock_subscription_plan.get(
+                    'days_until_expiration_including_renewals'
+                ),
+                'should_auto_apply_licenses': self.mock_subscription_plan.get('should_auto_apply_licenses'),
+            },
+        }
+
+    @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_customers_for_user')
+    @mock.patch(
+        'enterprise_access.apps.api_client.license_manager_client.LicenseManagerUserApiClient'
+        '.get_subscription_licenses_for_learner'
+    )
+    @mock.patch(
+        'enterprise_access.apps.api_client.lms_client.LmsUserApiClient'
+        '.get_default_enterprise_enrollment_intentions_learner_status'
+    )
+    @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_course_enrollments')
+    def test_dashboard_empty_state(
+        self,
+        mock_get_enterprise_course_enrollments,
+        mock_get_default_enrollment_intentions_learner_status,
+        mock_get_subscription_licenses_for_learner,
+        mock_get_enterprise_customers_for_user,
+    ):
+        """
+        Test the dashboard route.
+        """
+        self.set_jwt_cookie([{
+            'system_wide_role': SYSTEM_ENTERPRISE_LEARNER_ROLE,
+            'context': str(self.mock_enterprise_customer_uuid),
+        }])
+        mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
+        mock_get_subscription_licenses_for_learner.return_value = self.mock_subscription_licenses_data
+        mock_get_default_enrollment_intentions_learner_status.return_value =\
+            self.mock_default_enterprise_enrollment_intentions_learner_status_data
+        mock_get_enterprise_course_enrollments.return_value = self.mock_enterprise_course_enrollments
+
+        query_params = {
+            'enterprie_customer_slug': self.mock_enterprise_customer_slug,
+        }
+        dashboard_url = reverse('api:v1:learner-portal-bff-dashboard')
+        dashboard_url += f"?{urlencode(query_params)}"
+
+        response = self.client.post(dashboard_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_response_data = {
+            'enterprise_customer_user_subsidies': {
+                'subscriptions': {
+                    'customer_agreement': None,
+                    'subscription_licenses': [],
+                    'subscription_licenses_by_status': {
+                        'activated': [],
+                        'assigned': [],
+                        'expired': [],
+                        'revoked': [],
+                    },
+                },
+            },
+            'enterprise_course_enrollments': [],
+            'errors': [],
+            'warnings': [],
+        }
+        self.assertEqual(response.json(), expected_response_data)
+
+    @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_customers_for_user')
+    @mock.patch(
+        'enterprise_access.apps.api_client.license_manager_client.LicenseManagerUserApiClient'
+        '.get_subscription_licenses_for_learner'
+    )
+    @mock.patch(
+        'enterprise_access.apps.api_client.lms_client.LmsUserApiClient'
+        '.get_default_enterprise_enrollment_intentions_learner_status'
+    )
+    @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_course_enrollments')
+    def test_dashboard_with_subscriptions(
+        self,
+        mock_get_enterprise_course_enrollments,
+        mock_get_default_enrollment_intentions_learner_status,
+        mock_get_subscription_licenses_for_learner,
+        mock_get_enterprise_customers_for_user,
+    ):
+        """
+        Test the dashboard route with subscriptions.
+        """
+        self.set_jwt_cookie([{
+            'system_wide_role': SYSTEM_ENTERPRISE_LEARNER_ROLE,
+            'context': str(self.mock_enterprise_customer_uuid),
+        }])
+        mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
+        mock_subscription_licenses_data = {
+            'customer_agreement': self.mock_customer_agreement,
+            'results': [self.mock_subscription_license],
+        }
+        mock_get_subscription_licenses_for_learner.return_value = mock_subscription_licenses_data
+        mock_get_default_enrollment_intentions_learner_status.return_value =\
+            self.mock_default_enterprise_enrollment_intentions_learner_status_data
+        mock_get_enterprise_course_enrollments.return_value = self.mock_enterprise_course_enrollments
+
+        query_params = {
+            'enterprie_customer_slug': self.mock_enterprise_customer_slug,
+        }
+        dashboard_url = reverse('api:v1:learner-portal-bff-dashboard')
+        dashboard_url += f"?{urlencode(query_params)}"
+
+        response = self.client.post(dashboard_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_response_data = {
+            'enterprise_customer_user_subsidies': {
+                'subscriptions': {
+                    'customer_agreement': self.expected_customer_agreement,
+                    'subscription_licenses': [self.expected_subscription_license],
+                    'subscription_licenses_by_status': {
+                        'activated': [self.expected_subscription_license],
+                        'assigned': [],
+                        'expired': [],
+                        'revoked': [],
+                    },
+                },
+            },
+            'enterprise_course_enrollments': [],
+            'errors': [],
+            'warnings': [],
+        }
+        self.assertEqual(response.json(), expected_response_data)
+
+    @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_customers_for_user')
+    @mock.patch(
+        'enterprise_access.apps.api_client.license_manager_client.LicenseManagerUserApiClient'
+        '.get_subscription_licenses_for_learner'
+    )
+    @mock.patch('enterprise_access.apps.api_client.license_manager_client.LicenseManagerUserApiClient.activate_license')
+    @mock.patch(
+        'enterprise_access.apps.api_client.lms_client.LmsUserApiClient'
+        '.get_default_enterprise_enrollment_intentions_learner_status'
+    )
+    @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_course_enrollments')
+    def test_dashboard_with_subscriptions_license_activation(
+        self,
+        mock_get_enterprise_course_enrollments,
+        mock_get_default_enrollment_intentions_learner_status,
+        mock_activate_license,
+        mock_get_subscription_licenses_for_learner,
+        mock_get_enterprise_customers_for_user,
+    ):
+        """
+        Test the dashboard route with subscriptions.
+        """
+        self.set_jwt_cookie([{
+            'system_wide_role': SYSTEM_ENTERPRISE_LEARNER_ROLE,
+            'context': str(self.mock_enterprise_customer_uuid),
+        }])
+        mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
+        mock_assigned_subscription_license = {
+            **self.mock_subscription_license,
+            'status': 'assigned',
+            'activation_date': None,
+        }
+        mock_activated_subscription_license = {
+            **self.mock_subscription_license,
+            'status': 'activated',
+            'activation_date': '2024-01-01T00:00:00Z',
+        }
+        mock_subscription_licenses_data = {
+            'customer_agreement': self.mock_customer_agreement,
+            'results': [mock_assigned_subscription_license],
+        }
+        mock_get_subscription_licenses_for_learner.return_value = mock_subscription_licenses_data
+        mock_activate_license.return_value = mock_activated_subscription_license
+        mock_get_default_enrollment_intentions_learner_status.return_value =\
+            self.mock_default_enterprise_enrollment_intentions_learner_status_data
+        mock_get_enterprise_course_enrollments.return_value = self.mock_enterprise_course_enrollments
+
+        query_params = {
+            'enterprie_customer_slug': self.mock_enterprise_customer_slug,
+        }
+        dashboard_url = reverse('api:v1:learner-portal-bff-dashboard')
+        dashboard_url += f"?{urlencode(query_params)}"
+
+        response = self.client.post(dashboard_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_activated_subscription_license = {
+            **self.expected_subscription_license,
+            'status': 'activated',
+            'activation_date': '2024-01-01T00:00:00Z',
+        }
+        expected_response_data = {
+            'enterprise_customer_user_subsidies': {
+                'subscriptions': {
+                    'customer_agreement': self.expected_customer_agreement,
+                    'subscription_licenses': [expected_activated_subscription_license],
+                    'subscription_licenses_by_status': {
+                        'activated': [expected_activated_subscription_license],
+                        'assigned': [],
+                        'expired': [],
+                        'revoked': [],
+                    },
+                },
+            },
+            'enterprise_course_enrollments': [],
+            'errors': [],
+            'warnings': [],
+        }
+        self.assertEqual(response.json(), expected_response_data)
+
+    @ddt.data(
+        # No identity provider, no universal link auto-apply, no plan for auto-apply.
+        # Expected: Should not auto-apply.
+        {
+            'identity_provider': False,
+            'auto_apply_with_universal_link': False,
+            'has_plan_for_auto_apply': False,
+            'should_auto_apply': False,
+        },
+        # Identity provider exists, but no universal link auto-apply, no plan for auto-apply.
+        # Expected: Should not auto-apply.
+        {
+            'identity_provider': True,
+            'auto_apply_with_universal_link': False,
+            'has_plan_for_auto_apply': False,
+            'should_auto_apply': False,
+        },
+        # No identity provider, universal link auto-apply is enabled, no plan for auto-apply.
+        # Expected: Should not auto-apply.
+        {
+            'identity_provider': False,
+            'auto_apply_with_universal_link': True,
+            'has_plan_for_auto_apply': False,
+            'should_auto_apply': False,
+        },
+        # Identity provider exists, universal link auto-apply is enabled, no plan for auto-apply.
+        # Expected: Should not auto-apply.
+        {
+            'identity_provider': True,
+            'auto_apply_with_universal_link': True,
+            'has_plan_for_auto_apply': False,
+            'should_auto_apply': False,
+        },
+        # No identity provider, no universal link auto-apply, but a plan for auto-apply exists.
+        # Expected: Should not auto-apply.
+        {
+            'identity_provider': False,
+            'auto_apply_with_universal_link': False,
+            'has_plan_for_auto_apply': True,
+            'should_auto_apply': False,
+        },
+        # Identity provider exists, no universal link auto-apply, but a plan for auto-apply exists.
+        # Expected: Should auto-apply.
+        {
+            'identity_provider': True,
+            'auto_apply_with_universal_link': False,
+            'has_plan_for_auto_apply': True,
+            'should_auto_apply': True,
+        },
+        # No identity provider, universal link auto-apply is enabled, and a plan for auto-apply exists.
+        # Expected: Should auto-apply.
+        {
+            'identity_provider': False,
+            'auto_apply_with_universal_link': True,
+            'has_plan_for_auto_apply': True,
+            'should_auto_apply': True,
+        },
+        # Identity provider exists, universal link auto-apply is enabled, and a plan for auto-apply exists.
+        # Expected: Should auto-apply.
+        {
+            'identity_provider': True,
+            'auto_apply_with_universal_link': True,
+            'has_plan_for_auto_apply': True,
+            'should_auto_apply': True,
+        },
+    )
+    @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_customers_for_user')
+    @mock.patch(
+        'enterprise_access.apps.api_client.license_manager_client.LicenseManagerUserApiClient'
+        '.get_subscription_licenses_for_learner'
+    )
+    @mock.patch(
+        'enterprise_access.apps.api_client.license_manager_client.LicenseManagerUserApiClient.auto_apply_license'
+    )
+    @mock.patch(
+        'enterprise_access.apps.api_client.lms_client.LmsUserApiClient'
+        '.get_default_enterprise_enrollment_intentions_learner_status'
+    )
+    @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_course_enrollments')
+    @ddt.unpack
+    def test_dashboard_with_subscriptions_license_auto_apply(
+        self,
+        mock_get_enterprise_course_enrollments,
+        mock_get_default_enrollment_intentions_learner_status,
+        mock_auto_apply_license,
+        mock_get_subscription_licenses_for_learner,
+        mock_get_enterprise_customers_for_user,
+        identity_provider,
+        auto_apply_with_universal_link,
+        has_plan_for_auto_apply,
+        should_auto_apply,
+    ):
+        """
+        Test the dashboard route with subscriptions.
+        """
+        self.set_jwt_cookie([{
+            'system_wide_role': SYSTEM_ENTERPRISE_LEARNER_ROLE,
+            'context': str(self.mock_enterprise_customer_uuid),
+        }])
+        mock_enterprise_customer_with_auto_apply = {
+            **self.mock_enterprise_customer,
+            'identity_provider': identity_provider,
+        }
+        mock_enterprise_learner_response_data = {
+            **self.mock_enterprise_learner_response_data,
+            'results': [
+                {
+                    'active': True,
+                    'enterprise_customer': mock_enterprise_customer_with_auto_apply,
+                },
+            ],
+        }
+        mock_get_enterprise_customers_for_user.return_value = mock_enterprise_learner_response_data
+        mock_auto_applied_subscription_license = {
+            **self.mock_subscription_license,
+            'status': 'activated',
+            'activation_date': '2024-01-01T00:00:00Z',
+        }
+        mock_subscription_licenses_data = {
+            **self.mock_subscription_licenses_data,
+            'customer_agreement': {
+                **self.mock_customer_agreement,
+                'enable_auto_applied_subscriptions_with_universal_link': auto_apply_with_universal_link,
+                'subscription_for_auto_applied_licenses': (
+                    self.mock_subscription_plan_uuid
+                    if has_plan_for_auto_apply else None
+                ),
+            },
+        }
+        mock_get_subscription_licenses_for_learner.return_value = mock_subscription_licenses_data
+        mock_auto_apply_license.return_value = mock_auto_applied_subscription_license
+        mock_get_default_enrollment_intentions_learner_status.return_value =\
+            self.mock_default_enterprise_enrollment_intentions_learner_status_data
+        mock_get_enterprise_course_enrollments.return_value = self.mock_enterprise_course_enrollments
+
+        query_params = {
+            'enterprie_customer_slug': self.mock_enterprise_customer_slug,
+        }
+        dashboard_url = reverse('api:v1:learner-portal-bff-dashboard')
+        dashboard_url += f"?{urlencode(query_params)}"
+
+        response = self.client.post(dashboard_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_customer_agreement = {
+            **self.expected_customer_agreement,
+            'enable_auto_applied_subscriptions_with_universal_link': auto_apply_with_universal_link,
+            'subscription_for_auto_applied_licenses': (
+                self.mock_subscription_plan_uuid
+                if has_plan_for_auto_apply else None
+            ),
+        }
+        expected_activated_subscription_license = {
+            **self.expected_subscription_license,
+            'status': 'activated',
+            'activation_date': '2024-01-01T00:00:00Z',
+        }
+        expected_licenses = [expected_activated_subscription_license] if should_auto_apply else []
+        expected_response_data = {
+            'enterprise_customer_user_subsidies': {
+                'subscriptions': {
+                    'customer_agreement': expected_customer_agreement,
+                    'subscription_licenses': expected_licenses,
+                    'subscription_licenses_by_status': {
+                        'activated': expected_licenses,
+                        'assigned': [],
+                        'expired': [],
+                        'revoked': [],
+                    },
+                },
+            },
+            'enterprise_course_enrollments': [],
+            'errors': [],
+            'warnings': [],
+        }
+        self.assertEqual(response.json(), expected_response_data)
+
+    @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_customers_for_user')
+    @mock.patch(
+        'enterprise_access.apps.api_client.license_manager_client.LicenseManagerUserApiClient'
+        '.get_subscription_licenses_for_learner'
+    )
+    @mock.patch(
+        'enterprise_access.apps.api_client.lms_client.LmsUserApiClient'
+        '.get_default_enterprise_enrollment_intentions_learner_status'
+    )
+    @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_course_enrollments')
+    def test_dashboard_with_enrollments(
+        self,
+        mock_get_enterprise_course_enrollments,
+        mock_get_default_enrollment_intentions_learner_status,
+        mock_get_subscription_licenses_for_learner,
+        mock_get_enterprise_customers_for_user,
+    ):
+        """
+        Test the dashboard route with enrollments.
+        """
+        self.set_jwt_cookie([{
+            'system_wide_role': SYSTEM_ENTERPRISE_LEARNER_ROLE,
+            'context': str(self.mock_enterprise_customer_uuid),
+        }])
+        mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
+        mock_get_subscription_licenses_for_learner.return_value = self.mock_subscription_licenses_data
+        mock_get_default_enrollment_intentions_learner_status.return_value =\
+            self.mock_default_enterprise_enrollment_intentions_learner_status_data
+        mock_get_enterprise_course_enrollments.return_value = [self.mock_enterprise_course_enrollment]
+
+
+        query_params = {
+            'enterprie_customer_slug': self.mock_enterprise_customer_slug,
+        }
+        dashboard_url = reverse('api:v1:learner-portal-bff-dashboard')
+        dashboard_url += f"?{urlencode(query_params)}"
+
+        response = self.client.post(dashboard_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_response_data = {
+            'enterprise_customer_user_subsidies': {
+                'subscriptions': {
+                    'customer_agreement': None,
+                    'subscription_licenses': [],
+                    'subscription_licenses_by_status': {
+                        'activated': [],
+                        'assigned': [],
+                        'expired': [],
+                        'revoked': [],
+                    },
+                },
+            },
+            'enterprise_course_enrollments': [
+                self.mock_enterprise_course_enrollment,
+            ],
+            'errors': [],
+            'warnings': [],
+        }
+        self.assertEqual(response.json(), expected_response_data)

--- a/enterprise_access/apps/api/v1/tests/test_bff_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_bff_views.py
@@ -234,7 +234,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
         """
         self.set_jwt_cookie([{
             'system_wide_role': SYSTEM_ENTERPRISE_LEARNER_ROLE,
-            'context': str(self.mock_enterprise_customer_uuid),
+            'context': self.mock_enterprise_customer_uuid,
         }])
         mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
         mock_subscription_licenses_data = {
@@ -288,7 +288,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
         """
         self.set_jwt_cookie([{
             'system_wide_role': SYSTEM_ENTERPRISE_LEARNER_ROLE,
-            'context': str(self.mock_enterprise_customer_uuid),
+            'context': self.mock_enterprise_customer_uuid,
         }])
         mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
         mock_assigned_subscription_license = {
@@ -431,7 +431,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
         """
         self.set_jwt_cookie([{
             'system_wide_role': SYSTEM_ENTERPRISE_LEARNER_ROLE,
-            'context': str(self.mock_enterprise_customer_uuid),
+            'context': self.mock_enterprise_customer_uuid,
         }])
         mock_enterprise_customer_with_auto_apply = {
             **self.mock_enterprise_customer,
@@ -523,7 +523,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
         """
         self.set_jwt_cookie([{
             'system_wide_role': SYSTEM_ENTERPRISE_LEARNER_ROLE,
-            'context': str(self.mock_enterprise_customer_uuid),
+            'context': self.mock_enterprise_customer_uuid,
         }])
         mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
         mock_get_subscription_licenses_for_learner.return_value = self.mock_subscription_licenses_data

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -56,7 +56,6 @@ SUBSIDY_ACCESS_POLICY_LIST_ENDPOINT = reverse('api:v1:subsidy-access-policies-li
 TEST_ENTERPRISE_UUID = uuid4()
 
 
-# pylint: disable=missing-function-docstring
 class CRUDViewTestMixin:
     """
     Mixin to set some basic state for test classes that cover the

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -63,6 +63,9 @@ class CRUDViewTestMixin:
     """
     @classmethod
     def setUpTestData(cls):
+        """
+        Set up some basic state for the test class.
+        """
         super().setUpTestData()
 
         cls.enterprise_uuid = TEST_ENTERPRISE_UUID

--- a/enterprise_access/apps/api/v1/views/bffs/common.py
+++ b/enterprise_access/apps/api/v1/views/bffs/common.py
@@ -52,11 +52,11 @@ class BaseBFFViewSet(ViewSet):
             context = HandlerContext(request=request)
         except Exception as exc:  # pylint: disable=broad-except
             logger.exception("Could not create the handler context.")
-            errors = {
+            error = {
                 'user_message': 'An error occurred while processing the request.',
                 'developer_message': f'Could not create the handler context. Error: {exc}',
             }
-            response_data = BaseResponseSerializer({'errors': [errors]}).data
+            response_data = BaseResponseSerializer({'errors': [error]}).data
             return response_data, status.HTTP_500_INTERNAL_SERVER_ERROR
 
         try:

--- a/enterprise_access/apps/api/v1/views/bffs/common.py
+++ b/enterprise_access/apps/api/v1/views/bffs/common.py
@@ -12,6 +12,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import ViewSet
 
 from enterprise_access.apps.bffs.context import HandlerContext
+from enterprise_access.apps.bffs.serializers import BaseResponseSerializer
 
 logger = logging.getLogger(__name__)
 
@@ -49,23 +50,30 @@ class BaseBFFViewSet(ViewSet):
         try:
             # Create the context based on the request
             context = HandlerContext(request=request)
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.exception("Could not create the handler context.")
+            errors = {
+                'user_message': 'An error occurred while processing the request.',
+                'developer_message': f'Could not create the handler context. Error: {exc}',
+            }
+            response_data = BaseResponseSerializer({'errors': [errors]}).data
+            return response_data, status.HTTP_500_INTERNAL_SERVER_ERROR
 
-            # Create the response builder
-            response_builder = response_builder_class(context)
-
+        try:
             # Create the route handler
             handler = handler_class(context)
 
-            # Load and process data using the handler
+            # Load and process route data
             handler.load_and_process()
         except Exception as exc:  # pylint: disable=broad-except
-            logger.exception("Could not load route data and build response.")
+            logger.exception("Could not create route handler or load/process route data.")
             context.add_error(
-                user_message="An error occurred while processing the request.",
-                developer_message=f"Error: {exc}",
+                user_message='An error occurred while processing the request.',
+                developer_message=f'Could not create route handler or load/process route data. Error: {exc}',
             )
 
         # Build the response data and status code
+        response_builder = response_builder_class(context)
         response_data, status_code = response_builder.build()
 
         ordered_representation = OrderedDict(response_data)
@@ -76,4 +84,4 @@ class BaseBFFViewSet(ViewSet):
         ordered_representation['errors'] = errors
         ordered_representation['warnings'] = warnings
 
-        return ordered_representation, status_code
+        return dict(ordered_representation), status_code

--- a/enterprise_access/apps/api/v1/views/bffs/learner_portal.py
+++ b/enterprise_access/apps/api/v1/views/bffs/learner_portal.py
@@ -2,11 +2,13 @@
 Enterprise BFFs for MFEs.
 """
 
-from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from edx_rbac.decorators import permission_required
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
+from enterprise_access.apps.api.utils import get_bff_enterprise_customer_uuid
 from enterprise_access.apps.api.v1.views.bffs.common import COMMON_BFF_QUERY_PARAMETERS, BaseBFFViewSet
 from enterprise_access.apps.bffs.handlers import DashboardHandler
 from enterprise_access.apps.bffs.response_builder import LearnerDashboardResponseBuilder
@@ -14,6 +16,7 @@ from enterprise_access.apps.bffs.serializers import (
     LearnerDashboardRequestSerializer,
     LearnerDashboardResponseSerializer
 )
+from enterprise_access.apps.core.constants import BFF_READ_PERMISSION
 
 
 class LearnerPortalBFFViewSet(BaseBFFViewSet):
@@ -35,6 +38,7 @@ class LearnerPortalBFFViewSet(BaseBFFViewSet):
         description='Retrieves, transforms, and processes data for the learner dashboard route.',
     )
     @action(detail=False, methods=['post'])
+    @permission_required(BFF_READ_PERMISSION, fn=get_bff_enterprise_customer_uuid)
     def dashboard(self, request, *args, **kwargs):
         """
         Retrieves, transforms, and processes data for the learner dashboard route.

--- a/enterprise_access/apps/api/v1/views/bffs/learner_portal.py
+++ b/enterprise_access/apps/api/v1/views/bffs/learner_portal.py
@@ -8,7 +8,7 @@ from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from enterprise_access.apps.api.utils import get_bff_enterprise_customer_uuid
+from enterprise_access.apps.api.utils import get_or_fetch_enterprise_uuid_for_bff_request
 from enterprise_access.apps.api.v1.views.bffs.common import COMMON_BFF_QUERY_PARAMETERS, BaseBFFViewSet
 from enterprise_access.apps.bffs.handlers import DashboardHandler
 from enterprise_access.apps.bffs.response_builder import LearnerDashboardResponseBuilder
@@ -38,7 +38,7 @@ class LearnerPortalBFFViewSet(BaseBFFViewSet):
         description='Retrieves, transforms, and processes data for the learner dashboard route.',
     )
     @action(detail=False, methods=['post'])
-    @permission_required(BFF_READ_PERMISSION, fn=get_bff_enterprise_customer_uuid)
+    @permission_required(BFF_READ_PERMISSION, fn=get_or_fetch_enterprise_uuid_for_bff_request)
     def dashboard(self, request, *args, **kwargs):
         """
         Retrieves, transforms, and processes data for the learner dashboard route.

--- a/enterprise_access/apps/api_client/tests/test_license_manager_client.py
+++ b/enterprise_access/apps/api_client/tests/test_license_manager_client.py
@@ -121,7 +121,7 @@ class TestLicenseManagerUserApiClient(MockLicenseManagerMetadataMixin):
     @mock.patch('requests.Session.send')
     @mock.patch('crum.get_current_request')
     def test_activate_license(self, mock_crum_get_current_request, mock_send):
-        expected_result = self.mock_learner_license_activation_response
+        expected_result = self.mock_subscription_license
         expected_url = LicenseManagerUserApiClient.license_activation_endpoint
 
         request = self.factory.post(expected_url)

--- a/enterprise_access/apps/api_client/tests/test_utils.py
+++ b/enterprise_access/apps/api_client/tests/test_utils.py
@@ -53,12 +53,12 @@ class MockLicenseManagerMetadataMixin(MockEnterpriseMetadata):
     def setUp(self):
         super().setUp()
 
-        self.mock_learner_license_uuid = self.faker.uuid4()
-        self.mock_learner_license_activation_uuid = self.faker.uuid4()
-        self.mock_license_activation_key = self.faker.uuid4()
-        self.mock_auto_apply_uuid = self.faker.uuid4()
-        self.mock_subscription_plan_uuid = self.faker.uuid4()
-        self.mock_customer_agreement_uuid = self.faker.uuid4()
+        self.mock_learner_license_uuid = str(self.faker.uuid4())
+        self.mock_learner_license_activation_uuid = str(self.faker.uuid4())
+        self.mock_license_activation_key = str(self.faker.uuid4())
+        self.mock_auto_apply_uuid = str(self.faker.uuid4())
+        self.mock_subscription_plan_uuid = str(self.faker.uuid4())
+        self.mock_customer_agreement_uuid = str(self.faker.uuid4())
 
         self.mock_subscription_plan = {
             "title": "mock_title",
@@ -88,11 +88,11 @@ class MockLicenseManagerMetadataMixin(MockEnterpriseMetadata):
                 self.mock_enterprise_catalog_uuid,
             ],
             "enable_auto_applied_subscriptions_with_universal_link": False,
-            "has_custom_license_expiration_messaging": False,
-            "modal_header_text": None,
-            "expired_subscription_modal_messaging": None,
-            "button_label_in_modal": None,
-            "url_for_button_in_modal": None
+            "has_custom_license_expiration_messaging_v2": False,
+            "modal_header_text_v2": None,
+            "expired_subscription_modal_messaging_v2": None,
+            "button_label_in_modal_v2": None,
+            "url_for_button_in_modal_v2": None
         }
         self.mock_subscription_license = {
             "uuid": self.mock_learner_license_activation_uuid,
@@ -104,10 +104,6 @@ class MockLicenseManagerMetadataMixin(MockEnterpriseMetadata):
             "revoked_date": None,
             "activation_key": self.mock_license_activation_key,
             "subscription_plan": self.mock_subscription_plan
-        }
-        self.mock_learner_license_activation_response = {
-            **self.mock_subscription_license,
-            "uuid": self.mock_learner_license_activation_uuid,
         }
         self.mock_learner_license_auto_apply_response = {
             **self.mock_subscription_license,

--- a/enterprise_access/apps/bffs/api.py
+++ b/enterprise_access/apps/bffs/api.py
@@ -1,0 +1,245 @@
+"""
+API methods for retrieving data from downstream services in the bffs app.
+"""
+import logging
+
+from django.conf import settings
+from edx_django_utils.cache import TieredCache
+
+from enterprise_access.apps.api_client.lms_client import LmsApiClient, LmsUserApiClient
+from enterprise_access.cache_utils import versioned_cache_key
+
+logger = logging.getLogger(__name__)
+
+REQUEST_CACHE_NAMESPACE = 'subsidy_access_policy'
+
+CACHE_MISS = object()
+
+
+def enterprise_customer_users_cache_key(username):
+    return versioned_cache_key('get_subsidy_learners_aggregate_data', username)
+
+
+def enterprise_customer_cache_key(enterprise_customer_slug, enterprise_customer_uuid):
+    return versioned_cache_key('enterprise_customer', enterprise_customer_slug, enterprise_customer_uuid)
+
+
+def get_and_cache_enterprise_customer_users(request, **kwargs):
+    """
+    Retrieves and caches enterprise learner data.
+    """
+    username = request.user.username
+    cache_key = enterprise_customer_users_cache_key(username)
+    cached_response = TieredCache.get_cached_response(cache_key)
+    if cached_response.is_found:
+        logger.info(
+            f'enterprise_customer_users cache hit for username {username}'
+        )
+        return cached_response.value
+
+    client = LmsUserApiClient(request)
+    response_payload = client.get_enterprise_customers_for_user(
+        username=username,
+        **kwargs,
+    )
+    TieredCache.set_all_tiers(cache_key, response_payload, settings.LMS_CLIENT_TIMEOUT)
+    return response_payload
+
+
+def get_and_cache_enterprise_customer(
+    enterprise_customer_slug=None,
+    enterprise_customer_uuid=None,
+):
+    """
+    Retrieves and caches enterprise customer data.
+    """
+    cache_key = enterprise_customer_cache_key(
+        enterprise_customer_slug=enterprise_customer_slug,
+        enterprise_customer_uuid=enterprise_customer_uuid,
+    )
+
+    cached_response = TieredCache.get_cached_response(cache_key)
+    if cached_response.is_found:
+        logger.info(
+            f'enterprise_customer cache hit for enterprise_customer_slug {enterprise_customer_slug} '
+            f'and/or enterprise_customer_uuid {enterprise_customer_uuid}'
+        )
+        return cached_response.value
+
+    response_payload = LmsApiClient().get_enterprise_customer_data(
+        enterprise_customer_uuid=enterprise_customer_uuid,
+        enterprise_customer_slug=enterprise_customer_slug,
+    )
+    TieredCache.set_all_tiers(cache_key, response_payload, settings.LMS_CLIENT_TIMEOUT)
+    return response_payload
+
+
+def _get_active_enterprise_customer(enterprise_customer_users):
+    """
+    Get the active enterprise customer user from the list of enterprise customer users.
+    """
+    active_enterprise_customer_user = next(
+        (
+            enterprise_customer_user
+            for enterprise_customer_user in enterprise_customer_users
+            if enterprise_customer_user.get('active', False)
+        ),
+        None
+    )
+    if active_enterprise_customer_user:
+        return active_enterprise_customer_user.get('enterprise_customer')
+    return None
+
+
+def _get_staff_enterprise_customer(
+    user,
+    enterprise_customer_slug=None,
+    enterprise_customer_uuid=None,
+):
+    """
+    Retrieve enterprise customer metadata from `enterprise-customer` LMS API endpoint
+    if there is no enterprise customer user for the request enterprise and the user is staff.
+    """
+    has_enterprise_customer_slug_or_uuid = enterprise_customer_slug or enterprise_customer_uuid
+    if has_enterprise_customer_slug_or_uuid and user.is_staff:
+        try:
+            staff_enterprise_customer = get_and_cache_enterprise_customer(
+
+            )
+            staff_enterprise_customer = LmsApiClient().get_enterprise_customer_data(
+                enterprise_customer_uuid=enterprise_customer_uuid,
+                enterprise_customer_slug=enterprise_customer_slug,
+            )
+            return staff_enterprise_customer
+        except Exception as exc:
+            raise Exception('Error retrieving enterprise customer data') from exc
+    return None
+
+
+def _determine_enterprise_customer_for_display(
+    enterprise_customer_slug,
+    enterprise_customer_uuid,
+    active_enterprise_customer=None,
+    requested_enterprise_customer=None,
+    staff_enterprise_customer=None,
+):
+    """
+    Determine the enterprise customer user for display.
+
+    Returns:
+        The enterprise customer user for display.
+    """
+    if not enterprise_customer_slug and not enterprise_customer_uuid:
+        # No enterprise customer specified in the request, so return the active enterprise customer
+        return active_enterprise_customer
+
+    # If the requested enterprise does not match the active enterprise customer user's slug/uuid
+    # and there is a linked enterprise customer user for the requested enterprise, return the
+    # linked enterprise customer.
+    request_matches_active_enterprise_customer = _request_matches_active_enterprise_customer(
+        active_enterprise_customer=active_enterprise_customer,
+        enterprise_customer_slug=enterprise_customer_slug,
+        enterprise_customer_uuid=enterprise_customer_uuid,
+    )
+    if not request_matches_active_enterprise_customer and requested_enterprise_customer:
+        return requested_enterprise_customer
+
+    # If the request user is staff and the requested enterprise does not match the active enterprise
+    # customer user's slug/uuid, return the staff-enterprise customer.
+    if staff_enterprise_customer:
+        return staff_enterprise_customer
+
+    # Otherwise, return the active enterprise customer.
+    return active_enterprise_customer
+
+
+def _request_matches_active_enterprise_customer(
+    enterprise_customer_slug,
+    enterprise_customer_uuid,
+    active_enterprise_customer
+):
+    """
+    Check if the request matches the active enterprise customer.
+    """
+    slug_matches_active_enterprise_customer = (
+        active_enterprise_customer and active_enterprise_customer.get('slug') == enterprise_customer_slug
+    )
+    uuid_matches_active_enterprise_customer = (
+        active_enterprise_customer and active_enterprise_customer.get('uuid') == enterprise_customer_uuid
+    )
+    return (
+        slug_matches_active_enterprise_customer or uuid_matches_active_enterprise_customer
+    )
+
+
+def _enterprise_customer_matches_slug_or_uuid(
+    enterprise_customer_slug,
+    enterprise_customer_uuid,
+    enterprise_customer,
+):
+    """
+    Check if the enterprise customer matches the slug or UUID.
+    Args:
+        enterprise_customer: The enterprise customer data.
+    Returns:
+        True if the enterprise customer matches the slug or UUID, otherwise False.
+    """
+    if not enterprise_customer:
+        return False
+
+    return (
+        enterprise_customer.get('slug') == enterprise_customer_slug or
+        enterprise_customer.get('uuid') == enterprise_customer_uuid
+    )
+
+
+def transform_enterprise_customer_users_data(data, request, enterprise_customer_slug, enterprise_customer_uuid):
+    """
+    Transforms enterprise learner data.
+    """
+    enterprise_customer_users = data.get('results', [])
+    active_enterprise_customer = _get_active_enterprise_customer(enterprise_customer_users)
+    enterprise_customer_user_for_requested_customer = next(
+        (
+            enterprise_customer_user
+            for enterprise_customer_user in enterprise_customer_users
+            if _enterprise_customer_matches_slug_or_uuid(
+                enterprise_customer=enterprise_customer_user.get('enterprise_customer'),
+                enterprise_customer_slug=enterprise_customer_slug,
+                enterprise_customer_uuid=enterprise_customer_uuid,
+            )
+        ),
+        None
+    )
+
+    # If no enterprise customer user is found for the requested customer (i.e., request user not explicitly
+    # linked), but the request user is staff, attempt to retrieve enterprise customer metadata from the
+    # `/enterprise-customer/` LMS API endpoint instead.
+    if not enterprise_customer_user_for_requested_customer:
+        staff_enterprise_customer = _get_staff_enterprise_customer(
+            user=request.user,
+            enterprise_customer_slug=enterprise_customer_slug,
+            enterprise_customer_uuid=enterprise_customer_uuid,
+        )
+    else:
+        staff_enterprise_customer = None
+
+    # Determine the enterprise customer user to use for the request.
+    requested_enterprise_customer = (
+        enterprise_customer_user_for_requested_customer.get('enterprise_customer')
+        if enterprise_customer_user_for_requested_customer else None
+    )
+    enterprise_customer = _determine_enterprise_customer_for_display(
+        enterprise_customer_slug=enterprise_customer_slug,
+        enterprise_customer_uuid=enterprise_customer_uuid,
+        active_enterprise_customer=active_enterprise_customer,
+        requested_enterprise_customer=requested_enterprise_customer,
+        staff_enterprise_customer=staff_enterprise_customer,
+    )
+
+    return {
+        'enterprise_customer': enterprise_customer,
+        'active_enterprise_customer': active_enterprise_customer,
+        'all_linked_enterprise_customer_users': enterprise_customer_users,
+        'staff_enterprise_customer': staff_enterprise_customer,
+    }

--- a/enterprise_access/apps/bffs/context.py
+++ b/enterprise_access/apps/bffs/context.py
@@ -140,12 +140,12 @@ class HandlerContext:
                 self.user.username,
                 traverse_pagination=True
             )
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as exc:
             self.add_error(
                 user_message='Error retrieving linked enterprise customers',
-                developer_message=str(e)
+                developer_message=f'Error: {exc}'
             )
-            return
+            raise exc
 
         # Set enterprise features from the response
         self._enterprise_features = enterprise_customer_users_data.get('enterprise_features', {})

--- a/enterprise_access/apps/bffs/context.py
+++ b/enterprise_access/apps/bffs/context.py
@@ -1,11 +1,18 @@
 """
 HandlerContext for bffs app.
 """
+import logging
 
 from rest_framework import status
 
 from enterprise_access.apps.api_client.lms_client import LmsApiClient, LmsUserApiClient
 from enterprise_access.apps.bffs import serializers
+from enterprise_access.apps.bffs.api import (
+    get_and_cache_enterprise_customer_users,
+    transform_enterprise_customer_users_data
+)
+
+logger = logging.getLogger(__name__)
 
 
 class HandlerContext:
@@ -136,157 +143,43 @@ class HandlerContext:
         Initializes the enterprise customer users for the request user.
         """
         try:
-            enterprise_customer_users_data = self.lms_user_api_client.get_enterprise_customers_for_user(
-                self.user.username,
+            enterprise_customer_users_data = get_and_cache_enterprise_customer_users(
+                self.request,
                 traverse_pagination=True
             )
-        except Exception as exc:
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.exception('Error retrieving linked enterprise customers')
             self.add_error(
                 user_message='Error retrieving linked enterprise customers',
-                developer_message=f'Error: {exc}'
+                developer_message=f'Could not fetch enterprise customer users. Error: {exc}'
             )
-            raise exc
+            return
 
         # Set enterprise features from the response
         self._enterprise_features = enterprise_customer_users_data.get('enterprise_features', {})
 
-        # Parse the enterprise customer user data
-        enterprise_customer_users = enterprise_customer_users_data.get('results', [])
-        active_enterprise_customer = self._get_active_enterprise_customer(enterprise_customer_users)
-        enterprise_customer_user_for_requested_customer = next(
-            (
-                enterprise_customer_user
-                for enterprise_customer_user in enterprise_customer_users
-                if self._enterprise_customer_matches_slug_or_uuid(enterprise_customer_user.get('enterprise_customer'))
-            ),
-            None
-        )
+        # Parse/transform the enterprise customer users data and update the context data
+        transformed_data = {}
+        try:
+            transformed_data = transform_enterprise_customer_users_data(
+                enterprise_customer_users_data,
+                request=self.request,
+                enterprise_customer_slug=self.enterprise_customer_slug,
+                enterprise_customer_uuid=self.enterprise_customer_uuid,
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.exception('Error transforming enterprise customer users data')
+            self.add_error(
+                user_message='Error transforming enterprise customer users data',
+                developer_message=f'Could not transform enterprise customer users data. Error: {exc}'
+            )
 
-        # If no enterprise customer user is found for the requested customer (i.e., request user not explicitly
-        # linked), but the request user is staff, attempt to retrieve enterprise customer metadata from the
-        # `/enterprise-customer/` LMS API endpoint instead.
-        if not enterprise_customer_user_for_requested_customer:
-            staff_enterprise_customer = self._get_staff_enterprise_customer()
-        else:
-            staff_enterprise_customer = None
-
-        # Determine the enterprise customer user to display
-        requested_enterprise_customer = (
-            enterprise_customer_user_for_requested_customer.get('enterprise_customer')
-            if enterprise_customer_user_for_requested_customer else None
-        )
-        enterprise_customer = self._determine_enterprise_customer_for_display(
-            active_enterprise_customer=active_enterprise_customer,
-            requested_enterprise_customer=requested_enterprise_customer,
-            staff_enterprise_customer=staff_enterprise_customer,
-        )
-
-        # Update the context data with the enterprise customer user information
         self.data.update({
-            'enterprise_customer': enterprise_customer,
-            'active_enterprise_customer': active_enterprise_customer,
-            'all_linked_enterprise_customer_users': enterprise_customer_users,
-            'staff_enterprise_customer': staff_enterprise_customer,
+            'enterprise_customer': transformed_data.get('enterprise_customer'),
+            'active_enterprise_customer': transformed_data.get('active_enterprise_customer'),
+            'all_linked_enterprise_customer_users': transformed_data.get('all_linked_enterprise_customer_users', []),
+            'staff_enterprise_customer': transformed_data.get('staff_enterprise_customer'),
         })
-
-    def _get_active_enterprise_customer(self, enterprise_customer_users):
-        """
-        Get the active enterprise customer user from the list of enterprise customer users.
-        """
-        active_enterprise_customer_user = next(
-            (
-                enterprise_customer_user
-                for enterprise_customer_user in enterprise_customer_users
-                if enterprise_customer_user.get('active', False)
-            ),
-            None
-        )
-        if active_enterprise_customer_user:
-            return active_enterprise_customer_user.get('enterprise_customer')
-        return None
-
-    def _get_staff_enterprise_customer(self):
-        """
-        Retrieve enterprise customer metadata from `enterprise-customer` LMS API endpoint
-        if there is no enterprise customer user for the request enterprise and the user is staff.
-        """
-        has_enterprise_customer_slug_or_uuid = self.enterprise_customer_slug or self.enterprise_customer_uuid
-        if has_enterprise_customer_slug_or_uuid and self.user.is_staff:
-            try:
-                staff_enterprise_customer = self.lms_api_client.get_enterprise_customer_data(
-                    enterprise_customer_uuid=self.enterprise_customer_uuid,
-                    enterprise_customer_slug=self.enterprise_customer_slug,
-                )
-                return staff_enterprise_customer
-            except Exception as e:  # pylint: disable=broad-except
-                self.add_error(
-                    user_message='Error retrieving enterprise customer data',
-                    developer_message=str(e)
-                )
-        return None
-
-    def _determine_enterprise_customer_for_display(
-        self,
-        active_enterprise_customer=None,
-        requested_enterprise_customer=None,
-        staff_enterprise_customer=None,
-    ):
-        """
-        Determine the enterprise customer user for display.
-
-        Returns:
-            The enterprise customer user for display.
-        """
-        if not self.enterprise_customer_slug and not self.enterprise_customer_uuid:
-            # No enterprise customer specified in the request, so return the active enterprise customer
-            return active_enterprise_customer
-
-        # If the requested enterprise does not match the active enterprise customer user's slug/uuid
-        # and there is a linked enterprise customer user for the requested enterprise, return the
-        # linked enterprise customer.
-        request_matches_active_enterprise_customer = self._request_matches_active_enterprise_customer(
-            active_enterprise_customer
-        )
-        if not request_matches_active_enterprise_customer and requested_enterprise_customer:
-            return requested_enterprise_customer
-
-        # If the request user is staff and the requested enterprise does not match the active enterprise
-        # customer user's slug/uuid, return the staff-enterprise customer.
-        if staff_enterprise_customer:
-            return staff_enterprise_customer
-
-        # Otherwise, return the active enterprise customer.
-        return active_enterprise_customer
-
-    def _request_matches_active_enterprise_customer(self, active_enterprise_customer):
-        """
-        Check if the request matches the active enterprise customer.
-        """
-        slug_matches_active_enterprise_customer = (
-            active_enterprise_customer and active_enterprise_customer.get('slug') == self.enterprise_customer_slug
-        )
-        uuid_matches_active_enterprise_customer = (
-            active_enterprise_customer and active_enterprise_customer.get('uuid') == self.enterprise_customer_uuid
-        )
-        return (
-            slug_matches_active_enterprise_customer or uuid_matches_active_enterprise_customer
-        )
-
-    def _enterprise_customer_matches_slug_or_uuid(self, enterprise_customer):
-        """
-        Check if the enterprise customer matches the slug or UUID.
-        Args:
-            enterprise_customer: The enterprise customer data.
-        Returns:
-            True if the enterprise customer matches the slug or UUID, otherwise False.
-        """
-        if not enterprise_customer:
-            return False
-
-        return (
-            enterprise_customer.get('slug') == self.enterprise_customer_slug or
-            enterprise_customer.get('uuid') == self.enterprise_customer_uuid
-        )
 
     def add_error(self, **kwargs):
         """

--- a/enterprise_access/apps/bffs/serializers.py
+++ b/enterprise_access/apps/bffs/serializers.py
@@ -58,6 +58,10 @@ class CustomerAgreementSerializer(serializers.Serializer):
     disable_expiration_notifications = serializers.BooleanField()
     enable_auto_applied_subscriptions_with_universal_link = serializers.BooleanField()
     subscription_for_auto_applied_licenses = serializers.UUIDField(allow_null=True)
+    has_custom_license_expiration_messaging_v2 = serializers.BooleanField()
+    button_label_in_modal_v2 = serializers.CharField(allow_null=True)
+    expired_subscription_modal_messaging_v2 = serializers.CharField(allow_null=True)
+    modal_header_text_v2 = serializers.CharField(allow_null=True)
 
     def create(self, validated_data):
         return validated_data
@@ -132,9 +136,9 @@ class SubscriptionsSerializer(serializers.Serializer):
     Serializer for enterprise customer user subsidies.
     """
 
-    customer_agreement = CustomerAgreementSerializer(required=False)
+    customer_agreement = CustomerAgreementSerializer(required=False, allow_null=True)
     subscription_licenses = SubscriptionLicenseSerializer(many=True, required=False, default=list)
-    subscription_licenses_by_status = SubscriptionLicenseStatusSerializer()
+    subscription_licenses_by_status = SubscriptionLicenseStatusSerializer(required=False)
 
     def create(self, validated_data):
         return validated_data
@@ -189,6 +193,10 @@ class EnterpriseCourseEnrollmentSerializer(serializers.Serializer):
     course_run_url = serializers.URLField()
     resume_course_run_url = serializers.URLField(allow_null=True)
     is_revoked = serializers.BooleanField()
+    due_dates = serializers.ListField(
+        child=serializers.DictField(),
+        allow_empty=True,
+    )
 
     def create(self, validated_data):
         return validated_data

--- a/enterprise_access/apps/bffs/tests/test_context.py
+++ b/enterprise_access/apps/bffs/tests/test_context.py
@@ -65,7 +65,7 @@ class TestHandlerContext(TestHandlerContextMixin):
         expected_errors = (
             [
                 {
-                    'developer_message': 'Mock exception',
+                    'developer_message': 'Could not fetch enterprise customer users. Error: Mock exception',
                     'user_message': 'Error retrieving linked enterprise customers'
                 }
             ] if raises_exception else []
@@ -124,8 +124,11 @@ class TestHandlerContext(TestHandlerContextMixin):
         expected_errors = (
             [
                 {
-                    'developer_message': 'Mock exception',
-                    'user_message': 'Error retrieving enterprise customer data'
+                    'user_message': 'Error transforming enterprise customer users data',
+                    'developer_message': (
+                        'Could not transform enterprise customer users data. '
+                        'Error: Error retrieving enterprise customer data'
+                    ),
                 }
             ] if raises_exception else []
         )

--- a/enterprise_access/apps/bffs/tests/test_handlers.py
+++ b/enterprise_access/apps/bffs/tests/test_handlers.py
@@ -15,7 +15,9 @@ class TestBaseHandler(TestHandlerContextMixin):
     Test BaseHandler
     """
 
-    def test_base_handler_load_and_process_not_implemented(self):
+    @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_customers_for_user')
+    def test_base_handler_load_and_process_not_implemented(self, mock_get_enterprise_customers_for_user):
+        mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
         context = HandlerContext(self.request)
         base_handler = BaseHandler(context)
         with self.assertRaises(NotImplementedError):
@@ -23,7 +25,7 @@ class TestBaseHandler(TestHandlerContextMixin):
 
     @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_customers_for_user')
     def test_base_handler_add_error(self, mock_get_enterprise_customers_for_user):
-        mock_get_enterprise_customers_for_user.return_value = {'results': []}
+        mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
         context = HandlerContext(self.request)
         base_handler = BaseHandler(context)
         # Define kwargs for add_error
@@ -36,7 +38,9 @@ class TestBaseHandler(TestHandlerContextMixin):
         )
         self.assertEqual(self.mock_error, base_handler.context.errors[0])
 
-    def test_base_handler_add_warning(self):
+    @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_customers_for_user')
+    def test_base_handler_add_warning(self, mock_get_enterprise_customers_for_user):
+        mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
         context = HandlerContext(self.request)
         base_handler = BaseHandler(context)
         # Define kwargs for add_warning
@@ -248,8 +252,14 @@ class TestDashboardHandler(TestHandlerContextMixin):
         }
         self.mock_enterprise_course_enrollments = [self.mock_enterprise_course_enrollment]
 
+    @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_customers_for_user')
     @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_course_enrollments')
-    def test_load_and_process(self, mock_get_enterprise_course_enrollments):
+    def test_load_and_process(
+        self,
+        mock_get_enterprise_course_enrollments,
+        mock_get_enterprise_customers_for_user,
+    ):
+        mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
         mock_get_enterprise_course_enrollments.return_value = self.mock_enterprise_course_enrollments
 
         context = HandlerContext(self.request)

--- a/enterprise_access/apps/bffs/tests/test_handlers.py
+++ b/enterprise_access/apps/bffs/tests/test_handlers.py
@@ -102,17 +102,17 @@ class TestBaseLearnerPortalHandler(TestHandlerContextMixin):
 
     @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_customers_for_user')
     @mock.patch(
-        'enterprise_access.apps.api_client.lms_client.LmsUserApiClient'
-        '.get_default_enterprise_enrollment_intentions_learner_status'
-    )
-    @mock.patch(
         'enterprise_access.apps.api_client.license_manager_client.LicenseManagerUserApiClient'
         '.get_subscription_licenses_for_learner'
     )
+    @mock.patch(
+        'enterprise_access.apps.api_client.lms_client.LmsUserApiClient'
+        '.get_default_enterprise_enrollment_intentions_learner_status'
+    )
     def test_load_and_process(
         self,
-        mock_get_subscription_licenses_for_learner,
         mock_get_default_enrollment_intentions_learner_status,
+        mock_get_subscription_licenses_for_learner,
         mock_get_enterprise_customers_for_user,
     ):
         """

--- a/enterprise_access/apps/bffs/tests/utils.py
+++ b/enterprise_access/apps/bffs/tests/utils.py
@@ -24,9 +24,9 @@ class TestHandlerContextMixin(TestCase):
         self.mock_staff_user = UserFactory(is_staff=True)
         self.faker = Faker()
 
-        self.mock_enterprise_customer_uuid = self.faker.uuid4()
+        self.mock_enterprise_customer_uuid = str(self.faker.uuid4())
         self.mock_enterprise_customer_slug = 'mock-slug'
-        self.mock_enterprise_customer_uuid_2 = self.faker.uuid4()
+        self.mock_enterprise_customer_uuid_2 = str(self.faker.uuid4())
         self.mock_enterprise_customer_slug_2 = 'mock-slug-2'
 
         # Mock request

--- a/enterprise_access/apps/bffs/tests/utils.py
+++ b/enterprise_access/apps/bffs/tests/utils.py
@@ -118,3 +118,49 @@ class TestHandlerContextMixin(TestCase):
             )
 
         return mock_handler_context
+
+
+def mock_enterprise_learner_dependency(func):
+    @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_customers_for_user')
+    def wrapper(self, *args, **kwargs):
+        return func(self, *args, **kwargs)
+    return wrapper
+
+
+def mock_subsidy_dependencies(func):
+    """
+    Mock the service dependencies for the subsidies.
+    """
+    @mock.patch(
+        'enterprise_access.apps.api_client.license_manager_client.LicenseManagerUserApiClient'
+        '.get_subscription_licenses_for_learner'
+    )
+    @mock.patch(
+        'enterprise_access.apps.api_client.lms_client.LmsUserApiClient'
+        '.get_default_enterprise_enrollment_intentions_learner_status'
+    )
+    def wrapper(self, *args, **kwargs):
+        return func(self, *args, **kwargs)
+    return wrapper
+
+
+def mock_common_dependencies(func):
+    """
+    Mock the common service dependencies.
+    """
+    @mock_enterprise_learner_dependency
+    @mock_subsidy_dependencies
+    def wrapper(self, *args, **kwargs):
+        return func(self, *args, **kwargs)
+    return wrapper
+
+
+def mock_dashboard_dependencies(func):
+    """
+    Mock the service dependencies for the dashboard route.
+    """
+    @mock_common_dependencies
+    @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_course_enrollments')
+    def wrapper(self, *args, **kwargs):
+        return func(self, *args, **kwargs)
+    return wrapper

--- a/enterprise_access/apps/core/constants.py
+++ b/enterprise_access/apps/core/constants.py
@@ -28,6 +28,11 @@ CONTENT_ASSIGNMENT_ADMIN_READ_PERMISSION = 'content_assignment.has_admin_read_ac
 CONTENT_ASSIGNMENT_ADMIN_WRITE_PERMISSION = 'content_assignment.has_admin_write_access'
 CONTENT_ASSIGNMENT_LEARNER_READ_PERMISSION = 'content_assignment.has_learner_read_access'
 
+BFF_LEARNER_ROLE = 'enterprise_access_bff_learner'
+BFF_ADMIN_ROLE = 'enterprise_access_bff_admin'
+BFF_OPERATOR_ROLE = 'enterprise_access_bff_operator'
+BFF_READ_PERMISSION = 'bff.has_read_access'
+
 ALL_ACCESS_CONTEXT = '*'
 
 

--- a/enterprise_access/apps/core/rules.py
+++ b/enterprise_access/apps/core/rules.py
@@ -209,6 +209,75 @@ def has_explicit_access_to_content_assignments_learner(user, enterprise_customer
     return _has_explicit_access_to_role(user, enterprise_customer_uuid, constants.CONTENT_ASSIGNMENTS_LEARNER_ROLE)
 
 
+@rules.predicate
+def has_implicit_access_to_bff_learner(_, enterprise_customer_uuid):
+    """
+    Check that if request user has implicit access to the given enterprise UUID for the
+    `BFF_LEARNER_ROLE` feature role.
+
+    Returns:
+        boolean: whether the request user has access.
+    """
+    return _has_implicit_access_to_role(_, enterprise_customer_uuid, constants.BFF_LEARNER_ROLE)
+
+
+@rules.predicate
+def has_explicit_access_to_bff_learner(user, enterprise_customer_uuid):
+    """
+    Check that if request user has explicit access to `BFF_LEARNER_ROLE` feature role.
+
+    Returns:
+        boolean: whether the request user has access.
+    """
+    return _has_explicit_access_to_role(user, enterprise_customer_uuid, constants.BFF_LEARNER_ROLE)
+
+
+@rules.predicate
+def has_implicit_access_to_bff_admin(_, enterprise_customer_uuid):
+    """
+    Check that if request user has implicit access to the given enterprise UUID for the
+    `BFF_ADMIN_ROLE` feature role.
+
+    Returns:
+        boolean: whether the request user has access.
+    """
+    return _has_implicit_access_to_role(_, enterprise_customer_uuid, constants.BFF_ADMIN_ROLE)
+
+
+@rules.predicate
+def has_explicit_access_to_bff_admin(user, enterprise_customer_uuid):
+    """
+    Check that if request user has explicit access to `BFF_ADMIN_ROLE` feature role.
+
+    Returns:
+        boolean: whether the request user has access.
+    """
+    return _has_explicit_access_to_role(user, enterprise_customer_uuid, constants.BFF_ADMIN_ROLE)
+
+
+@rules.predicate
+def has_implicit_access_to_bff_operator(_, enterprise_customer_uuid):
+    """
+    Check that if request user has implicit access to the given enterprise UUID for the
+    `BFF_OPERATOR_ROLE` feature role.
+
+    Returns:
+        boolean: whether the request user has access.
+    """
+    return _has_implicit_access_to_role(_, enterprise_customer_uuid, constants.BFF_OPERATOR_ROLE)
+
+
+@rules.predicate
+def has_explicit_access_to_bff_operator(user, enterprise_customer_uuid):
+    """
+    Check that if request user has explicit access to `BFF_OPERATOR_ROLE` feature role.
+
+    Returns:
+        boolean: whether the request user has access.
+    """
+    return _has_explicit_access_to_role(user, enterprise_customer_uuid, constants.BFF_OPERATOR_ROLE)
+
+
 ######################################################
 # Consolidate implicit and explicit rule predicates. #
 ######################################################
@@ -245,6 +314,18 @@ has_content_assignments_admin_access = (
 
 has_content_assignments_learner_access = (
     has_implicit_access_to_content_assignments_learner | has_explicit_access_to_content_assignments_learner
+)
+
+has_bff_learner_access = (
+    has_implicit_access_to_bff_learner | has_explicit_access_to_bff_learner
+)
+
+has_bff_admin_access = (
+    has_implicit_access_to_bff_admin | has_explicit_access_to_bff_admin
+)
+
+has_bff_operator_access = (
+    has_implicit_access_to_bff_operator | has_explicit_access_to_bff_operator
 )
 
 
@@ -342,5 +423,14 @@ rules.add_perm(
         has_content_assignments_operator_access |
         has_content_assignments_admin_access |
         has_content_assignments_learner_access
+    ),
+)
+
+rules.add_perm(
+    constants.BFF_READ_PERMISSION,
+    (
+        has_bff_learner_access |
+        has_bff_admin_access |
+        has_bff_operator_access
     ),
 )

--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -4,6 +4,9 @@ from os.path import abspath, dirname, join
 from corsheaders.defaults import default_headers as corsheaders_default_headers
 
 from enterprise_access.apps.core.constants import (
+    BFF_ADMIN_ROLE,
+    BFF_LEARNER_ROLE,
+    BFF_OPERATOR_ROLE,
     CONTENT_ASSIGNMENTS_ADMIN_ROLE,
     CONTENT_ASSIGNMENTS_LEARNER_ROLE,
     CONTENT_ASSIGNMENTS_OPERATOR_ROLE,
@@ -325,6 +328,7 @@ SYSTEM_TO_FEATURE_ROLE_MAPPING = {
         SUBSIDY_ACCESS_POLICY_OPERATOR_ROLE,
         CONTENT_ASSIGNMENTS_OPERATOR_ROLE,
         REQUESTS_ADMIN_ROLE,
+        BFF_OPERATOR_ROLE,
     ],
     SYSTEM_ENTERPRISE_ADMIN_ROLE: [
         # enterprise admins only need learner-level access to Subsidy Access Policy APIs since they aren't responsible
@@ -332,11 +336,13 @@ SYSTEM_TO_FEATURE_ROLE_MAPPING = {
         SUBSIDY_ACCESS_POLICY_LEARNER_ROLE,
         CONTENT_ASSIGNMENTS_ADMIN_ROLE,
         REQUESTS_ADMIN_ROLE,
+        BFF_ADMIN_ROLE,
     ],
     SYSTEM_ENTERPRISE_LEARNER_ROLE: [
         SUBSIDY_ACCESS_POLICY_LEARNER_ROLE,
         CONTENT_ASSIGNMENTS_LEARNER_ROLE,
         REQUESTS_LEARNER_ROLE,
+        BFF_LEARNER_ROLE,
     ],
 }
 


### PR DESCRIPTION
**Description:**

* Adds tests for `LearnerPortalBFFViewSet`.
  * Empty state (e.g., new enterprise learner)
  * Subscription licenses, including activation and auto-apply
  * Enrollments
* Add BFF permissions for viewset with edx-rbac's `@permission_required`.
* Error / exception handling cleanup.
* Adds `get_and_cache_*` methods for `enterprise-learner` and `enterprise-customer` LMS API calls.
* Updated serializers with `allow_null`, etc. where appropriate.

**Jira:**
[ENT-9639](https://2u-internal.atlassian.net/browse/ENT-9639)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
