### PR TITLE
fix: account for revoked licenses and staff users in auto-apply logic

### DIFF
--- a/enterprise_access/apps/api/v1/tests/test_bff_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_bff_views.py
@@ -448,7 +448,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             'has_plan_for_auto_apply': True,
             'should_auto_apply': True,
         },
-        # Existing activated license, identity provider exists, no universal link auto-apply,
+        # Existing activated license, identity provider exists, universal link auto-apply is enabled,
         # a plan for auto-apply exists, and not a staff request user.
         # Expected: Should not auto-apply.
         {
@@ -460,7 +460,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             'has_plan_for_auto_apply': True,
             'should_auto_apply': False,
         },
-        # Existing revoked license, identity provider exists, no universal link auto-apply,
+        # Existing revoked license, identity provider exists, universal link auto-apply is enabled,
         # a plan for auto-apply exists, and not a staff request user.
         # Expected: Should not auto-apply.
         {

--- a/enterprise_access/apps/api/v1/tests/test_bff_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_bff_views.py
@@ -352,73 +352,142 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
         self.assertEqual(response.json(), expected_response_data)
 
     @ddt.data(
-        # No identity provider, no universal link auto-apply, no plan for auto-apply.
+        # No existing licenses, identity provider, no universal link auto-apply, no plan for auto-apply,
+        # and not a staff request user.
         # Expected: Should not auto-apply.
         {
+            'has_existing_activated_license': False,
+            'has_existing_revoked_license': False,
+            'is_staff_request_user': False,
             'identity_provider': False,
             'auto_apply_with_universal_link': False,
             'has_plan_for_auto_apply': False,
             'should_auto_apply': False,
         },
-        # Identity provider exists, but no universal link auto-apply, no plan for auto-apply.
+        # No existing licenses, identity provider exists, but no universal link auto-apply, no plan for auto-apply.
+        # and not a staff request user.
         # Expected: Should not auto-apply.
         {
+            'has_existing_activated_license': False,
+            'has_existing_revoked_license': False,
+            'is_staff_request_user': False,
             'identity_provider': True,
             'auto_apply_with_universal_link': False,
             'has_plan_for_auto_apply': False,
             'should_auto_apply': False,
         },
-        # No identity provider, universal link auto-apply is enabled, no plan for auto-apply.
+        # No existing licenses, no identity provider, universal link auto-apply is enabled, no plan for auto-apply,
+        # and not a staff request user.
         # Expected: Should not auto-apply.
         {
+            'has_existing_activated_license': False,
+            'has_existing_revoked_license': False,
+            'is_staff_request_user': False,
             'identity_provider': False,
             'auto_apply_with_universal_link': True,
             'has_plan_for_auto_apply': False,
             'should_auto_apply': False,
         },
-        # Identity provider exists, universal link auto-apply is enabled, no plan for auto-apply.
+        # No existing licenses, identity provider exists, universal link auto-apply is enabled, no plan for auto-apply,
+        # and not a staff request user.
         # Expected: Should not auto-apply.
         {
+            'has_existing_activated_license': False,
+            'has_existing_revoked_license': False,
+            'is_staff_request_user': False,
             'identity_provider': True,
             'auto_apply_with_universal_link': True,
             'has_plan_for_auto_apply': False,
             'should_auto_apply': False,
         },
-        # No identity provider, no universal link auto-apply, but a plan for auto-apply exists.
+        # No existing licenses, no identity provider, no universal link auto-apply, a plan for auto-apply exists,
+        # and not a staff request user.
         # Expected: Should not auto-apply.
         {
+            'has_existing_activated_license': False,
+            'has_existing_revoked_license': False,
+            'is_staff_request_user': False,
             'identity_provider': False,
             'auto_apply_with_universal_link': False,
             'has_plan_for_auto_apply': True,
             'should_auto_apply': False,
         },
-        # Identity provider exists, no universal link auto-apply, but a plan for auto-apply exists.
+        # No existing licenses, identity provider exists, no universal link auto-apply,
+        # a plan for auto-apply exists, and not a staff request user.
         # Expected: Should auto-apply.
         {
+            'has_existing_activated_license': False,
+            'has_existing_revoked_license': False,
+            'is_staff_request_user': False,
             'identity_provider': True,
             'auto_apply_with_universal_link': False,
             'has_plan_for_auto_apply': True,
             'should_auto_apply': True,
         },
-        # No identity provider, universal link auto-apply is enabled, and a plan for auto-apply exists.
+        # No existing licenses, no identity provider, universal link auto-apply is enabled,
+        # a plan for auto-apply exists, and not a staff request user.
         # Expected: Should auto-apply.
         {
+            'has_existing_activated_license': False,
+            'has_existing_revoked_license': False,
+            'is_staff_request_user': False,
             'identity_provider': False,
             'auto_apply_with_universal_link': True,
             'has_plan_for_auto_apply': True,
             'should_auto_apply': True,
         },
-        # Identity provider exists, universal link auto-apply is enabled, and a plan for auto-apply exists.
+        # No existing licenses, identity provider exists, universal link auto-apply is enabled,
+        # a plan for auto-apply exists, and not a staff request user.
         # Expected: Should auto-apply.
         {
+            'has_existing_activated_license': False,
+            'has_existing_revoked_license': False,
+            'is_staff_request_user': False,
             'identity_provider': True,
             'auto_apply_with_universal_link': True,
             'has_plan_for_auto_apply': True,
             'should_auto_apply': True,
+        },
+        # Existing activated license, identity provider exists, no universal link auto-apply,
+        # a plan for auto-apply exists, and not a staff request user.
+        # Expected: Should not auto-apply.
+        {
+            'has_existing_activated_license': True,
+            'has_existing_revoked_license': False,
+            'is_staff_request_user': False,
+            'identity_provider': True,
+            'auto_apply_with_universal_link': True,
+            'has_plan_for_auto_apply': True,
+            'should_auto_apply': False,
+        },
+        # Existing revoked license, identity provider exists, no universal link auto-apply,
+        # a plan for auto-apply exists, and not a staff request user.
+        # Expected: Should not auto-apply.
+        {
+            'has_existing_activated_license': False,
+            'has_existing_revoked_license': True,
+            'is_staff_request_user': False,
+            'identity_provider': True,
+            'auto_apply_with_universal_link': True,
+            'has_plan_for_auto_apply': True,
+            'should_auto_apply': False,
+        },
+        # No existing licenses, identity provider exists, universal link auto-apply is enabled,
+        # a plan for auto-apply exists, and is a staff request user.
+        # Expected: Should not auto-apply.
+        {
+            'has_existing_activated_license': False,
+            'has_existing_revoked_license': False,
+            'is_staff_request_user': True,
+            'identity_provider': True,
+            'auto_apply_with_universal_link': True,
+            'has_plan_for_auto_apply': True,
+            'should_auto_apply': False,
         },
     )
     @ddt.unpack
     @mock_dashboard_dependencies
+    @mock.patch('enterprise_access.apps.api_client.lms_client.LmsApiClient.get_enterprise_customer_data')
     @mock.patch(
         'enterprise_access.apps.api_client.license_manager_client.LicenseManagerUserApiClient.auto_apply_license'
     )
@@ -429,6 +498,10 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
         mock_get_subscription_licenses_for_learner,
         mock_get_enterprise_course_enrollments,
         mock_auto_apply_license,
+        mock_get_enterprise_customer_data,
+        has_existing_activated_license,
+        has_existing_revoked_license,
+        is_staff_request_user,
         identity_provider,
         auto_apply_with_universal_link,
         has_plan_for_auto_apply,
@@ -442,6 +515,13 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             'system_wide_role': SYSTEM_ENTERPRISE_LEARNER_ROLE,
             'context': self.mock_enterprise_customer_uuid,
         }])
