### PR TITLE
fix: update error handling and add logger.info in BFF

### DIFF
--- a/enterprise_access/apps/bffs/context.py
+++ b/enterprise_access/apps/bffs/context.py
@@ -4,7 +4,6 @@ HandlerContext for bffs app.
 import logging
 
 from rest_framework import status
-from requests.exceptions import HTTPError
 
 from enterprise_access.apps.bffs import serializers
 from enterprise_access.apps.bffs.api import (
@@ -174,14 +173,14 @@ class HandlerContext:
             logger.info(
                 'No enterprise customer found for request user %s, enterprise customer uuid %s, '
                 'and/or enterprise slug %s',
-                self.user.id,
+                self.lms_user_id,
                 enterprise_customer_uuid,
                 enterprise_customer_slug,
             )
             self.add_error(
                 user_message='No enterprise customer found',
                 developer_message=(
-                    f'No enterprise customer found for request user {self.user.id} and enterprise uuid '
+                    f'No enterprise customer found for request user {self.lms_user_id} and enterprise uuid '
                     f'{enterprise_customer_uuid}, and/or enterprise slug {enterprise_customer_slug}'
                 ),
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -215,19 +214,13 @@ class HandlerContext:
                 enterprise_customer_slug=self.enterprise_customer_slug,
                 enterprise_customer_uuid=self.enterprise_customer_uuid,
             )
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             logger.exception(
                 'Error transforming enterprise customer users metadata for request user %s, '
                 'enterprise customer uuid %s and/or slug %s',
                 self.lms_user_id,
                 self.enterprise_customer_uuid,
                 self.enterprise_customer_slug,
-            )
-            self.add_error(
-                user_message='Could not transform enterprise customer metadata',
-                developer_message=(
-                    f'Unable to transform enterprise customer users metadata. Error: {exc}'
-                ),
             )
 
         # Update the context data with the transformed enterprise customer users data

--- a/enterprise_access/apps/bffs/handlers.py
+++ b/enterprise_access/apps/bffs/handlers.py
@@ -121,7 +121,9 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
         """
         for customer_record_key in ('enterprise_customer', 'active_enterprise_customer', 'staff_enterprise_customer'):
             if not (customer_record := getattr(self.context, customer_record_key, None)):
-                logger.warning(f"No {customer_record_key} found in the context for request user {self.context.lms_user_id}")
+                logger.warning(
+                    f"No {customer_record_key} found in the context for request user {self.context.lms_user_id}"
+                )
                 continue
             self.context.data[customer_record_key] = self.transform_enterprise_customer(customer_record)
 

--- a/enterprise_access/apps/bffs/handlers.py
+++ b/enterprise_access/apps/bffs/handlers.py
@@ -457,6 +457,17 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
         """
         Load default enterprise course enrollments (stubbed)
         """
+        if not self.context.is_request_user_linked_to_enterprise_customer:
+            # Skip loading default enterprise enrollment intentions if the request
+            # user is not linked to specified enterprise customer (e.g., staff request user)
+            logger.info(
+                'Request user %s is not linked to enterprise customer %s. Skipping default '
+                'enterprise enrollment intentions.',
+                self.context.lms_user_id,
+                self.context.enterprise_customer_uuid,
+            )
+            return
+
         try:
             default_enterprise_enrollment_intentions =\
                 get_and_cache_default_enterprise_enrollment_intentions_learner_status(
@@ -627,6 +638,15 @@ class DashboardHandler(BaseLearnerPortalHandler):
         Returns:
             list: A list of enterprise course enrollments.
         """
+        if not self.context.is_request_user_linked_to_enterprise_customer:
+            # Skip loading enterprise course enrollments if the request user is not linked to the enterprise customer
+            logger.info(
+                'Request user %s is not linked to enterprise customer %s. Skipping enterprise course enrollments.',
+                self.context.lms_user_id,
+                self.context.enterprise_customer_uuid,
+            )
+            return
+
         try:
             enterprise_course_enrollments = get_and_cache_enterprise_course_enrollments(
                 request=self.context.request,

--- a/enterprise_access/apps/bffs/handlers.py
+++ b/enterprise_access/apps/bffs/handlers.py
@@ -42,19 +42,26 @@ class BaseHandler:
         """
         raise NotImplementedError("Subclasses must implement `load_and_process` method.")
 
-    def add_error(self, **kwargs):
+    def add_error(self, user_message, developer_message, status_code=None):
         """
         Adds an error to the context.
         Output fields determined by the ErrorSerializer
         """
-        self.context.add_error(**kwargs)
+        self.context.add_error(
+            user_message=user_message,
+            developer_message=developer_message,
+            status_code=status_code,
+        )
 
-    def add_warning(self, **kwargs):
+    def add_warning(self, user_message, developer_message):
         """
         Adds an error to the context.
         Output fields determined by the WarningSerializer
         """
-        self.context.add_warning(**kwargs)
+        self.context.add_warning(
+            user_message=user_message,
+            developer_message=developer_message,
+        )
 
 
 class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
@@ -84,10 +91,7 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
         The method in this class simply calls common learner logic to ensure the context is set up.
         """
         if not self.context.enterprise_customer:
-            self.add_error(
-                user_message="An error occurred while loading the learner portal handler.",
-                developer_message="Enterprise customer not found in the context.",
-            )
+            logger.info('No enterprise customer found in the context for request user %s', self.context.lms_user_id)
             return
 
         try:
@@ -100,11 +104,15 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
             # Retrieve default enterprise courses and enroll in the redeemable ones
             self.load_default_enterprise_enrollment_intentions()
             self.enroll_in_redeemable_default_enterprise_enrollment_intentions()
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.exception("Error loading learner portal handler")
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.exception(
+                "Error loading/processing learner portal handler for request user %s and enterprise customer %s",
+                self.context.lms_user_id,
+                self.context.enterprise_customer_uuid,
+            )
             self.add_error(
-                user_message="An error occurred while loading and processing common learner logic.",
-                developer_message=f"Error: {e}",
+                user_message="Could not load and/or process common data",
+                developer_message=f"Unable to load and/or process common learner portal data: {exc}",
             )
 
     def transform_enterprise_customers(self):
@@ -113,6 +121,7 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
         """
         for customer_record_key in ('enterprise_customer', 'active_enterprise_customer', 'staff_enterprise_customer'):
             if not (customer_record := getattr(self.context, customer_record_key, None)):
+                logger.warning(f"No {customer_record_key} found in the context for request user {self.context.lms_user_id}")
                 continue
             self.context.data[customer_record_key] = self.transform_enterprise_customer(customer_record)
 
@@ -121,6 +130,10 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
                 self.transform_enterprise_customer_user(enterprise_customer_user)
                 for enterprise_customer_user in enterprise_customer_users
             ]
+        else:
+            logger.warning(
+                f"No linked enterprise customer users found in the context for request user {self.context.lms_user_id}"
+            )
 
     def load_and_process_subsidies(self):
         """
@@ -159,8 +172,13 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
         Returns:
             The transformed enterprise customer data.
         """
-        if not enterprise_customer or not enterprise_customer.get('enable_learner_portal', False):
-            # If the enterprise customer does not exist or the learner portal is not enabled, return None
+        if not enterprise_customer:
+            # If the enterprise customer does not exist, return None.
+            return None
+
+        if not enterprise_customer.get('enable_learner_portal', False):
+            # If the enterprise customer's learner portal is not enabled, log an info message and return None.
+            logger.info(f"Learner portal is not enabled for enterprise customer {enterprise_customer.get('uuid')}")
             return None
 
         # Learner Portal is enabled, so transform the enterprise customer data.
@@ -192,30 +210,16 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
             self.context.data['enterprise_customer_user_subsidies'].update({
                 'subscriptions': subscriptions_data,
             })
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.exception("Error loading subscription licenses")
-            self.add_error(
-                user_message="An error occurred while loading subscription licenses.",
-                developer_message=f"Error: {e}",
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.exception(
+                "Error loading subscription licenses for request user %s and enterprise customer %s",
+                self.context.lms_user_id,
+                self.context.enterprise_customer_uuid,
             )
-
-    def transform_subscription_licenses(self, subscription_licenses):
-        """
-        Transform subscription licenses data if needed.
-        """
-        return [
-            {
-                'uuid': subscription_license.get('uuid'),
-                'status': subscription_license.get('status'),
-                'user_email': subscription_license.get('user_email'),
-                'activation_date': subscription_license.get('activation_date'),
-                'last_remind_date': subscription_license.get('last_remind_date'),
-                'revoked_date': subscription_license.get('revoked_date'),
-                'activation_key': subscription_license.get('activation_key'),
-                'subscription_plan': subscription_license.get('subscription_plan', {}),
-            }
-            for subscription_license in subscription_licenses
-        ]
+            self.add_error(
+                user_message="Unable to retrieve subscription licenses",
+                developer_message=f"Unable to fetch subscription licenses. Error: {exc}",
+            )
 
     def transform_subscriptions_result(self, subscriptions_result):
         """
@@ -223,10 +227,7 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
         """
         subscription_licenses = subscriptions_result.get('results', [])
         subscription_licenses_by_status = {}
-
-        transformed_licenses = self.transform_subscription_licenses(subscription_licenses)
-
-        for subscription_license in transformed_licenses:
+        for subscription_license in subscription_licenses:
             status = subscription_license.get('status')
             if status not in subscription_licenses_by_status:
                 subscription_licenses_by_status[status] = []
@@ -234,7 +235,7 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
 
         return {
             'customer_agreement': subscriptions_result.get('customer_agreement'),
-            'subscription_licenses': transformed_licenses,
+            'subscription_licenses': subscription_licenses,
             'subscription_licenses_by_status': subscription_licenses_by_status,
         }
 
@@ -290,10 +291,14 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
         This method is called after `load_subscription_licenses` to handle further actions based
         on the loaded data.
         """
-        if not self.subscriptions or self.current_activated_license:
-            # Skip processing if:
-            # - there is no subscriptions data
-            # - user already has an activated license(s)
+        if not self.subscriptions:
+            # Skip process if there are no subscriptions data
+            logger.warning("No subscription data found for the request user %s", self.context.lms_user_id)
+            return
+
+        if self.current_activated_license:
+            # Skip processing if request user already has an activated license(s)
+            logger.info("User %s already has an activated license", self.context.lms_user_id)
             return
 
         # Check if there are 'assigned' licenses that need to be activated
@@ -332,23 +337,25 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
                         enterprise_customer_uuid=self.context.enterprise_customer_uuid,
                         lms_user_id=self.context.lms_user_id,
                     )
-                except Exception as e:  # pylint: disable=broad-exception-caught
-                    logger.exception(f"Error activating license {subscription_license.get('uuid')}")
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    license_uuid = subscription_license.get('uuid')
+                    logger.exception(f"Error activating license {license_uuid}")
                     self.add_error(
-                        user_message="An error occurred while activating a subscription license.",
-                        developer_message=f"License UUID: {subscription_license.get('uuid')}, Error: {e}",
+                        user_message="Unable to activate subscription license",
+                        developer_message=f"Could not activate subscription license {license_uuid}, Error: {exc}",
                     )
                     return
 
                 # Update the subscription_license data with the activation status and date; the activated license is not
                 # returned from the API, so we need to manually update the license object we have available.
-                transformed_activated_subscription_licenses = self.transform_subscription_licenses([activated_license])
+                transformed_activated_subscription_licenses = [activated_license]
                 activated_licenses.append(transformed_activated_subscription_licenses[0])
             else:
-                logger.error(f"Activation key not found for license {subscription_license.get('uuid')}")
+                license_uuid = subscription_license.get('uuid')
+                logger.error(f"Activation key not found for license {license_uuid}")
                 self.add_error(
-                    user_message="An error occurred while activating a subscription license.",
-                    developer_message=f"Activation key not found for license {subscription_license.get('uuid')}",
+                    user_message="No subscription license activation key found",
+                    developer_message=f"Activation key not found for license {license_uuid}",
                 )
 
         # Update the subscription_licenses_by_status data with the activated licenses
@@ -424,18 +431,26 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
                 lms_user_id=self.context.lms_user_id,
             )
             # Update the context with the auto-applied license data
