### PR TITLE
fix: remove expired license status and define EnrollmentDueDateSerializer

### DIFF
--- a/enterprise_access/apps/api/v1/tests/test_bff_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_bff_views.py
@@ -141,7 +141,6 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                     'subscription_licenses_by_status': {
                         'activated': [],
                         'assigned': [],
-                        'expired': [],
                         'revoked': [],
                     },
                 },
@@ -277,7 +276,6 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                     'subscription_licenses_by_status': {
                         'activated': [self.expected_subscription_license],
                         'assigned': [],
-                        'expired': [],
                         'revoked': [],
                     },
                 },
@@ -346,7 +344,6 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                     'subscription_licenses_by_status': {
                         'activated': [expected_activated_subscription_license],
                         'assigned': [],
-                        'expired': [],
                         'revoked': [],
                     },
                 },
@@ -531,7 +528,6 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                     'subscription_licenses_by_status': {
                         'activated': expected_licenses,
                         'assigned': [],
-                        'expired': [],
                         'revoked': [],
                     },
                 },

--- a/enterprise_access/apps/bffs/serializers.py
+++ b/enterprise_access/apps/bffs/serializers.py
@@ -222,7 +222,6 @@ class SubscriptionLicenseStatusSerializer(BaseBffSerializer):
 
     activated = SubscriptionLicenseSerializer(many=True, required=False, default=list)
     assigned = SubscriptionLicenseSerializer(many=True, required=False, default=list)
-    expired = SubscriptionLicenseSerializer(many=True, required=False, default=list)
     revoked = SubscriptionLicenseSerializer(many=True, required=False, default=list)
 
 
@@ -252,6 +251,17 @@ class BaseLearnerPortalResponseSerializer(BaseResponseSerializer):
     enterprise_customer_user_subsidies = EnterpriseCustomerUserSubsidiesSerializer()
 
 
+
+class EnrollmentDueDateSerializer(BaseBffSerializer):
+    """
+    Serializer for enrollment due date.
+    """
+
+    name = serializers.CharField()
+    date = serializers.CharField()
+    url = serializers.URLField()
+
+
 class EnterpriseCourseEnrollmentSerializer(BaseBffSerializer):
     """
     Serializer for enterprise course enrollment.
@@ -277,7 +287,7 @@ class EnterpriseCourseEnrollmentSerializer(BaseBffSerializer):
     resume_course_run_url = serializers.URLField(allow_null=True)
     is_revoked = serializers.BooleanField()
     due_dates = serializers.ListField(
-        child=serializers.DictField(),
+        child=EnrollmentDueDateSerializer(),
         allow_empty=True,
     )
 

--- a/enterprise_access/apps/bffs/tests/test_response_builders.py
+++ b/enterprise_access/apps/bffs/tests/test_response_builders.py
@@ -141,7 +141,6 @@ class TestBaseLearnerResponseBuilder(TestBaseResponseBuilder, MockLicenseManager
             "subscription_licenses_by_status": {
                 'activated': [],
                 'assigned': [],
-                'expired': [],
                 'revoked': [],
             },
         }


### PR DESCRIPTION
**Description:**

* Defines `EnrollmentDueDate` serializer to reflect the specific fields it'd return, if there's a non-empty list (technically a no-op, since the `enterprise_course_enrollments` API hardcoded an empty list in its response). Opted to be explicit to match the newly defined TypeScript interface on the consuming Learner Portal.
* Removes `expired` subscription license status from the BFF serializer/responses since it's not actually a valid license status.

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