+
+        if is_staff_request_user:
+            # Set the request user as a staff user and mock the enterprise customer response data.
+            self.user.is_staff = True
+            self.user.save()
+            mock_get_enterprise_customer_data.return_value = self.mock_enterprise_customer
+
         mock_identity_provider = 'mock_idp' if identity_provider else None
         mock_identity_providers = (
             [
@@ -458,14 +538,17 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             'identity_provider': mock_identity_provider,
             'identity_providers': mock_identity_providers,
         }
+        mock_linked_enterprise_customer_users = (
+            []
+            if is_staff_request_user
+            else [{
+                'active': True,
+                'enterprise_customer': mock_enterprise_customer_with_auto_apply,
+            }]
+        )
         mock_enterprise_learner_response_data = {
             **self.mock_enterprise_learner_response_data,
-            'results': [
-                {
-                    'active': True,
-                    'enterprise_customer': mock_enterprise_customer_with_auto_apply,
-                },
-            ],
+            'results': mock_linked_enterprise_customer_users,
         }
         mock_get_enterprise_customers_for_user.return_value = mock_enterprise_learner_response_data
         mock_auto_applied_subscription_license = {
@@ -484,6 +567,17 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                 ),
             },
         }
+        if has_existing_activated_license:
+            mock_subscription_licenses_data['results'].append({
+                **self.mock_subscription_license,
+                'status': 'activated',
+                'activation_date': '2024-01-01T00:00:00Z',
+            })
+        if has_existing_revoked_license:
+            mock_subscription_licenses_data['results'].append({
+                **self.mock_subscription_license,
+                'status': 'revoked',
+            })
         mock_get_subscription_licenses_for_learner.return_value = mock_subscription_licenses_data
         mock_auto_apply_license.return_value = mock_auto_applied_subscription_license
         mock_get_default_enrollment_intentions_learner_status.return_value =\
