### PR TITLE
feat: incorporate enterprise customer logic into BFF

### DIFF
--- a/enterprise_access/apps/api_client/lms_client.py
+++ b/enterprise_access/apps/api_client/lms_client.py
@@ -45,12 +45,13 @@ class LmsApiClient(BaseOAuthClient):
     """
     API client for calls to the LMS service.
     """
-    enterprise_api_base_url = settings.LMS_URL + '/enterprise/api/v1/'
-    enterprise_learner_endpoint = enterprise_api_base_url + 'enterprise-learner/'
-    enterprise_customer_endpoint = enterprise_api_base_url + 'enterprise-customer/'
-    pending_enterprise_learner_endpoint = enterprise_api_base_url + 'pending-enterprise-learner/'
-    enterprise_group_membership_endpoint = enterprise_api_base_url + 'enterprise-group/'
-    pending_enterprise_admin_endpoint = enterprise_api_base_url + 'pending-enterprise-admin/'
+    enterprise_base_url = settings.LMS_URL + '/enterprise/'
+    enterprise_api_v1_base_url = enterprise_base_url + 'api/v1/'
+    enterprise_learner_endpoint = enterprise_api_v1_base_url + 'enterprise-learner/'
+    enterprise_customer_endpoint = enterprise_api_v1_base_url + 'enterprise-customer/'
+    pending_enterprise_learner_endpoint = enterprise_api_v1_base_url + 'pending-enterprise-learner/'
+    enterprise_group_membership_endpoint = enterprise_api_v1_base_url + 'enterprise-group/'
+    pending_enterprise_admin_endpoint = enterprise_api_v1_base_url + 'pending-enterprise-admin/'
 
     def enterprise_customer_url(self, enterprise_customer_uuid):
         return os.path.join(
@@ -60,7 +61,7 @@ class LmsApiClient(BaseOAuthClient):
 
     def enterprise_group_endpoint(self, group_uuid):
         return os.path.join(
-            self.enterprise_api_base_url + 'enterprise-group/',
+            self.enterprise_api_v1_base_url + 'enterprise-group/',
             f"{group_uuid}/",
         )
 
@@ -553,12 +554,12 @@ class LmsUserApiClient(BaseUserApiClient):
     """
     API client for user-specific calls to the LMS service.
     """
-    enterprise_api_base_url = f"{settings.LMS_URL}/enterprise/api/v1/"
+    enterprise_base_url = settings.LMS_URL + "/enterprise/"
+    enterprise_api_v1_base_url = enterprise_base_url + "api/v1/"
     enterprise_learner_portal_api_base_url = f"{settings.LMS_URL}/enterprise_learner_portal/api/v1/"
-
-    enterprise_learner_endpoint = f"{enterprise_api_base_url}enterprise-learner/"
+    enterprise_learner_endpoint = f"{enterprise_api_v1_base_url}enterprise-learner/"
     default_enterprise_enrollment_intentions_learner_status_endpoint = (
-        f'{enterprise_api_base_url}default-enterprise-enrollment-intentions/learner-status/'
+        f'{enterprise_api_v1_base_url}default-enterprise-enrollment-intentions/learner-status/'
     )
     enterprise_course_enrollments_endpoint = (
         f'{enterprise_learner_portal_api_base_url}enterprise_course_enrollments/'

--- a/enterprise_access/apps/bffs/context.py
+++ b/enterprise_access/apps/bffs/context.py
@@ -103,8 +103,16 @@ class HandlerContext:
         return self.data.get('active_enterprise_customer')
 
     @property
+    def staff_enterprise_customer(self):
+        return self.data.get('staff_enterprise_customer')
+
+    @property
     def all_linked_enterprise_customer_users(self):
         return self.data.get('all_linked_enterprise_customer_users')
+
+    @property
+    def should_update_active_enterprise_customer_user(self):
+        return self.data.get('should_update_active_enterprise_customer_user')
 
     @property
     def is_request_user_linked_to_enterprise_customer(self):
@@ -121,10 +129,6 @@ class HandlerContext:
             enterprise_customer_user.get('enterprise_customer', {}).get('uuid') == enterprise_customer_uuid
             for enterprise_customer_user in self.all_linked_enterprise_customer_users
         )
-
-    @property
-    def staff_enterprise_customer(self):
-        return self.data.get('staff_enterprise_customer')
 
     def set_status_code(self, status_code):
         """
@@ -229,6 +233,9 @@ class HandlerContext:
             'active_enterprise_customer': transformed_data.get('active_enterprise_customer'),
             'all_linked_enterprise_customer_users': transformed_data.get('all_linked_enterprise_customer_users', []),
             'staff_enterprise_customer': transformed_data.get('staff_enterprise_customer'),
+            'should_update_active_enterprise_customer_user': transformed_data.get(
+                'should_update_active_enterprise_customer_user', False
+            )
         })
 
     def add_error(self, status_code=None, **kwargs):

--- a/enterprise_access/apps/bffs/response_builder.py
+++ b/enterprise_access/apps/bffs/response_builder.py
@@ -44,6 +44,12 @@ class BaseResponseBuilder:
             dict: A dictionary containing the response data.
         """
         self.response_data['enterprise_customer'] = self.context.enterprise_customer
+        self.response_data['all_linked_enterprise_customer_users'] = self.context.all_linked_enterprise_customer_users
+        self.response_data['active_enterprise_customer'] = self.context.active_enterprise_customer
+        self.response_data['staff_enterprise_customer'] = self.context.staff_enterprise_customer
+        self.response_data['should_update_active_enterprise_customer_user'] = (
+            self.context.should_update_active_enterprise_customer_user
+        )
         self.response_data['enterprise_features'] = self.context.enterprise_features
         return self.response_data, self.status_code
 
@@ -121,7 +127,6 @@ class LearnerDashboardResponseBuilder(BaseLearnerResponseBuilder, LearnerDashboa
             'enterprise_course_enrollments': self.enterprise_course_enrollments,
             'all_enrollments_by_status': self.all_enrollments_by_status,
         })