-            transformed_auto_applied_licenses = self.transform_subscription_licenses([auto_applied_license])
-            licenses = self.subscription_licenses + transformed_auto_applied_licenses
-            subscription_licenses_by_status['activated'] = transformed_auto_applied_licenses
+            licenses = self.subscription_licenses + [auto_applied_license]
+            subscription_licenses_by_status['activated'] = [auto_applied_license]
             self.context.data['enterprise_customer_user_subsidies']['subscriptions'].update({
                 'subscription_licenses': licenses,
                 'subscription_licenses_by_status': subscription_licenses_by_status,
             })
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.exception("Error auto-applying license")
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.exception(
+                "Error auto-applying subscription license for user %s and "
+                "enterprise customer %s and customer agreement %s",
+                self.context.lms_user_id,
+                self.context.enterprise_customer_uuid,
+                customer_agreement.get('uuid'),
+            )
             self.add_error(
-                user_message="An error occurred while auto-applying a license.",
-                developer_message=f"Customer agreement UUID: {customer_agreement.get('uuid')}, Error: {e}",
+                user_message="Unable to auto-apply a subscription license.",
+                developer_message=(
+                    f"Could not auto-apply a subscription license for "
+                    f"customer agreement {customer_agreement.get('uuid')}, Error: {exc}",
+                )
             )
 
     def load_default_enterprise_enrollment_intentions(self):