@@ -511,7 +605,23 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             'status': 'activated',
             'activation_date': '2024-01-01T00:00:00Z',
         }
-        expected_licenses = [expected_activated_subscription_license] if should_auto_apply else []
+        expected_activated_licenses = (
+            [expected_activated_subscription_license]
+            if should_auto_apply or has_existing_activated_license
+            else []
+        )
+        expected_revoked_subscription_license = {
+            **self.expected_subscription_license,
+            'status': 'revoked',
+        }
+        expected_revoked_licenses = (
+            [expected_revoked_subscription_license]
+            if has_existing_revoked_license
+            else []
+        )
+        expected_licenses = []
+        expected_licenses.extend(expected_activated_licenses)
+        expected_licenses.extend(expected_revoked_licenses)
         expected_response_data = self.mock_dashboard_route_response_data.copy()
         expected_show_integration_warning = bool(identity_provider)
         expected_response_data.update({
@@ -526,9 +636,9 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                     'customer_agreement': expected_customer_agreement,
                     'subscription_licenses': expected_licenses,
                     'subscription_licenses_by_status': {
-                        'activated': expected_licenses,
+                        'activated': expected_activated_licenses,
                         'assigned': [],
-                        'revoked': [],
+                        'revoked': expected_revoked_licenses,
                     },
                 },
             },

--- a/enterprise_access/apps/api/v1/tests/test_bff_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_bff_views.py
@@ -364,7 +364,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             'has_plan_for_auto_apply': False,
             'should_auto_apply': False,
         },
