### PR TITLE
fix: transform and group enrollments by status

### DIFF
--- a/enterprise_access/apps/bffs/constants.py
+++ b/enterprise_access/apps/bffs/constants.py
@@ -1,0 +1,25 @@
+"""
+Constants module for the BFFs.
+"""
+
+
+class COURSE_ENROLLMENT_STATUSES:
+    """
+    Course enrollment statuses.
+    """
+    IN_PROGRESS = 'in_progress'
+    UPCOMING = 'upcoming'
+    COMPLETED = 'completed'
+    SAVED_FOR_LATER = 'saved_for_later'
+    # Not a realized enrollment status, but used for the purpose of requesting enrollment
+    REQUESTED = 'requested'
+    # Not a realized enrollment status, but used for the purpose of assigned enrollment
+    ASSIGNED = 'assigned'
+
+
+UNENROLLABLE_COURSE_STATUSES = {
+    COURSE_ENROLLMENT_STATUSES.IN_PROGRESS,
+    COURSE_ENROLLMENT_STATUSES.UPCOMING,
+    COURSE_ENROLLMENT_STATUSES.COMPLETED,
+    COURSE_ENROLLMENT_STATUSES.SAVED_FOR_LATER,
+}

--- a/enterprise_access/apps/bffs/response_builder.py
+++ b/enterprise_access/apps/bffs/response_builder.py
@@ -119,6 +119,7 @@ class LearnerDashboardResponseBuilder(BaseLearnerResponseBuilder, LearnerDashboa
         # Add specific fields related to the learner dashboard
         self.response_data.update({
             'enterprise_course_enrollments': self.enterprise_course_enrollments,
+            'all_enrollments_by_status': self.all_enrollments_by_status,
         })
 
         # Serialize and validate the response

--- a/enterprise_access/apps/bffs/serializers.py
+++ b/enterprise_access/apps/bffs/serializers.py
@@ -270,29 +270,41 @@ class EnterpriseCourseEnrollmentSerializer(BaseBffSerializer):
     Serializer for enterprise course enrollment.
     """
 
+    can_unenroll = serializers.BooleanField()
     course_run_id = serializers.CharField()
+    course_run_status = serializers.CharField()
     course_key = serializers.CharField()
     course_type = serializers.CharField()
-    org_name = serializers.CharField()
-    course_run_status = serializers.CharField()
-    display_name = serializers.CharField()
-    emails_enabled = serializers.BooleanField(required=False, allow_null=True)
-    certificate_download_url = serializers.CharField(allow_null=True)
     created = serializers.DateTimeField()
-    start_date = serializers.DateTimeField(allow_null=True)
     end_date = serializers.DateTimeField(allow_null=True)
-    mode = serializers.CharField()
-    is_enrollment_active = serializers.BooleanField()
-    product_source = serializers.CharField()
     enroll_by = serializers.DateTimeField(allow_null=True)
-    pacing = serializers.CharField()
-    course_run_url = serializers.URLField()
-    resume_course_run_url = serializers.URLField(allow_null=True)
+    has_emails_enabled = serializers.BooleanField()
+    is_enrollment_active = serializers.BooleanField()
     is_revoked = serializers.BooleanField()
+    link_to_course = serializers.URLField()
+    link_to_certificate = serializers.URLField(allow_null=True)
+    micromasters_title = serializers.CharField(allow_null=True)
+    mode = serializers.CharField()
+    notifications = serializers.ListField(
+        child=EnrollmentDueDateSerializer(),
+        allow_empty=True,
+    )
+    org_name = serializers.CharField()
+    pacing = serializers.CharField()
+    product_source = serializers.CharField()
+    resume_course_run_url = serializers.URLField(allow_null=True)
+    start_date = serializers.DateTimeField(allow_null=True)
+    title = serializers.CharField()
+
+    # Deprecated (will be removed in a future release)
+    certificate_download_url = serializers.CharField(allow_null=True)
+    course_run_url = serializers.URLField()
+    display_name = serializers.CharField()
     due_dates = serializers.ListField(
         child=EnrollmentDueDateSerializer(),
         allow_empty=True,
     )
+    emails_enabled = serializers.BooleanField(required=False, allow_null=True)
 
 
 class BFFRequestSerializer(BaseBffSerializer):
@@ -316,9 +328,21 @@ class LearnerDashboardRequestSerializer(BFFRequestSerializer):
     """
 
 
+class LearnerEnrollmentsByStatusSerializer(BaseBffSerializer):
+    """
+    Serializer for subscription license status.
+    """
+
+    in_progress = EnterpriseCourseEnrollmentSerializer(many=True, required=False, default=list)
+    upcoming = EnterpriseCourseEnrollmentSerializer(many=True, required=False, default=list)
+    completed = EnterpriseCourseEnrollmentSerializer(many=True, required=False, default=list)
+    saved_for_later = EnterpriseCourseEnrollmentSerializer(many=True, required=False, default=list)
+
+
 class LearnerDashboardResponseSerializer(BaseLearnerPortalResponseSerializer):
     """
     Serializer for the learner dashboard response.
     """
 
     enterprise_course_enrollments = EnterpriseCourseEnrollmentSerializer(many=True)
+    all_enrollments_by_status = LearnerEnrollmentsByStatusSerializer()

--- a/enterprise_access/apps/bffs/tests/test_handlers.py
+++ b/enterprise_access/apps/bffs/tests/test_handlers.py
@@ -376,26 +376,34 @@ class TestDashboardHandler(TestHandlerContextMixin):
         super().setUp()
 
         self.mock_enterprise_course_enrollment = {
-            "certificate_download_url": None,
-            "emails_enabled": False,
             "course_run_id": "course-v1:BabsonX+MIS01x+1T2019",
             "course_run_status": "in_progress",
             "created": "2023-09-29T14:24:45.409031+00:00",
             "start_date": "2019-03-19T10:00:00Z",
             "end_date": "2024-12-31T04:30:00Z",
-            "display_name": "AI for Leaders",
-            "course_run_url": "https://learning.edx.org/course/course-v1:BabsonX+MIS01x+1T2019/home",
-            "due_dates": [],
+            "title": "AI for Leaders",
+            "notifications": [],
             "pacing": "self",
             "org_name": "BabsonX",
             "is_revoked": False,
             "is_enrollment_active": True,
             "mode": "verified",
+            "link_to_course": "https://learning.edx.org/course/course-v1:BabsonX+MIS01x+1T2019/home",
+            "link_to_certificate": None,
             "resume_course_run_url": None,
             "course_key": "BabsonX+MIS01x",
             "course_type": "verified-audit",
             "product_source": "edx",
             "enroll_by": "2024-12-21T23:59:59Z",
+            'can_unenroll': True,
+            'has_emails_enabled': False,
+            'micromasters_title': None,
+            # Deprecated fields (to be removed in a future release)
+            'certificate_download_url': None,
+            "course_run_url": "https://learning.edx.org/course/course-v1:BabsonX+MIS01x+1T2019/home",
+            "display_name": "AI for Leaders",
+            'due_dates': [],
+            'emails_enabled': False,
         }
         self.mock_enterprise_course_enrollments = [self.mock_enterprise_course_enrollment]
 


### PR DESCRIPTION
**Description:**

Corresponding change in `frontend-app-learner-portal-enterprise`: https://github.com/openedx/frontend-app-learner-portal-enterprise/pull/1293 (**this PR to merge first**)

This PR brings some data transforms from the frontend (frontend-app-learner-portal-enterprise) to the BFF / API Gateway layer, to enable eventually removing business logic from the frontend long-term.

The overall strategy here is to:

1. Expose the additional fields resulting from the transform in the BFF API response (additive-only).
2. Remove the frontend data transforms on the enrollments data served by the BFF API response, relying solely on the BFF transformations.
3. Remove the no-longer consumed (deprecated) fields related to enrollments from the BFF API response.

Other changes:

* Creates `LearnerDashboardDataMixin` to house methods related to retrieving/transforming enterprise course enrollments related metadata.
* Implements and serializes an `all_enrollments_by_status` for the Learner Dashboard BFF API response.
  * Currently contains realized enterprise course enrollments returned by the `enterprise_course_enrollments` API.
  * In the future, it likely will also contain additional lists of requested and assigned enrollments.

**Jira:**
[ENT-9631](https://2u-internal.atlassian.net/browse/ENT-9631)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
