### PR TITLE
refactor: update deprecated MonitoringCustomMetricsMiddleware

### DIFF
--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -92,7 +92,7 @@ MIDDLEWARE = (
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
     'edx_django_utils.monitoring.DeploymentMonitoringMiddleware',
     # Enables monitoring utility for writing custom metrics.
-    'edx_django_utils.monitoring.middleware.MonitoringCustomMetricsMiddleware',
+    'edx_django_utils.monitoring.CachedCustomMonitoringMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',


### PR DESCRIPTION
## Description
- PR created under the issue https://github.com/edx/edx-arch-experiments/issues/815
- `edx_django_utils.monitoring.middleware.MonitoringCustomMetricsMiddleware` has been deprecated for a while and has been replaced with `edx_django_utils.monitoring.CachedCustomMonitoringMiddleware`