### PR TITLE
test: add local dev container for consuming event-bus events

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,31 @@ services:
     volumes:
       - .:/edx/app/enterprise-access/
 
+  consume_enterprise_subsidies_transaction_lifecycle:
+    image: edxops/enterprise-access-dev
+    container_name: enterprise_access.consume_enterprise_subsidies_transaction_lifecycle
+    volumes:
+      - .:/edx/app/enterprise-access/
+      - ../src:/edx/src
+    command: bash -c 'while true; do python /edx/app/enterprise-access/manage.py consume_events -t enterprise-subsidies-transaction-lifecycle -g enterprise_access_dev; sleep 2; done'
+    ports:
+      - "18272:18272"
+    depends_on:
+      - mysql80
+      - memcache
+      - worker
+    networks:
+      - devstack_default
+    stdin_open: true
+    tty: true
+    environment:
+      CELERY_ALWAYS_EAGER: 'false'
+      CELERY_BROKER_TRANSPORT: redis
+      CELERY_BROKER_HOSTNAME: edx.devstack.redis:6379
+      CELERY_BROKER_VHOST: 0
+      CELERY_BROKER_PASSWORD: password
+      DJANGO_SETTINGS_MODULE: enterprise_access.settings.devstack
+
 networks:
   devstack_default:
     external: true


### PR DESCRIPTION
ENT-9901

Testing
===

Launching the container:
```
(enterprise-access) ubuntu@ip-10-13-20-242:~/edx-repos/enterprise-access$ make dev.up
...
 ✔ Container enterprise_access.consume_enterprise_subsidies_transaction_lifecycle  Started                                                                                                                                                                                         0.3s 
```

Container logs after launch:
```
(enterprise-access) ubuntu@ip-10-13-20-242:~/edx-repos/enterprise-access$ make consume_enterprise_subsidies_transaction_lifecycle-logs
...
enterprise_access.consume_enterprise_subsidies_transaction_lifecycle  | 2025-01-10 19:55:14,558 INFO 7 [edx_event_bus_kafka.internal.consumer] [user None] [ip None] [request_id None] consumer.py:284 - Running consumer for {'full_topic': 'dev-enterprise-subsidies-transaction-lifecycle', 'consumer_group': 'enterprise_access_dev'}
```

Container logs after emitting a TRANSACTION_REVERSED event from enterprise-subsidy:
```
enterprise_access.consume_enterprise_subsidies_transaction_lifecycle  | 2025-01-10 19:57:44,638 INFO 7 [edx_event_bus_kafka.internal.consumer] [user None] [ip None] [request_id None] consumer.py:513 - Message received from Kafka: topic=dev-enterprise-subsidies-transaction-lifecycle, partition=0, offset=29, message_id=28559382-cf8d-11ef-82b5-0242ac120020, key=b'\x00\x00\x00\x00\x01H7382cea3-6a3a-430f-9251-ee791cdab25e', event_timestamp_ms=1736539064581
enterprise_access.consume_enterprise_subsidies_transaction_lifecycle  | 2025-01-10 19:57:44,639 INFO 7 [enterprise_access.apps.content_assignments.signals] [user None] [ip None] [request_id None] signals.py:53 - No LearnerContentAssignment exists with transaction uuid: 7382cea3-6a3a-430f-9251-ee791cdab25e
enterprise_access.consume_enterprise_subsidies_transaction_lifecycle  | 2025-01-10 19:57:44,639 INFO 7 [edx_event_bus_kafka.internal.consumer] [user None] [ip None] [request_id None] consumer.py:393 - Message from Kafka processed successfully
```