-
         # Serialize and validate the response
         try:
             serializer = LearnerDashboardResponseSerializer(data=self.response_data)

--- a/enterprise_access/apps/bffs/serializers.py
+++ b/enterprise_access/apps/bffs/serializers.py
@@ -152,12 +152,25 @@ class EnterpriseCustomerSerializer(BaseBffSerializer):
     show_integration_warning = serializers.BooleanField()
 
 
+class EnterpriseCustomerUserSerializer(BaseBffSerializer):
+    """
+    Serializer for all linked enterprise customer users
+    """
+    id = serializers.IntegerField()
+    enterprise_customer = EnterpriseCustomerSerializer()
+    active = serializers.BooleanField()
+
+
 class BaseResponseSerializer(BaseBffSerializer):
     """
     Serializer for base response.
     """
 
     enterprise_customer = EnterpriseCustomerSerializer(required=False, allow_null=True)
+    all_linked_enterprise_customer_users = EnterpriseCustomerUserSerializer(many=True, allow_empty=True, default=list)
+    active_enterprise_customer = EnterpriseCustomerSerializer(required=False, allow_null=True)
+    staff_enterprise_customer = EnterpriseCustomerSerializer(required=False, allow_null=True)
+    should_update_active_enterprise_customer_user = serializers.BooleanField()
     errors = ErrorSerializer(many=True, required=False, default=list)
     warnings = WarningSerializer(many=True, required=False, default=list)
     enterprise_features = serializers.DictField(required=False, default=dict)

--- a/enterprise_access/apps/bffs/tests/test_context.py
+++ b/enterprise_access/apps/bffs/tests/test_context.py
@@ -51,6 +51,7 @@ class TestHandlerContext(TestHandlerContextMixin):
                         'enterprise_customer': self.mock_enterprise_customer_2,
                     }
                 ],
+                'should_update_active_enterprise_customer_user': False,
             }
 
         self.assertEqual(context.data, expected_data)
@@ -125,11 +126,13 @@ class TestHandlerContext(TestHandlerContextMixin):
             'active_enterprise_customer': None,
             'staff_enterprise_customer': self.mock_enterprise_customer,
             'all_linked_enterprise_customer_users': [],
