### PR TITLE
feat: serialize additional subscriptions-related fields within the Learner BFF

### DIFF
--- a/enterprise_access/apps/api/v1/tests/test_bff_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_bff_views.py
@@ -143,6 +143,9 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                         'assigned': [],
                         'revoked': [],
                     },
+                    'subscription_license': None,
+                    'subscription_plan': None,
+                    'show_expiration_notifications': False,
                 },
             },
             'errors': [],
@@ -278,6 +281,9 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                         'assigned': [],
                         'revoked': [],
                     },
+                    'subscription_license': self.expected_subscription_license,
+                    'subscription_plan': self.expected_subscription_license['subscription_plan'],
+                    'show_expiration_notifications': True,
                 },
             },
         })
@@ -346,6 +352,9 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                         'assigned': [],
                         'revoked': [],
                     },
+                    'subscription_license': expected_activated_subscription_license,
+                    'subscription_plan': expected_activated_subscription_license['subscription_plan'],
+                    'show_expiration_notifications': True,
                 },
             },
         })
@@ -619,6 +628,11 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             if has_existing_revoked_license
             else []
         )
+        expected_subscription_license = None
+        if should_auto_apply or has_existing_activated_license:
+            expected_subscription_license = expected_activated_subscription_license
+        elif has_existing_revoked_license:
+            expected_subscription_license = expected_revoked_subscription_license
         expected_licenses = []
         expected_licenses.extend(expected_activated_licenses)
         expected_licenses.extend(expected_revoked_licenses)
@@ -640,6 +654,9 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                         'assigned': [],
                         'revoked': expected_revoked_licenses,
                     },
+                    'subscription_license': expected_subscription_license,
+                    'subscription_plan': expected_subscription_license['subscription_plan'] if expected_subscription_license else None,
+                    'show_expiration_notifications': True,
                 },
             },
         })

--- a/enterprise_access/apps/api/v1/tests/test_bff_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_bff_views.py
@@ -629,10 +629,14 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             else []
         )
         expected_subscription_license = None
+        expected_subscription_plan = None
         if should_auto_apply or has_existing_activated_license:
             expected_subscription_license = expected_activated_subscription_license
         elif has_existing_revoked_license:
             expected_subscription_license = expected_revoked_subscription_license
+        if expected_subscription_license:
+            expected_subscription_plan = expected_subscription_license['subscription_plan']
+
         expected_licenses = []
         expected_licenses.extend(expected_activated_licenses)
         expected_licenses.extend(expected_revoked_licenses)
@@ -655,7 +659,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                         'revoked': expected_revoked_licenses,
                     },
                     'subscription_license': expected_subscription_license,
-                    'subscription_plan': expected_subscription_license['subscription_plan'] if expected_subscription_license else None,
+                    'subscription_plan': expected_subscription_plan,
                     'show_expiration_notifications': True,
                 },
             },

--- a/enterprise_access/apps/bffs/handlers.py
+++ b/enterprise_access/apps/bffs/handlers.py
@@ -250,7 +250,7 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
             None,
         )
         return subscription_license
-    
+
     def transform_subscriptions_result(self, subscriptions_result):
         """
         Transform subscription licenses data if needed.

--- a/enterprise_access/apps/bffs/mixins.py
+++ b/enterprise_access/apps/bffs/mixins.py
@@ -64,6 +64,27 @@ class LearnerSubscriptionsDataMixin(EnterpriseCustomerUserSubsidiesDataMixin):
         """
         return self.subscriptions.get('subscription_licenses_by_status', {})
 
+    @property
+    def subscription_license(self):
+        """
+        Get subscription license from the context.
+        """
+        return self.subscriptions.get('subscription_license', None)
+
+    @property
+    def subscription_plan(self):
+        """
+        Get subscription plan from the context.
+        """
+        return self.subscriptions.get('subscription_plan', {})
+
+    @property
+    def show_expiration_notifications(self):
+        """
+        Get whether subscription expiration notifications should be shown from the context.
+        """
+        return self.subscriptions.get('show_expiration_notifications', False)
+
 
 class LearnerSubsidiesDataMixin(LearnerSubscriptionsDataMixin):
     """

--- a/enterprise_access/apps/bffs/mixins.py
+++ b/enterprise_access/apps/bffs/mixins.py
@@ -79,7 +79,7 @@ class LearnerSubscriptionsDataMixin(EnterpriseCustomerUserSubsidiesDataMixin):
         return self.subscriptions.get('subscription_plan', {})
 
     @property
-    def show_expiration_notifications(self):
+    def show_subscription_expiration_notifications(self):
         """
         Get whether subscription expiration notifications should be shown from the context.
         """

--- a/enterprise_access/apps/bffs/response_builder.py
+++ b/enterprise_access/apps/bffs/response_builder.py
@@ -121,9 +121,6 @@ class LearnerDashboardResponseBuilder(BaseLearnerResponseBuilder, LearnerDashboa
             'enterprise_course_enrollments': self.enterprise_course_enrollments,
         })
 
-        # Add any errors and warnings to the response
-        self.add_errors_warnings_to_response()
-
         # Serialize and validate the response
         try:
             serializer = LearnerDashboardResponseSerializer(data=self.response_data)

--- a/enterprise_access/apps/bffs/serializers.py
+++ b/enterprise_access/apps/bffs/serializers.py
@@ -227,12 +227,15 @@ class SubscriptionLicenseStatusSerializer(BaseBffSerializer):
 
 class SubscriptionsSerializer(BaseBffSerializer):
     """
-    Serializer for enterprise customer user subsidies.
+    Serializer for subscriptions subsidies.
     """
 
     customer_agreement = CustomerAgreementSerializer(required=False, allow_null=True)
     subscription_licenses = SubscriptionLicenseSerializer(many=True, required=False, default=list)
     subscription_licenses_by_status = SubscriptionLicenseStatusSerializer(required=False)
+    subscription_license = SubscriptionLicenseSerializer(required=False, allow_null=True)
+    subscription_plan = SubscriptionPlanSerializer(required=False, allow_null=True)
+    show_expiration_notifications = serializers.BooleanField(required=False)
 
 
 class EnterpriseCustomerUserSubsidiesSerializer(BaseBffSerializer):

--- a/enterprise_access/apps/bffs/tests/test_handlers.py
+++ b/enterprise_access/apps/bffs/tests/test_handlers.py
@@ -148,6 +148,9 @@ class TestBaseLearnerPortalHandler(TestHandlerContextMixin):
             'customer_agreement': None,
             'subscription_licenses': [],
             'subscription_licenses_by_status': {},
+            'subscription_license': None,
+            'subscription_plan': None,
+            'show_expiration_notifications': False,
         }
         self.assertEqual(actual_subscriptions, expected_subscriptions)
 


### PR DESCRIPTION
**Description:**

Serializes `subscription_license`, `subscription_plan`, and `show_expiration_notifications` within the Learner Portal BFF API, ensuring parity with existing frontend transforms for these same properties.

Corresponding frontend PR: https://github.com/openedx/frontend-app-learner-portal-enterprise/pull/1253

**Jira:**
[ENT-9630](https://2u-internal.atlassian.net/browse/ENT-9630)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
