### PR TITLE
build: pin confluent-kafka<2.6.2

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,7 +3,7 @@
 
 analytics-python
 celery
-confluent-kafka[schemaregistry]
+confluent-kafka[avro,schema-registry]
 Django>=2.2          # Web application framework
 djangoql
 django-cors-headers

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,34 +8,28 @@ amqp==5.3.1
     # via kombu
 analytics-python==1.4.post1
     # via -r requirements/base.in
-anyio==4.8.0
-    # via httpx
 asgiref==3.8.1
     # via
     #   django
     #   django-cors-headers
 attrs==24.3.0
     # via
-    #   confluent-kafka
     #   jsonschema
     #   openedx-events
     #   referencing
+avro==1.12.0
+    # via confluent-kafka
 backoff==1.10.0
     # via analytics-python
 billiard==4.2.1
     # via celery
-cachetools==5.5.0
-    # via confluent-kafka
 celery==5.4.0
     # via
     #   -r requirements/base.in
     #   django-celery-results
     #   edx-celeryutils
 certifi==2024.12.14
-    # via
-    #   httpcore
-    #   httpx
-    #   requests
+    # via requests
 cffi==1.17.1
     # via
     #   cryptography
@@ -58,8 +52,10 @@ click-repl==0.3.0
     # via celery
 code-annotations==2.1.0
     # via edx-toggles
-confluent-kafka[schemaregistry]==2.7.0
-    # via -r requirements/base.in
+confluent-kafka[avro,schema-registry]==2.6.1
+    # via
+    #   -c /edx/app/enterprise-access/requirements/constraints.txt
+    #   -r requirements/base.in
 coreapi==2.3.3
     # via
     #   django-rest-swagger
@@ -202,18 +198,10 @@ edx-toggles==5.2.0
 fastavro==1.10.0
     # via
     #   -r requirements/base.in
+    #   confluent-kafka
     #   openedx-events
-h11==0.14.0
-    # via httpcore
-httpcore==1.0.7
-    # via httpx
-httpx==0.27.2
-    # via confluent-kafka
 idna==3.10
-    # via
-    #   anyio
-    #   httpx
-    #   requests
+    # via requests
 inflection==0.5.1
     # via
     #   drf-spectacular
@@ -264,7 +252,7 @@ psutil==6.1.1
     # via edx-django-utils
 pycparser==2.22
     # via cffi
-pygments==2.19.0
+pygments==2.19.1
     # via -r requirements/base.in
 pyjwt[crypto]==2.10.1
     # via
@@ -306,6 +294,7 @@ referencing==0.35.1
 requests==2.32.3
     # via
     #   analytics-python
+    #   confluent-kafka
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -331,10 +320,6 @@ six==1.17.0
     #   edx-django-release-util
     #   edx-rbac
     #   python-dateutil
-sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
 social-auth-app-django==5.4.2
     # via edx-auth-backends
 social-auth-core==4.5.4
@@ -351,9 +336,7 @@ stevedore==5.4.0
 text-unidecode==1.3
     # via python-slugify
 typing-extensions==4.12.2
-    # via
-    #   anyio
-    #   edx-opaque-keys
+    # via edx-opaque-keys
 tzdata==2024.2
     # via
     #   celery

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,3 +13,6 @@
 
 # For python greater than or equal to 3.9 backports.zoneinfo causing failures
 backports.zoneinfo; python_version<'3.9'
+
+# confluent-kafka 2.7.0 increased CPU usage
+confluent-kafka<2.6.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,10 +10,6 @@ amqp==5.3.1
     #   kombu
 analytics-python==1.4.post1
     # via -r /edx/app/enterprise-access/requirements/validation.txt
-anyio==4.8.0
-    # via
-    #   -r /edx/app/enterprise-access/requirements/validation.txt
-    #   httpx
 asgiref==3.8.1
     # via
     #   -r /edx/app/enterprise-access/requirements/validation.txt
@@ -27,10 +23,13 @@ astroid==3.3.8
 attrs==24.3.0
     # via
     #   -r /edx/app/enterprise-access/requirements/validation.txt
-    #   confluent-kafka
     #   jsonschema
     #   openedx-events
     #   referencing