+            'should_update_active_enterprise_customer_user': False,
         }
         if raises_exception:
             expected_data.update({
                 'enterprise_customer': None,
                 'staff_enterprise_customer': None,
+                'should_update_active_enterprise_customer_user': False,
             })
         self.assertEqual(context.data, expected_data)
         expected_errors = (

--- a/enterprise_access/apps/bffs/tests/test_response_builders.py
+++ b/enterprise_access/apps/bffs/tests/test_response_builders.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from unittest.mock import MagicMock
 
 import ddt
 from rest_framework import status
@@ -22,6 +23,10 @@ class TestBaseResponseBuilder(TestHandlerContextMixin):
     def test_base_build_error(self, mock_handler_context):
         mock_context_data = {
             'enterprise_customer': self.mock_enterprise_customer,
+            'all_linked_enterprise_customer_users': self.mock_all_linked_enterprise_customer_users,
+            'staff_enterprise_customer': self.mock_staff_enterprise_customer,
+            'active_enterprise_customer': self.mock_active_enterprise_customer,
+            'should_update_active_enterprise_customer_user': self.mock_should_update_active_enterprise_customer_user,
         }
         mock_handler_context.return_value = self.get_mock_handler_context(
             data=mock_context_data,
@@ -32,6 +37,10 @@ class TestBaseResponseBuilder(TestHandlerContextMixin):
         expected_response_data = {
             'enterprise_customer': self.mock_enterprise_customer,
             'enterprise_features': {'feature_flag': True},
+            'all_linked_enterprise_customer_users': self.mock_all_linked_enterprise_customer_users,
+            'staff_enterprise_customer': self.mock_staff_enterprise_customer,
+            'active_enterprise_customer': self.mock_active_enterprise_customer,
+            'should_update_active_enterprise_customer_user': self.mock_should_update_active_enterprise_customer_user,
         }
         self.assertEqual(response_data, expected_response_data)
         self.assertEqual(status_code, status.HTTP_200_OK)
@@ -59,6 +68,10 @@ class TestBaseResponseBuilder(TestHandlerContextMixin):
     def test_add_errors_warnings_to_response(self, mock_handler_context, errors, warnings):
         mock_context_data = {
             'enterprise_customer': self.mock_enterprise_customer,
+            'all_linked_enterprise_customer_users': self.mock_all_linked_enterprise_customer_users,
+            'staff_enterprise_customer': self.mock_staff_enterprise_customer,
+            'active_enterprise_customer': self.mock_active_enterprise_customer,
+            'should_update_active_enterprise_customer_user': self.mock_should_update_active_enterprise_customer_user,
         }
         mock_handler_context.return_value = self.get_mock_handler_context(
             data=mock_context_data,
@@ -68,6 +81,10 @@ class TestBaseResponseBuilder(TestHandlerContextMixin):
         expected_output = {
             'enterprise_customer': self.mock_enterprise_customer,
             'enterprise_features': {'feature_flag': True},
+            'all_linked_enterprise_customer_users': self.mock_all_linked_enterprise_customer_users,
+            'staff_enterprise_customer': self.mock_staff_enterprise_customer,
+            'active_enterprise_customer': self.mock_active_enterprise_customer,
+            'should_update_active_enterprise_customer_user': self.mock_should_update_active_enterprise_customer_user,
             'errors': [],
             'warnings': [],
         }
@@ -129,6 +146,10 @@ class TestBaseLearnerResponseBuilder(TestBaseResponseBuilder, MockLicenseManager
     def test_build(self, mock_handler_context, has_subscriptions_data):
         mock_context_data = {
             'enterprise_customer': self.mock_enterprise_customer,
+            'all_linked_enterprise_customer_users': self.mock_all_linked_enterprise_customer_users,
+            'staff_enterprise_customer': self.mock_staff_enterprise_customer,
+            'active_enterprise_customer': self.mock_active_enterprise_customer,
+            'should_update_active_enterprise_customer_user': self.mock_should_update_active_enterprise_customer_user,
         }
         mock_handler_context.return_value = self.get_mock_handler_context(
             data=mock_context_data,
@@ -165,6 +186,10 @@ class TestBaseLearnerResponseBuilder(TestBaseResponseBuilder, MockLicenseManager
             'enterprise_customer_user_subsidies': {
                 'subscriptions': mock_subscriptions_data,
             },
+            'staff_enterprise_customer': self.mock_staff_enterprise_customer,
+            'active_enterprise_customer': self.mock_active_enterprise_customer,
+            'all_linked_enterprise_customer_users': self.mock_all_linked_enterprise_customer_users,
+            'should_update_active_enterprise_customer_user': self.mock_should_update_active_enterprise_customer_user,
             'errors': [],
             'warnings': [],
         }


### PR DESCRIPTION
Serializes fields in the BFF context to always return `all_linked_enterprise_customer_users` and `should_update_active_enterprise_customer_user`. The intention is to eventually remove `should_update_active_enterprise_customer_user` and take advantage of a net new API call to select an active enterprise customer. This work will be completed as part of a seperate ticket. 

It modifies the enterprise customer user object to update the metadata to the set active, and invalidate the enterprise customer user query cache. We return `should_update_active_enterprise_customer_user` back to the user to set the active enterprise customer in the frontend. We invalidate the query to ensure the next call to the BFF would return the now active enterprise customer without transformations on the enterprise customer user object in the BFF layer.

**Jira:**
ENT-XXXX

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