@@ -450,10 +465,14 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
                 )
             self.context.data['default_enterprise_enrollment_intentions'] = default_enterprise_enrollment_intentions
         except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.exception("Error loading default enterprise courses")
+            logger.exception(
+                "Error loading default enterprise enrollment intentions for user %s and enterprise customer %s",
+                self.context.lms_user_id,
+                self.context.enterprise_customer_uuid,
+            )
             self.add_error(
-                user_message="An error occurred while loading default enterprise courses.",
-                developer_message=f"Error: {e}",
+                user_message="Could not load default enterprise enrollment intentions",
+                developer_message=f"Could not load default enterprise enrollment intentions. Error: {e}",
             )
 
     def enroll_in_redeemable_default_enterprise_enrollment_intentions(self):
@@ -464,7 +483,24 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
         needs_enrollment = enrollment_statuses.get('needs_enrollment', {})
         needs_enrollment_enrollable = needs_enrollment.get('enrollable', [])
 
-        if not (needs_enrollment_enrollable and self.current_activated_license):
+        if not needs_enrollment_enrollable:
+            # Skip enrolling in default enterprise courses if there are no enrollable courses for which to enroll
+            logger.info(
+                "No default enterprise enrollment intentions courses for which to enroll "
+                "for request user %s and enterprise customer %s",
+                self.context.lms_user_id,
+                self.context.enterprise_customer_uuid,
+            )
+            return
+
+        if not self.current_activated_license:
+            # Skip enrolling in default enterprise courses if there is no activated license
+            logger.info(
+                "No activated license found for request user %s and enterprise customer %s. "
+                "Skipping realization of default enterprise enrollment intentions.",
+                self.context.lms_user_id,
+                self.context.enterprise_customer_uuid,
+            )
             return
 
         license_uuids_by_course_run_key = {}