+avro==1.12.0
+    # via
+    #   -r /edx/app/enterprise-access/requirements/validation.txt
+    #   confluent-kafka
 backoff==1.10.0
     # via
     #   -r /edx/app/enterprise-access/requirements/validation.txt
@@ -46,7 +45,6 @@ build==1.2.2.post1
 cachetools==5.5.0
     # via
     #   -r /edx/app/enterprise-access/requirements/validation.txt
-    #   confluent-kafka
     #   tox
 celery==5.4.0
     # via
@@ -56,8 +54,6 @@ celery==5.4.0
 certifi==2024.12.14
     # via
     #   -r /edx/app/enterprise-access/requirements/validation.txt
-    #   httpcore
-    #   httpx
     #   requests
 cffi==1.17.1
     # via
@@ -111,7 +107,7 @@ colorama==0.4.6
     # via
     #   -r /edx/app/enterprise-access/requirements/validation.txt
     #   tox
-confluent-kafka[schemaregistry]==2.7.0
+confluent-kafka[avro,schema-registry]==2.6.1
     # via -r /edx/app/enterprise-access/requirements/validation.txt
 coreapi==2.3.3
     # via
@@ -308,6 +304,7 @@ faker==33.3.0
 fastavro==1.10.0
     # via
     #   -r /edx/app/enterprise-access/requirements/validation.txt
+    #   confluent-kafka
     #   openedx-events
 filelock==3.16.1
     # via
@@ -316,23 +313,9 @@ filelock==3.16.1
     #   virtualenv
 freezegun==1.5.1
     # via -r /edx/app/enterprise-access/requirements/validation.txt
-h11==0.14.0
-    # via
-    #   -r /edx/app/enterprise-access/requirements/validation.txt
-    #   httpcore
-httpcore==1.0.7
-    # via
-    #   -r /edx/app/enterprise-access/requirements/validation.txt
-    #   httpx
-httpx==0.27.2
-    # via
-    #   -r /edx/app/enterprise-access/requirements/validation.txt
-    #   confluent-kafka
 idna==3.10
     # via
     #   -r /edx/app/enterprise-access/requirements/validation.txt
-    #   anyio
-    #   httpx
     #   requests
 inflection==0.5.1
     # via
@@ -506,7 +489,7 @@ pycparser==2.22
     #   cffi
 pydocstyle==6.3.0
     # via -r /edx/app/enterprise-access/requirements/validation.txt
-pygments==2.19.0
+pygments==2.19.1
     # via
     #   -r /edx/app/enterprise-access/requirements/validation.txt
     #   diff-cover
@@ -610,6 +593,7 @@ requests==2.32.3
     # via
     #   -r /edx/app/enterprise-access/requirements/validation.txt
     #   analytics-python
+    #   confluent-kafka
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -662,11 +646,6 @@ six==1.17.0
     #   edx-lint
     #   edx-rbac
     #   python-dateutil
-sniffio==1.3.1
-    # via
-    #   -r /edx/app/enterprise-access/requirements/validation.txt
-    #   anyio
-    #   httpx
 snowballstemmer==2.2.0
     # via
     #   -r /edx/app/enterprise-access/requirements/validation.txt
@@ -706,7 +685,6 @@ twine==6.0.1
 typing-extensions==4.12.2
     # via
     #   -r /edx/app/enterprise-access/requirements/validation.txt
-    #   anyio
     #   edx-opaque-keys
     #   faker
 tzdata==2024.2

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -14,10 +14,6 @@ amqp==5.3.1
     #   kombu
 analytics-python==1.4.post1
     # via -r /edx/app/enterprise-access/requirements/test.txt
-anyio==4.8.0
-    # via
-    #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   httpx
 asgiref==3.8.1
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
@@ -31,10 +27,13 @@ astroid==3.3.8
 attrs==24.3.0
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   confluent-kafka
     #   jsonschema
     #   openedx-events
     #   referencing
+avro==1.12.0
+    # via
+    #   -r /edx/app/enterprise-access/requirements/test.txt
+    #   confluent-kafka
 babel==2.16.0
     # via
     #   pydata-sphinx-theme
