### PR TITLE
fix: don't cache if default intentions need enrollment

### DIFF
--- a/enterprise_access/apps/bffs/tests/test_handlers.py
+++ b/enterprise_access/apps/bffs/tests/test_handlers.py
@@ -350,6 +350,19 @@ class TestBaseLearnerPortalHandler(TestHandlerContextMixin):
             }],
         )
 
+        # a simple validation here that a second consecutive call to
+        # load the default intentions means the handler doesn't read from the cache,
+        # because the first request included enrollable intentions.
+        # We make this assertion using the returned value from the mock call
+        # to fetch default intention status. In a production-like setting, this
+        # second call should contain data indicating that default enrollment
+        # intentions were actually realized.
+        handler.load_default_enterprise_enrollment_intentions()
+        self.assertEqual(
+            handler.context.data['default_enterprise_enrollment_intentions'],
+            mock_get_intentions.return_value,
+        )
+
 
 class TestDashboardHandler(TestHandlerContextMixin):
     """


### PR DESCRIPTION
**Description:**
We don't want to cache default intentions data if it includes any enrollable intentions, because we don't want to re-attempt enrollment realization on the second of consecutive requests.

**Jira:**
ENT-9862

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