@@ -481,21 +517,30 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
         response_payload = self._request_default_enrollment_realizations(license_uuids_by_course_run_key)
 
         if failures := response_payload.get('failures'):
+            # Log and add error if there are failures realizing default enrollments
+            failures_str = json.dumps(failures)
+            logger.error(
+                'Default realization enrollment failures for request user %s and '
+                'enterprise customer %s: %s',
+                self.context.lms_user_id,
+                self.context.enterprise_customer_uuid,
+                failures_str,
+            )
             self.add_error(
                 user_message='There were failures realizing default enrollments',
-                developer_message='Default realization enrollment failures: ' + json.dumps(failures),
+                developer_message='Default realization enrollment failures: ' + failures_str,
             )
 
         if not self.context.data.get('default_enterprise_enrollment_realizations'):
             self.context.data['default_enterprise_enrollment_realizations'] = []
 
-        if response_payload['successes']:
+        if successful_enrollments := response_payload.get('successes', []):
             # Invalidate the default enterprise enrollment intentions and enterprise course enrollments cache
             # as the previously redeemable enrollment intentions have been processed/enrolled.
             self.invalidate_default_enrollment_intentions_cache()
             self.invalidate_enrollments_cache()
 
-        for enrollment in response_payload['successes']:
+        for enrollment in successful_enrollments:
             course_run_key = enrollment.get('course_run_key')
             self.context.data['default_enterprise_enrollment_realizations'].append({
                 'course_key': course_run_key,
@@ -523,7 +568,7 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
                 bulk_enrollment_payload,
             )
         except Exception as exc:  # pylint: disable=broad-exception-caught
-            logger.exception('Error actualizing default enrollments')
+            logger.exception('Error realizing default enterprise enrollment intentions')
             self.add_error(
                 user_message='There was an exception realizing default enrollments',
                 developer_message=f'Default realization enrollment exception: {exc}',
@@ -565,10 +610,14 @@ class DashboardHandler(BaseLearnerPortalHandler):
             # Load data specific to the dashboard route
             self.load_enterprise_course_enrollments()
         except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.exception("Error retrieving enterprise_course_enrollments")
+            logger.exception(
+                "Error loading and/or processing dashboard data for user %s and enterprise customer %s",
+                self.context.lms_user_id,
+                self.context.enterprise_customer_uuid,
+            )
             self.add_error(
-                user_message="An error occurred while processing the learner dashboard.",
-                developer_message=f"Error: {e}",
+                user_message="Could not load and/or processing the learner dashboard.",
+                developer_message=f"Failed to load and/or processing the learner dashboard data: {e}",
             )
 
     def load_enterprise_course_enrollments(self):
@@ -585,9 +634,9 @@ class DashboardHandler(BaseLearnerPortalHandler):
                 is_active=True,
             )
             self.context.data['enterprise_course_enrollments'] = enterprise_course_enrollments
-        except Exception as e:  # pylint: disable=broad-exception-caught
+        except Exception as exc:  # pylint: disable=broad-exception-caught
             logger.exception("Error retrieving enterprise course enrollments")
             self.add_error(
-                user_message="An error occurred while retrieving enterprise course enrollments.",
-                developer_message=f"Error: {e}",
+                user_message="Could not retrieve your enterprise course enrollments.",
+                developer_message=f"Failed to retrieve enterprise course enrollments: {exc}",
             )

--- a/enterprise_access/apps/bffs/response_builder.py
+++ b/enterprise_access/apps/bffs/response_builder.py
@@ -134,7 +134,7 @@ class LearnerDashboardResponseBuilder(BaseLearnerResponseBuilder, LearnerDashboa
             return serialized_data, self.status_code
         except Exception as exc:  # pylint: disable=broad-except
             logger.exception('Could not serialize the response data.')
-            self.context.add_error(
+            self.context.add_warning(
                 user_message='An error occurred while processing the response data.',
                 developer_message=f'Could not serialize the response data. Error: {exc}',
             )

--- a/enterprise_access/apps/bffs/serializers.py
+++ b/enterprise_access/apps/bffs/serializers.py
@@ -179,7 +179,7 @@ class CustomerAgreementSerializer(BaseBffSerializer):
         required=False, allow_null=True, default=False,
     )
     button_label_in_modal_v2 = serializers.CharField(required=False, allow_null=True)
-    expired_subscription_modal_messaging_v2 = serializers.CharField(required=False, allow_null=True)
+    expired_subscription_modal_messaging_v2 = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     modal_header_text_v2 = serializers.CharField(required=False, allow_null=True)
 
 

--- a/enterprise_access/apps/bffs/serializers.py
+++ b/enterprise_access/apps/bffs/serializers.py
@@ -157,7 +157,7 @@ class BaseResponseSerializer(BaseBffSerializer):
     Serializer for base response.
     """
 
-    enterprise_customer = EnterpriseCustomerSerializer()
+    enterprise_customer = EnterpriseCustomerSerializer(required=False, allow_null=True)
     errors = ErrorSerializer(many=True, required=False, default=list)
     warnings = WarningSerializer(many=True, required=False, default=list)
     enterprise_features = serializers.DictField(required=False, default=dict)
@@ -240,7 +240,7 @@ class EnterpriseCustomerUserSubsidiesSerializer(BaseBffSerializer):
     Serializer for enterprise customer user subsidies.
     """
 
-    subscriptions = SubscriptionsSerializer()
+    subscriptions = SubscriptionsSerializer(required=False, default=dict)
 
 
 class BaseLearnerPortalResponseSerializer(BaseResponseSerializer):

--- a/enterprise_access/apps/bffs/tests/test_context.py
+++ b/enterprise_access/apps/bffs/tests/test_context.py
@@ -5,6 +5,7 @@ Tests for the BFF context
 from unittest import mock
 
 import ddt
+from rest_framework import status
 from rest_framework.exceptions import ValidationError
 
 from enterprise_access.apps.bffs.context import HandlerContext
@@ -72,6 +73,14 @@ class TestHandlerContext(TestHandlerContextMixin):
         )
         self.assertEqual(context.errors, expected_errors)
         self.assertEqual(context.warnings, [])
+
+        expected_status_code = (
+            status.HTTP_500_INTERNAL_SERVER_ERROR
+            if raises_exception
+            else status.HTTP_200_OK
+        )
+        self.assertEqual(context.status_code, expected_status_code)
+
         self.assertEqual(context.enterprise_customer_uuid, self.mock_enterprise_customer_uuid)
         expected_slug = None if raises_exception else self.mock_enterprise_customer_slug
         self.assertEqual(context.enterprise_customer_slug, expected_slug)
@@ -135,9 +144,16 @@ class TestHandlerContext(TestHandlerContextMixin):
                 }
             ] if raises_exception else []
         )