@@ -52,7 +51,6 @@ billiard==4.2.1
 cachetools==5.5.0
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   confluent-kafka
     #   tox
 celery==5.4.0
     # via
@@ -62,8 +60,6 @@ celery==5.4.0
 certifi==2024.12.14
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   httpcore
-    #   httpx
     #   requests
 cffi==1.17.1
     # via
@@ -114,8 +110,10 @@ colorama==0.4.6
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
     #   tox
-confluent-kafka[schemaregistry]==2.7.0
-    # via -r /edx/app/enterprise-access/requirements/test.txt
+confluent-kafka[avro,schema-registry]==2.6.1
+    # via
+    #   -c /edx/app/enterprise-access/requirements/constraints.txt
+    #   -r /edx/app/enterprise-access/requirements/test.txt
 coreapi==2.3.3
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
@@ -308,6 +306,7 @@ faker==33.3.0
 fastavro==1.10.0
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
+    #   confluent-kafka
     #   openedx-events
 filelock==3.16.1
     # via
@@ -316,23 +315,9 @@ filelock==3.16.1
     #   virtualenv
 freezegun==1.5.1
     # via -r /edx/app/enterprise-access/requirements/test.txt
-h11==0.14.0
-    # via
-    #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   httpcore
-httpcore==1.0.7
-    # via
-    #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   httpx
-httpx==0.27.2
-    # via
-    #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   confluent-kafka
 idna==3.10
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   anyio
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
@@ -451,7 +436,7 @@ pycparser==2.22
     #   cffi
 pydata-sphinx-theme==0.16.1
     # via sphinx-book-theme
-pygments==2.19.0
+pygments==2.19.1
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
     #   accessible-pygments
@@ -549,6 +534,7 @@ requests==2.32.3
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
     #   analytics-python
+    #   confluent-kafka
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -586,11 +572,6 @@ six==1.17.0
     #   edx-lint
     #   edx-rbac
     #   python-dateutil
-sniffio==1.3.1
-    # via
-    #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   anyio
-    #   httpx
 snowballstemmer==2.2.0
     # via sphinx
 social-auth-app-django==5.4.2
@@ -647,7 +628,6 @@ tox==4.23.2
 typing-extensions==4.12.2
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   anyio
     #   edx-opaque-keys
     #   faker
     #   pydata-sphinx-theme

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -10,10 +10,6 @@ amqp==5.3.1
     #   kombu
 analytics-python==1.4.post1
     # via -r /edx/app/enterprise-access/requirements/base.txt
-anyio==4.8.0
-    # via
-    #   -r /edx/app/enterprise-access/requirements/base.txt
-    #   httpx
 asgiref==3.8.1
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
@@ -22,10 +18,13 @@ asgiref==3.8.1
 attrs==24.3.0
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
-    #   confluent-kafka
     #   jsonschema
     #   openedx-events
     #   referencing
+avro==1.12.0
+    # via
+    #   -r /edx/app/enterprise-access/requirements/base.txt
+    #   confluent-kafka
 backoff==1.10.0
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
@@ -34,10 +33,6 @@ billiard==4.2.1
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
     #   celery
-cachetools==5.5.0
-    # via
-    #   -r /edx/app/enterprise-access/requirements/base.txt
-    #   confluent-kafka
 celery==5.4.0
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
@@ -46,8 +41,6 @@ celery==5.4.0
 certifi==2024.12.14
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
-    #   httpcore
-    #   httpx
     #   requests
 cffi==1.17.1
     # via
@@ -83,7 +76,7 @@ code-annotations==2.1.0
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
     #   edx-toggles
-confluent-kafka[schemaregistry]==2.7.0
+confluent-kafka[avro,schema-registry]==2.6.1
     # via -r /edx/app/enterprise-access/requirements/base.txt
 coreapi==2.3.3
     # via
@@ -243,6 +236,7 @@ edx-toggles==5.2.0
 fastavro==1.10.0
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
+    #   confluent-kafka
     #   openedx-events
 gevent==24.11.1
     # via -r requirements/production.in
@@ -250,23 +244,9 @@ greenlet==3.1.1
     # via gevent
 gunicorn==23.0.0
     # via -r requirements/production.in
