### PR TITLE
fix: include url_for_button_in_modal_v2 in CustomerAgreementSerializer

### DIFF
--- a/enterprise_access/apps/api/v1/tests/test_bff_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_bff_views.py
@@ -106,6 +106,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                 'expired_subscription_modal_messaging_v2'
             ),
             'modal_header_text_v2': self.mock_customer_agreement.get('modal_header_text_v2'),
+            'url_for_button_in_modal_v2': self.mock_customer_agreement.get('url_for_button_in_modal_v2'),
         }
         self.expected_subscription_license = {
             'uuid': self.mock_subscription_license.get('uuid'),

--- a/enterprise_access/apps/api_client/tests/test_utils.py
+++ b/enterprise_access/apps/api_client/tests/test_utils.py
@@ -74,7 +74,7 @@ class MockLicenseManagerMetadataMixin(MockEnterpriseMetadata):
             "days_until_expiration_including_renewals": 50,
             "is_locked_for_renewal_processing": False,
             "should_auto_apply_licenses": False,
-            "created": _days_from_now(-60, DATE_FORMAT_ISO_8601)
+            "created": _days_from_now(-60, DATE_FORMAT_ISO_8601),
         }
         self.mock_customer_agreement = {
             "uuid": self.mock_customer_agreement_uuid,
@@ -92,7 +92,7 @@ class MockLicenseManagerMetadataMixin(MockEnterpriseMetadata):
             "modal_header_text_v2": None,
             "expired_subscription_modal_messaging_v2": None,
             "button_label_in_modal_v2": None,
-            "url_for_button_in_modal_v2": None
+            "url_for_button_in_modal_v2": None,
         }
         self.mock_subscription_license = {
             "uuid": self.mock_learner_license_activation_uuid,
@@ -103,7 +103,7 @@ class MockLicenseManagerMetadataMixin(MockEnterpriseMetadata):
             "subscription_plan_uuid": self.mock_subscription_plan_uuid,
             "revoked_date": None,
             "activation_key": self.mock_license_activation_key,
-            "subscription_plan": self.mock_subscription_plan
+            "subscription_plan": self.mock_subscription_plan,
         }
         self.mock_learner_license_auto_apply_response = {
             **self.mock_subscription_license,

--- a/enterprise_access/apps/bffs/serializers.py
+++ b/enterprise_access/apps/bffs/serializers.py
@@ -181,6 +181,7 @@ class CustomerAgreementSerializer(BaseBffSerializer):
     button_label_in_modal_v2 = serializers.CharField(required=False, allow_null=True)
     expired_subscription_modal_messaging_v2 = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     modal_header_text_v2 = serializers.CharField(required=False, allow_null=True)
+    url_for_button_in_modal_v2 = serializers.CharField(required=False, allow_null=True)
 
 
 class SubscriptionPlanSerializer(BaseBffSerializer):


### PR DESCRIPTION
**Description:**

Serializes `url_for_button_in_modal_v2` in `CustomerAgreementSerializer`.

**Jira:**
https://2u-internal.atlassian.net/browse/ENT-9837

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