-
         self.assertEqual(context.errors, expected_errors)
         self.assertEqual(context.warnings, [])
+
+        expected_status_code = (
+            status.HTTP_404_NOT_FOUND
+            if raises_exception
+            else status.HTTP_200_OK
+        )
+        self.assertEqual(context.status_code, expected_status_code)
+
         self.assertEqual(context.enterprise_features, self.mock_enterprise_learner_response_data['enterprise_features'])
         self.assertEqual(context.enterprise_customer_uuid, self.mock_enterprise_customer_uuid)
         expected_slug = None if raises_exception else self.mock_enterprise_customer_slug

--- a/enterprise_access/apps/bffs/tests/test_context.py
+++ b/enterprise_access/apps/bffs/tests/test_context.py
@@ -65,8 +65,8 @@ class TestHandlerContext(TestHandlerContextMixin):
         expected_errors = (
             [
                 {
-                    'developer_message': 'Could not fetch enterprise customer users. Error: Mock exception',
-                    'user_message': 'Error retrieving linked enterprise customers'
+                    'developer_message': 'Could not initialize enterprise customer users. Error: Mock exception',
+                    'user_message': 'Error initializing enterprise customer users'
                 }
             ] if raises_exception else []
         )
@@ -126,14 +126,16 @@ class TestHandlerContext(TestHandlerContextMixin):
         expected_errors = (
             [
                 {
-                    'user_message': 'Error transforming enterprise customer users data',
+                    'user_message': 'No enterprise customer found',
                     'developer_message': (
-                        'Could not transform enterprise customer users data. '
-                        'Error: Error retrieving enterprise customer data'
+                        f'No enterprise customer found for request user {context.lms_user_id} '
+                        f'and enterprise uuid {context.enterprise_customer_uuid}, '
+                        f'and/or enterprise slug {context.enterprise_customer_slug}'
                     ),
                 }
             ] if raises_exception else []
         )