-h11==0.14.0
-    # via
-    #   -r /edx/app/enterprise-access/requirements/base.txt
-    #   httpcore
-httpcore==1.0.7
-    # via
-    #   -r /edx/app/enterprise-access/requirements/base.txt
-    #   httpx
-httpx==0.27.2
-    # via
-    #   -r /edx/app/enterprise-access/requirements/base.txt
-    #   confluent-kafka
 idna==3.10
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
-    #   anyio
-    #   httpx
     #   requests
 inflection==0.5.1
     # via
@@ -354,7 +334,7 @@ pycparser==2.22
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
     #   cffi
-pygments==2.19.0
+pygments==2.19.1
     # via -r /edx/app/enterprise-access/requirements/base.txt
 pyjwt[crypto]==2.10.1
     # via
@@ -412,6 +392,7 @@ requests==2.32.3
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
     #   analytics-python
+    #   confluent-kafka
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -445,11 +426,6 @@ six==1.17.0
     #   edx-django-release-util
     #   edx-rbac
     #   python-dateutil
-sniffio==1.3.1
-    # via
-    #   -r /edx/app/enterprise-access/requirements/base.txt
-    #   anyio
-    #   httpx
 social-auth-app-django==5.4.2
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
@@ -476,7 +452,6 @@ text-unidecode==1.3
 typing-extensions==4.12.2
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
-    #   anyio
     #   edx-opaque-keys
 tzdata==2024.2
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -10,10 +10,6 @@ amqp==5.3.1
     #   kombu
 analytics-python==1.4.post1
     # via -r /edx/app/enterprise-access/requirements/test.txt
-anyio==4.8.0
-    # via
-    #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   httpx
 asgiref==3.8.1
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
@@ -27,10 +23,13 @@ astroid==3.3.8
 attrs==24.3.0
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   confluent-kafka
     #   jsonschema
     #   openedx-events
     #   referencing
+avro==1.12.0
+    # via
+    #   -r /edx/app/enterprise-access/requirements/test.txt
+    #   confluent-kafka
 backoff==1.10.0
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
@@ -42,7 +41,6 @@ billiard==4.2.1
 cachetools==5.5.0
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   confluent-kafka
     #   tox
 celery==5.4.0
     # via
@@ -52,8 +50,6 @@ celery==5.4.0
 certifi==2024.12.14
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   httpcore
-    #   httpx
     #   requests
 cffi==1.17.1
     # via
@@ -104,8 +100,10 @@ colorama==0.4.6
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
     #   tox
-confluent-kafka[schemaregistry]==2.7.0
-    # via -r /edx/app/enterprise-access/requirements/test.txt
+confluent-kafka[avro,schema-registry]==2.6.1
+    # via
+    #   -c /edx/app/enterprise-access/requirements/constraints.txt
+    #   -r /edx/app/enterprise-access/requirements/test.txt
 coreapi==2.3.3
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
@@ -294,6 +292,7 @@ faker==33.3.0
 fastavro==1.10.0
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
+    #   confluent-kafka
     #   openedx-events
 filelock==3.16.1
     # via
@@ -302,23 +301,9 @@ filelock==3.16.1
     #   virtualenv
 freezegun==1.5.1
     # via -r /edx/app/enterprise-access/requirements/test.txt
-h11==0.14.0
-    # via
-    #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   httpcore
-httpcore==1.0.7
-    # via
-    #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   httpx
-httpx==0.27.2
-    # via
-    #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   confluent-kafka
 idna==3.10
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   anyio
-    #   httpx
     #   requests
 inflection==0.5.1
     # via
@@ -459,7 +444,7 @@ pycparser==2.22
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pygments==2.19.0
+pygments==2.19.1
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
     #   readme-renderer
@@ -554,6 +539,7 @@ requests==2.32.3
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
     #   analytics-python
+    #   confluent-kafka
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -598,11 +584,6 @@ six==1.17.0
     #   edx-lint
     #   edx-rbac
     #   python-dateutil
-sniffio==1.3.1
-    # via
-    #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   anyio
-    #   httpx
 snowballstemmer==2.2.0
     # via pydocstyle
 social-auth-app-django==5.4.2