-        # No existing licenses, identity provider exists, but no universal link auto-apply, no plan for auto-apply.
+        # No existing licenses, identity provider exists, but no universal link auto-apply, no plan for auto-apply,
         # and not a staff request user.
         # Expected: Should not auto-apply.
         {

--- a/enterprise_access/apps/bffs/api.py
+++ b/enterprise_access/apps/bffs/api.py
@@ -229,9 +229,6 @@ def _get_staff_enterprise_customer(
     if has_enterprise_customer_slug_or_uuid and user.is_staff:
         try:
             staff_enterprise_customer = get_and_cache_enterprise_customer(
-
-            )
-            staff_enterprise_customer = LmsApiClient().get_enterprise_customer_data(
                 enterprise_customer_uuid=enterprise_customer_uuid,
                 enterprise_customer_slug=enterprise_customer_slug,
             )

--- a/enterprise_access/apps/bffs/context.py
+++ b/enterprise_access/apps/bffs/context.py
@@ -99,6 +99,22 @@ class HandlerContext:
         return self.data.get('all_linked_enterprise_customer_users')
 
     @property
+    def is_request_user_linked_to_enterprise_customer(self):
+        """
+        Returns True if the request user is linked to the resolved enterprise customer, False otherwise.
+        Primary use case is to determine if the request user is explicitly linked to the enterprise customer versus
+        being a staff user with access.
+        """
+        if not self.enterprise_customer:
+            return False
+
+        enterprise_customer_uuid = self.enterprise_customer.get('uuid')
+        return any(
+            enterprise_customer_user.get('enterprise_customer', {}).get('uuid') == enterprise_customer_uuid
+            for enterprise_customer_user in self.all_linked_enterprise_customer_users
+        )
+
+    @property
     def staff_enterprise_customer(self):
         return self.data.get('staff_enterprise_customer')
 

--- a/enterprise_access/apps/bffs/handlers.py
+++ b/enterprise_access/apps/bffs/handlers.py
@@ -290,7 +290,7 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
         This method is called after `load_subscription_licenses` to handle further actions based
         on the loaded data.
         """
-        if not self.subscriptions or self.current_activated_licenses:
+        if not self.subscriptions or self.current_activated_license:
             # Skip processing if:
             # - there is no subscriptions data
             # - user already has an activated license(s)

--- a/enterprise_access/apps/bffs/handlers.py
+++ b/enterprise_access/apps/bffs/handlers.py
@@ -390,12 +390,7 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
         """
         Check if auto-apply licenses are available and apply them to the user.
         """
-        if (
-            self.current_assigned_licenses or
-            self.current_activated_licenses or
-            self.current_revoked_licenses or
-            not self.context.is_request_user_linked_to_enterprise_customer
-        ):
+        if (self.subscription_licenses or not self.context.is_request_user_linked_to_enterprise_customer):
             # Skip auto-apply if:
             #   - User has assigned/current license(s)
             #   - User has activated/current license(s)

--- a/enterprise_access/apps/bffs/tests/test_context.py
+++ b/enterprise_access/apps/bffs/tests/test_context.py
@@ -78,6 +78,8 @@ class TestHandlerContext(TestHandlerContextMixin):
         self.assertEqual(context.lms_user_id, self.mock_user.lms_user_id)
         expected_enterprise_customer = None if raises_exception else self.mock_enterprise_customer
         self.assertEqual(context.enterprise_customer, expected_enterprise_customer)
+        expected_is_linked_user = False if raises_exception else True
+        self.assertEqual(context.is_request_user_linked_to_enterprise_customer, expected_is_linked_user)
 
     @ddt.data(
         {'raises_exception': False},
@@ -141,6 +143,7 @@ class TestHandlerContext(TestHandlerContextMixin):
         self.assertEqual(context.lms_user_id, self.mock_staff_user.lms_user_id)
         expected_enterprise_customer = None if raises_exception else self.mock_enterprise_customer
         self.assertEqual(context.enterprise_customer, expected_enterprise_customer)
+        self.assertEqual(context.is_request_user_linked_to_enterprise_customer, False)
 
     @ddt.data(
         # No enterprise customer uuid/slug in the request; returns active enterprise customer user

--- a/enterprise_access/apps/bffs/tests/utils.py
+++ b/enterprise_access/apps/bffs/tests/utils.py
@@ -170,6 +170,8 @@ class TestHandlerContextMixin(TestCase):
             'enterprise_customer_uuid': getattr(mock_handler_context, '_enterprise_customer_uuid'),
             'enterprise_customer_slug': getattr(mock_handler_context, '_enterprise_customer_slug'),
             'enterprise_customer': mock_property_enterprise_customer,
+            'active_enterprise_customer': mock_property_enterprise_customer,
+            'staff_enterprise_customer': None,
             'lms_user_id': getattr(mock_handler_context, '_lms_user_id'),
             'enterprise_features': getattr(mock_handler_context, '_enterprise_features'),
         }
@@ -186,6 +188,10 @@ class TestHandlerContextMixin(TestCase):
 
 
 def mock_enterprise_learner_dependency(func):
+    """
+    Mock the enterprise customer related service dependencies.
+    """
+
     @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_customers_for_user')
     def wrapper(self, *args, **kwargs):
         return func(self, *args, **kwargs)

--- a/enterprise_access/apps/bffs/tests/utils.py
+++ b/enterprise_access/apps/bffs/tests/utils.py
@@ -191,7 +191,6 @@ def mock_enterprise_learner_dependency(func):
     """
     Mock the enterprise customer related service dependencies.
     """
-
     @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_customers_for_user')
     def wrapper(self, *args, **kwargs):
         return func(self, *args, **kwargs)


### PR DESCRIPTION
**Description:**

Extends auto-apply subscription license business logic and tests to include:
* Check for revoked subscription licenses (i.e., no auto-apply with revoked license).
* Check for being explicitly linked to the requested enterprise customer (i.e., no auto-apply as an unlinked staff user).

These additional checks ensure parity with existing business logic around auto-applied subscription licenses in the frontend ([source](https://github.com/openedx/frontend-app-learner-portal-enterprise/blob/73fc10e94aa64cb9103e8131d3fa9d4031d0c410/src/components/app/data/services/subsidies/subscriptions.js#L184)).

**Jira:**
[ENT-9813](https://2u-internal.atlassian.net/browse/ENT-9813)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