+
         self.assertEqual(context.errors, expected_errors)
         self.assertEqual(context.warnings, [])
         self.assertEqual(context.enterprise_features, self.mock_enterprise_learner_response_data['enterprise_features'])

--- a/enterprise_access/apps/bffs/tests/test_handlers.py
+++ b/enterprise_access/apps/bffs/tests/test_handlers.py
@@ -37,7 +37,6 @@ class TestBaseHandler(TestHandlerContextMixin):
         self.assertEqual(self.mock_error, base_handler.context.errors[0])
         self.assertEqual(status.HTTP_400_BAD_REQUEST, base_handler.context.status_code)
 
-
     @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_customers_for_user')
     def test_base_handler_add_warning(self, mock_get_enterprise_customers_for_user):
         mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data

--- a/enterprise_access/apps/bffs/tests/test_handlers.py
+++ b/enterprise_access/apps/bffs/tests/test_handlers.py
@@ -33,24 +33,17 @@ class TestBaseHandler(TestHandlerContextMixin):
             **self.mock_error,
             "status_code": status.HTTP_400_BAD_REQUEST
         }
-        base_handler.add_error(
-            **arguments
-        )
+        base_handler.add_error(**arguments)
         self.assertEqual(self.mock_error, base_handler.context.errors[0])
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, base_handler.context.status_code)
+
 
     @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_customers_for_user')
     def test_base_handler_add_warning(self, mock_get_enterprise_customers_for_user):
         mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
         context = HandlerContext(self.request)
         base_handler = BaseHandler(context)