@@ -639,7 +620,6 @@ twine==6.0.1
 typing-extensions==4.12.2
     # via
     #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   anyio
     #   edx-opaque-keys
     #   faker
 tzdata==2024.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,10 +10,6 @@ amqp==5.3.1
     #   kombu
 analytics-python==1.4.post1
     # via -r /edx/app/enterprise-access/requirements/base.txt
-anyio==4.8.0
-    # via
-    #   -r /edx/app/enterprise-access/requirements/base.txt
-    #   httpx
 asgiref==3.8.1
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
@@ -26,10 +22,13 @@ astroid==3.3.8
 attrs==24.3.0
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
-    #   confluent-kafka
     #   jsonschema
     #   openedx-events
     #   referencing
+avro==1.12.0
+    # via
+    #   -r /edx/app/enterprise-access/requirements/base.txt
+    #   confluent-kafka
 backoff==1.10.0
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
@@ -39,10 +38,7 @@ billiard==4.2.1
     #   -r /edx/app/enterprise-access/requirements/base.txt
     #   celery
 cachetools==5.5.0
-    # via
-    #   -r /edx/app/enterprise-access/requirements/base.txt
-    #   confluent-kafka
-    #   tox
+    # via tox
 celery==5.4.0
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
@@ -51,8 +47,6 @@ celery==5.4.0
 certifi==2024.12.14
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
-    #   httpcore
-    #   httpx
     #   requests
 cffi==1.17.1
     # via
@@ -98,8 +92,10 @@ code-annotations==2.1.0
     #   edx-toggles
 colorama==0.4.6
     # via tox
-confluent-kafka[schemaregistry]==2.7.0
-    # via -r /edx/app/enterprise-access/requirements/base.txt
+confluent-kafka[avro,schema-registry]==2.6.1
+    # via
+    #   -c /edx/app/enterprise-access/requirements/constraints.txt
+    #   -r /edx/app/enterprise-access/requirements/base.txt
 coreapi==2.3.3
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
@@ -276,6 +272,7 @@ faker==33.3.0
 fastavro==1.10.0
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
+    #   confluent-kafka
     #   openedx-events
 filelock==3.16.1
     # via
@@ -283,23 +280,9 @@ filelock==3.16.1
     #   virtualenv
 freezegun==1.5.1
     # via -r requirements/test.in
-h11==0.14.0
-    # via
-    #   -r /edx/app/enterprise-access/requirements/base.txt
-    #   httpcore
-httpcore==1.0.7
-    # via
-    #   -r /edx/app/enterprise-access/requirements/base.txt
-    #   httpx
-httpx==0.27.2
-    # via
-    #   -r /edx/app/enterprise-access/requirements/base.txt
-    #   confluent-kafka
 idna==3.10
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
-    #   anyio
-    #   httpx
     #   requests
 inflection==0.5.1
     # via
@@ -402,7 +385,7 @@ pycparser==2.22
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
     #   cffi
-pygments==2.19.0
+pygments==2.19.1
     # via -r /edx/app/enterprise-access/requirements/base.txt
 pyjwt[crypto]==2.10.1
     # via
@@ -483,6 +466,7 @@ requests==2.32.3
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
     #   analytics-python
+    #   confluent-kafka
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -517,11 +501,6 @@ six==1.17.0
     #   edx-lint
     #   edx-rbac
     #   python-dateutil
-sniffio==1.3.1
-    # via
-    #   -r /edx/app/enterprise-access/requirements/base.txt
-    #   anyio
-    #   httpx
 social-auth-app-django==5.4.2
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
@@ -552,7 +531,6 @@ tox==4.23.2
 typing-extensions==4.12.2
     # via
     #   -r /edx/app/enterprise-access/requirements/base.txt
-    #   anyio
     #   edx-opaque-keys
     #   faker
 tzdata==2024.2

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -13,11 +13,6 @@ analytics-python==1.4.post1
     # via
     #   -r /edx/app/enterprise-access/requirements/quality.txt
     #   -r /edx/app/enterprise-access/requirements/test.txt
-anyio==4.8.0
-    # via
-    #   -r /edx/app/enterprise-access/requirements/quality.txt
-    #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   httpx
 asgiref==3.8.1
     # via
     #   -r /edx/app/enterprise-access/requirements/quality.txt
