### PR TITLE
feat: add an LmsApiClient.create_enterprise_customer() method

### DIFF
--- a/enterprise_access/apps/api_client/__init__.py
+++ b/enterprise_access/apps/api_client/__init__.py
@@ -1,0 +1,7 @@
+"""
+Root api_client module.
+"""
+from .braze_client import *
+from .discovery_client import *
+from .enterprise_catalog_client import *
+from .lms_client import *

--- a/enterprise_access/apps/api_client/lms_client.py
+++ b/enterprise_access/apps/api_client/lms_client.py
@@ -105,6 +105,47 @@ class LmsApiClient(BaseOAuthClient):
             logger.exception(exc)
             raise
 
+    def create_enterprise_customer(self, *, name, slug, country, **kwargs):
+        """
+        Creates a new enterprise customer record.
+
+        Arguments:
+            name (string): The name of the customer.
+            slug (string): Slug of the enterprise customer.
+            country (string): The country code of the customer.
+            kwargs (dict): Any other fields to specify for the newly-created customer.
+        Returns:
+            dictionary containing enterprise customer metadata
+        """
+        payload = {
+            'name': name,
+            'slug': slug,
+            'country': country,
+            'site': {
+                'domain': settings.DEFAULT_CUSTOMER_SITE,
+            },
+            **kwargs,
+        }
+        response = self.client.post(
+            self.enterprise_customer_endpoint,
+            json=payload,
+            timeout=settings.LMS_CLIENT_TIMEOUT,
+        )
+        try:
+            response.raise_for_status()
+            payload = response.json()
+            logger.info(
+                'Successfully created customer %s with data %s',
+                name, payload,
+            )
+            return payload
+        except requests.exceptions.HTTPError:
+            logger.exception(
+                'Failed to create enterprise customer with name %s, response content %s',
+                name, response.content.decode(),
+            )
+            raise
+
     def get_enterprise_admin_users(self, enterprise_customer_uuid):
         """
         Gets a list of admin users for a given enterprise customer.

--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -531,3 +531,6 @@ BRAZE_GROUPS_EMAIL_AUTO_REMINDER_DAY_85_CAMPAIGN = ''
 # https://github.com/openedx/enterprise-subsidy/blob/70e1a13f9f9b1be6a09a2c2f1a02e7a46315eaa6/enterprise_subsidy/apps/subsidy/models.py#L67
 SALES_CONTRACT_REFERENCE_PROVIDER_NAME = 'Salesforce OpportunityLineItem'
 SALES_CONTRACT_REFERENCE_PROVIDER_SLUG = 'salesforce_opportunity_line_item'
+
+# Settings for creation of enterprise customers
+DEFAULT_CUSTOMER_SITE = 'example.com'


### PR DESCRIPTION
**Description:**
In support of https://2u-internal.atlassian.net/browse/ENT-9970

Adds a new API client method to create enterprise customer records.

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