-        # Define kwargs for add_warning
-        arguments = {
-            **self.mock_warning,
-            "status_code": 113  # Add an attribute that is not explicitly defined in the serializer to verify
-        }
-        base_handler.add_warning(
-            **arguments
-        )
+        base_handler.add_warning(**self.mock_warning)
         self.assertEqual(self.mock_warning, base_handler.context.warnings[0])
 
 
@@ -222,10 +215,7 @@ class TestBaseLearnerPortalHandler(TestHandlerContextMixin):
     @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_customers_for_user')
     @mock.patch('enterprise_access.apps.api_client.lms_client.LmsApiClient.bulk_enroll_enterprise_learners')
     def test_request_default_enrollment_realizations(self, mock_bulk_enroll, mock_get_customers):
-        mock_get_customers.return_value = {
-            **self.mock_enterprise_learner_response_data,
-            'results': [],
-        }
+        mock_get_customers.return_value = self.mock_enterprise_learner_response_data
         license_uuids_by_course_run_key = {
             'course-run-1': 'license-1',
             'course-run-2': 'license-2',
@@ -250,10 +240,7 @@ class TestBaseLearnerPortalHandler(TestHandlerContextMixin):
     @mock.patch('enterprise_access.apps.api_client.lms_client.LmsUserApiClient.get_enterprise_customers_for_user')
     @mock.patch('enterprise_access.apps.api_client.lms_client.LmsApiClient.bulk_enroll_enterprise_learners')
     def test_request_default_enrollment_realizations_exception(self, mock_bulk_enroll, mock_get_customers):
-        mock_get_customers.return_value = {
-            **self.mock_enterprise_learner_response_data,
-            'results': [],
-        }
+        mock_get_customers.return_value = self.mock_enterprise_learner_response_data
         license_uuids_by_course_run_key = {
             'course-run-1': 'license-1',
             'course-run-2': 'license-2',
@@ -286,10 +273,7 @@ class TestBaseLearnerPortalHandler(TestHandlerContextMixin):
     def test_realize_default_enrollments(
         self, mock_get_intentions, mock_bulk_enroll, mock_get_customers
     ):
-        mock_get_customers.return_value = {
-            **self.mock_enterprise_learner_response_data,
-            'results': [],
-        }
+        mock_get_customers.return_value = self.mock_enterprise_learner_response_data
         mock_get_intentions.return_value = {
             "lms_user_id": self.mock_user.id,
             "user_email": self.mock_user.email,


### PR DESCRIPTION
**Description:**

1. Updates `logger.exception` messages in the BFF.
2. Updates some `user_message` and `developer_message` kwargs when calling `add_error` to add more info e.g., request user's `lms_user_id` and enterprise customer uuid, where possible.
3. Switched one usage of `add_error` to `add_warning` instead, specifically when the BFF response serializer input data is invalid. Rationale: considering it a warning vs. an error since we still resolve a serialized response, just without validation to keep the API response body usable by the frontend.
4. Added some `logger.info` throughout a few places in the BFF for better debugging/observability.
5. Updates `HandlerContext` to expose a `set_status_code` method, used within `add_error` to update the response status code when using `add_error`.
6. Removes `transform_subscription_license` as it was previously only extracting specific attributes of a license dictionary, but this is better handled by the response serializer extracting the specific attributes to include.
7. Resolves `KeyError` when accessing `successes` key in the `response_payload` for the bulk enrollment API (e.g., if an error occurred).
8. Adds `allow_blank=True` to `expired_subscription_modal_messaging_v2` in `CustomerAgreementSerializer`.
9. Only calls `enterprise_course_enrollments` and `default-enterprise-enrollment-intentions/learner-status/` if the request user is explicitly linked to the requested enterprise customer. These endpoints will raise a 404 and 400, respectively, when called as a staff user that is not linked to the enterprise customer.

**Jira:**
[ENT-9633](https://2u-internal.atlassian.net/browse/ENT-9633)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