@@ -34,10 +29,14 @@ attrs==24.3.0
     # via
     #   -r /edx/app/enterprise-access/requirements/quality.txt
     #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   confluent-kafka
     #   jsonschema
     #   openedx-events
     #   referencing
+avro==1.12.0
+    # via
+    #   -r /edx/app/enterprise-access/requirements/quality.txt
+    #   -r /edx/app/enterprise-access/requirements/test.txt
+    #   confluent-kafka
 backoff==1.10.0
     # via
     #   -r /edx/app/enterprise-access/requirements/quality.txt
@@ -52,7 +51,6 @@ cachetools==5.5.0
     # via
     #   -r /edx/app/enterprise-access/requirements/quality.txt
     #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   confluent-kafka
     #   tox
 celery==5.4.0
     # via
@@ -64,8 +62,6 @@ certifi==2024.12.14
     # via
     #   -r /edx/app/enterprise-access/requirements/quality.txt
     #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   httpcore
-    #   httpx
     #   requests
 cffi==1.17.1
     # via
@@ -126,7 +122,7 @@ colorama==0.4.6
     #   -r /edx/app/enterprise-access/requirements/quality.txt
     #   -r /edx/app/enterprise-access/requirements/test.txt
     #   tox
-confluent-kafka[schemaregistry]==2.7.0
+confluent-kafka[avro,schema-registry]==2.6.1
     # via
     #   -r /edx/app/enterprise-access/requirements/quality.txt
     #   -r /edx/app/enterprise-access/requirements/test.txt
@@ -386,6 +382,7 @@ fastavro==1.10.0
     # via
     #   -r /edx/app/enterprise-access/requirements/quality.txt
     #   -r /edx/app/enterprise-access/requirements/test.txt
+    #   confluent-kafka
     #   openedx-events
 filelock==3.16.1
     # via
@@ -397,27 +394,10 @@ freezegun==1.5.1
     # via
     #   -r /edx/app/enterprise-access/requirements/quality.txt
     #   -r /edx/app/enterprise-access/requirements/test.txt
-h11==0.14.0
-    # via
-    #   -r /edx/app/enterprise-access/requirements/quality.txt
-    #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   httpcore
-httpcore==1.0.7
-    # via
-    #   -r /edx/app/enterprise-access/requirements/quality.txt
-    #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   httpx
-httpx==0.27.2
-    # via
-    #   -r /edx/app/enterprise-access/requirements/quality.txt
-    #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   confluent-kafka
 idna==3.10
     # via
     #   -r /edx/app/enterprise-access/requirements/quality.txt
     #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   anyio
-    #   httpx
     #   requests
 inflection==0.5.1
     # via
@@ -603,7 +583,7 @@ pycparser==2.22
     #   cffi
 pydocstyle==6.3.0
     # via -r /edx/app/enterprise-access/requirements/quality.txt
-pygments==2.19.0
+pygments==2.19.1
     # via
     #   -r /edx/app/enterprise-access/requirements/quality.txt
     #   -r /edx/app/enterprise-access/requirements/test.txt
@@ -725,6 +705,7 @@ requests==2.32.3
     #   -r /edx/app/enterprise-access/requirements/quality.txt
     #   -r /edx/app/enterprise-access/requirements/test.txt
     #   analytics-python
+    #   confluent-kafka
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -784,12 +765,6 @@ six==1.17.0
     #   edx-lint
     #   edx-rbac
     #   python-dateutil
-sniffio==1.3.1
-    # via
-    #   -r /edx/app/enterprise-access/requirements/quality.txt
-    #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   anyio
-    #   httpx
 snowballstemmer==2.2.0
     # via
     #   -r /edx/app/enterprise-access/requirements/quality.txt
@@ -837,7 +812,6 @@ typing-extensions==4.12.2
     # via
     #   -r /edx/app/enterprise-access/requirements/quality.txt
     #   -r /edx/app/enterprise-access/requirements/test.txt
-    #   anyio
     #   edx-opaque-keys
     #   faker
 tzdata==2024.2


### PR DESCRIPTION
**Description:**
Pins confluent-kafka < 2.7, since we're experiencing increased CPU usage in stage and prod with 2.7.0 installed.

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
