### PR TITLE
feat: list_price is always populated in can_redeem

### DIFF
--- a/enterprise_access/apps/api_client/enterprise_catalog_client.py
+++ b/enterprise_access/apps/api_client/enterprise_catalog_client.py
@@ -1,6 +1,8 @@
 """
 API client for enterprise-catalog service.
 """
+from urllib.parse import urljoin
+
 import backoff
 from django.conf import settings
 
@@ -10,10 +12,14 @@ from enterprise_access.apps.api_client.constants import autoretry_for_exceptions
 
 class EnterpriseCatalogApiClient(BaseOAuthClient):
     """
-    API client for calls to the enterprise catalog service.
+    V2 API client for calls to the enterprise catalog service.
     """
-    api_base_url = settings.ENTERPRISE_CATALOG_URL + '/api/v2/'
-    enterprise_catalog_endpoint = api_base_url + 'enterprise-catalogs/'
+    api_version = 'v2'
+
+    def __init__(self):
+        self.api_base_url = urljoin(settings.ENTERPRISE_CATALOG_URL, f'api/{self.api_version}/')
+        self.enterprise_catalog_endpoint = urljoin(self.api_base_url, 'enterprise-catalogs/')
+        super().__init__()
 
     @backoff.on_exception(wait_gen=backoff.expo, exception=autoretry_for_exceptions)
     def contains_content_items(self, catalog_uuid, content_ids):
@@ -84,3 +90,37 @@ class EnterpriseCatalogApiClient(BaseOAuthClient):
         response = self.client.get(endpoint)
         response.raise_for_status()
         return response.json()['count']
+
+    def content_metadata(self, content_id):
+        raise NotImplementedError('There is currently no v2 API implementation for this endpoint.')
+
+
+class EnterpriseCatalogApiV1Client(EnterpriseCatalogApiClient):
+    """
+    V1 API client for calls to the enterprise catalog service.
+    """
+    api_version = 'v1'
+
+    def __init__(self):
+        super().__init__()
+        self.content_metadata_endpoint = urljoin(self.api_base_url, 'content-metadata/')
+
+    @backoff.on_exception(wait_gen=backoff.expo, exception=autoretry_for_exceptions)
+    def content_metadata(self, content_id, coerce_to_parent_course=False):
+        """
+        Fetch catalog-/customer-agnostic content metadata.
+
+        Arguments:
+            content_id (str): ID of content to fetch.
+
+        Returns:
+            dict: serialized content metadata, or None if not found.
+        """
+        query_params = {}
+        if coerce_to_parent_course:
+            query_params |= {'coerce_to_parent_course': True}
+        kwargs = {'params': query_params} if query_params else {}
+        endpoint = self.content_metadata_endpoint + content_id
+        response = self.client.get(endpoint, **kwargs)
+        response.raise_for_status()
+        return response.json()

--- a/enterprise_access/apps/content_metadata/tests/test_api.py
+++ b/enterprise_access/apps/content_metadata/tests/test_api.py
@@ -6,6 +6,7 @@ from unittest import mock
 from uuid import uuid4
 
 from django.test import TestCase
+from edx_django_utils.cache import TieredCache
 from requests.exceptions import HTTPError
 
 from enterprise_access.apps.content_metadata import api
@@ -15,10 +16,15 @@ class TestContentMetadataApi(TestCase):
     """
     Tests the content_metadata/api.py functions.
     """
+    def tearDown(self):
+        super().tearDown()
+        # Clear the cache to prevent cache bleed across tests.
+        TieredCache.dangerous_clear_all_tiers()
+
     @mock.patch('enterprise_access.apps.content_metadata.api.EnterpriseCatalogApiClient', autospec=True)
-    def test_get_and_cache_metadata_happy_path(self, mock_client_class):
+    def test_get_and_cache_catalog_content_metadata_happy_path(self, mock_client_class):
         content_keys = ['course+A', 'course+B']
-        customer_uuid = uuid4()
+        catalog_uuid = uuid4()
         # Mock results from the catalog content metadata API endpoint.
         mock_result = {
             'count': 2,
@@ -29,17 +35,17 @@ class TestContentMetadataApi(TestCase):
         mock_client = mock_client_class.return_value
         mock_client.catalog_content_metadata.return_value = mock_result
 
-        metadata_list = api.get_and_cache_catalog_content_metadata(customer_uuid, content_keys)
+        metadata_list = api.get_and_cache_catalog_content_metadata(catalog_uuid, content_keys)
 
         self.assertEqual(mock_client.catalog_content_metadata.call_count, 1)
         # tease apart the call args, because the client is passed a set() of content keys to fetch
         call_args, _ = mock_client.catalog_content_metadata.call_args_list[0]
-        self.assertEqual(call_args[0], customer_uuid)
+        self.assertEqual(call_args[0], catalog_uuid)
         self.assertEqual(sorted(call_args[1]), sorted(content_keys))
         self.assertEqual(metadata_list, mock_result['results'])
 
         # ask again to hit the cache, ensure that we're still at only one client fetch
-        metadata_list = api.get_and_cache_catalog_content_metadata(customer_uuid, content_keys)
+        metadata_list = api.get_and_cache_catalog_content_metadata(catalog_uuid, content_keys)
 
         self.assertEqual(mock_client.catalog_content_metadata.call_count, 1)
         self.assertEqual(metadata_list, mock_result['results'])
@@ -60,13 +66,13 @@ class TestContentMetadataApi(TestCase):
             ],
         }
 
-        new_metadata_list = api.get_and_cache_catalog_content_metadata(customer_uuid, new_content_keys)
+        new_metadata_list = api.get_and_cache_catalog_content_metadata(catalog_uuid, new_content_keys)
 
         # Should only have requested courses C and D via the client
         # tease apart the call args, because the client is passed a set() of content keys to fetch
         self.assertEqual(mock_client.catalog_content_metadata.call_count, 2)
         call_args, _ = mock_client.catalog_content_metadata.call_args_list[1]
-        self.assertEqual(call_args[0], customer_uuid)
+        self.assertEqual(call_args[0], catalog_uuid)
         self.assertEqual(sorted(call_args[1]), ['course+C', 'course+D'])
 
         # And there will be results for courses B and C, but no result for course D
@@ -79,16 +85,67 @@ class TestContentMetadataApi(TestCase):
         )
 
     @mock.patch('enterprise_access.apps.content_metadata.api.EnterpriseCatalogApiClient', autospec=True)
-    def test_get_and_cache_metadata_http_error(self, mock_client_class):
+    def test_get_and_cache_catalog_content_metadata_http_error(self, mock_client_class):
         content_keys = ['course+A', 'course+B']
-        customer_uuid = uuid4()
+        catalog_uuid = uuid4()
         mock_client = mock_client_class.return_value
         mock_client.catalog_content_metadata.side_effect = HTTPError('oh barnacles')
 
         with self.assertRaisesRegex(HTTPError, 'oh barnacles'):
-            api.get_and_cache_catalog_content_metadata(customer_uuid, content_keys)
+            api.get_and_cache_catalog_content_metadata(catalog_uuid, content_keys)
 
         # tease apart the call args, because the client is passed a set() of content keys to fetch
         call_args, _ = mock_client.catalog_content_metadata.call_args_list[0]
-        self.assertEqual(call_args[0], customer_uuid)
+        self.assertEqual(call_args[0], catalog_uuid)
         self.assertEqual(sorted(call_args[1]), sorted(content_keys))
+
+    @mock.patch('enterprise_access.apps.content_metadata.api.EnterpriseCatalogApiV1Client', autospec=True)
+    def test_get_and_cache_content_metadata_happy_path(self, mock_client_class):
+        content_key = 'course+A'
+        # Mock results from the content metadata API endpoint.
+        mock_result = {
+            'key': 'course+A',
+            'data': 'things',
+        }
+        mock_client = mock_client_class.return_value
+        mock_client.content_metadata.return_value = mock_result
+
+        metadata = api.get_and_cache_content_metadata(content_key)
+
+        self.assertEqual(mock_client.content_metadata.call_count, 1)
+        call_args, _ = mock_client.content_metadata.call_args_list[0]
+        self.assertEqual(call_args[0], content_key)
+        self.assertEqual(metadata, mock_result)
+
+        # ask again to hit the cache, ensure that we're still at only one client fetch
+        metadata = api.get_and_cache_content_metadata(content_key)
+
+        self.assertEqual(mock_client.content_metadata.call_count, 1)
+        self.assertEqual(metadata, mock_result)
+
+        # Now get-and-cache again, but this time request key is different.
+        new_content_key = 'course+B'
+        new_mock_result = {
+            'key': 'course+B',
+            'data': 'things',
+        }
+        mock_client.content_metadata.return_value = new_mock_result
+
+        new_metadata = api.get_and_cache_content_metadata(new_content_key)
+
+        self.assertEqual(mock_client.content_metadata.call_count, 2)
+        call_args, _ = mock_client.content_metadata.call_args_list[-1]
+        self.assertEqual(call_args[0], new_content_key)
+        self.assertEqual(new_metadata, new_mock_result)
+
+    @mock.patch('enterprise_access.apps.content_metadata.api.EnterpriseCatalogApiV1Client', autospec=True)
+    def test_get_and_cache_content_metadata_http_error(self, mock_client_class):
+        content_key = 'course+A'
+        mock_client = mock_client_class.return_value
+        mock_client.content_metadata.side_effect = HTTPError('oh barnacles')
+
+        with self.assertRaisesRegex(HTTPError, 'oh barnacles'):
+            api.get_and_cache_content_metadata(content_key)
+
+        call_args, _ = mock_client.content_metadata.call_args_list[0]
+        self.assertEqual(call_args[0], content_key)

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -52,7 +52,7 @@ from .content_metadata_api import (
     get_and_cache_catalog_contains_content,
     get_and_cache_content_metadata,
     get_list_price_for_content,
-    list_price_dict_from_usd_cents
+    make_list_price_dict
 )
 from .customer_api import get_and_cache_enterprise_learner_record
 from .exceptions import (
@@ -1391,7 +1391,7 @@ class AssignedLearnerCreditAccessPolicy(AssignedCreditPolicyMixin, SubsidyAccess
             return super().get_list_price(lms_user_id, content_key)
         # an assignment's content_quantity is always <= 0 to express the fact
         # that value has been consumed from a subsidy (though not necessarily fulfilled)
-        return list_price_dict_from_usd_cents(found_assignment.content_quantity * -1)
+        return make_list_price_dict(integer_cents=found_assignment.content_quantity * -1)
 
     def can_redeem(
         self, lms_user_id, content_key,

--- a/enterprise_access/apps/subsidy_access_policy/subsidy_api.py
+++ b/enterprise_access/apps/subsidy_access_policy/subsidy_api.py
@@ -134,7 +134,7 @@ def get_redemptions_by_content_and_policy_for_learner(policies, lms_user_id):
     """
     policies_by_subsidy_uuid = defaultdict(set)
     for policy in policies:
-        policies_by_subsidy_uuid[policy.subsidy_uuid].add(str(policy.uuid))
+        policies_by_subsidy_uuid[policy.subsidy_uuid].add(policy)
 
     result = defaultdict(lambda: defaultdict(list))
 
@@ -146,8 +146,15 @@ def get_redemptions_by_content_and_policy_for_learner(policies, lms_user_id):
             content_key = redemption['content_key']
             subsidy_access_policy_uuid = redemption['subsidy_access_policy_uuid']
 
-            if subsidy_access_policy_uuid in policies_with_subsidy:
-                result[content_key][subsidy_access_policy_uuid].append(redemption)
+            matching_policies = [
+                policy for policy in policies_with_subsidy
+                if str(policy.uuid) == subsidy_access_policy_uuid
+            ]
+            # We can assume there's at most one matching policy because the ``policies`` arg passed into this function
+            # should not contain duplicates.
+            matching_policy = matching_policies[0] if matching_policies else None
+            if matching_policy:
+                result[content_key][matching_policy].append(redemption)
             else:
                 logger.warning(
                     f"Transaction {transaction_uuid} has unmatched policy uuid for subsidy {subsidy_uuid}: "

--- a/enterprise_access/apps/subsidy_access_policy/tests/test_content_metadata_api.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/test_content_metadata_api.py
@@ -1,0 +1,67 @@
+"""
+Test content_metadata_api.py
+"""
+import contextlib
+
+import ddt
+from django.test import TestCase
+
+from enterprise_access.apps.subsidy_access_policy.content_metadata_api import make_list_price_dict
+
+
+@ddt.ddt
+class ContentMetadataApiTests(TestCase):
+    """
+    Test various functions inside content_metadata_api.py
+    """
+
+    @ddt.data(
+        # Standard happy path.
+        {
+            "decimal_dollars": 10.5,
+            "integer_cents": None,
+            "expected_result": {"usd": 10.5, "usd_cents": 1050},
+        },
+        # Standard happy path.
+        {
+            "decimal_dollars": None,
+            "integer_cents": 1050,
+            "expected_result": {"usd": 10.5, "usd_cents": 1050},
+        },
+        # Weird precision input just gets passed along as-is.
+        {
+            "decimal_dollars": 10.503,
+            "integer_cents": None,
+            "expected_result": {"usd": 10.503, "usd_cents": 1050},
+        },
+        # All None.
+        {
+            "decimal_dollars": None,
+            "integer_cents": None,
+            "expect_raises": ValueError,
+        },
+        # All defined.
+        {
+            "decimal_dollars": 10.5,
+            "integer_cents": 1050,
+            "expect_raises": ValueError,
+        },
+    )
+    @ddt.unpack
+    def test_make_list_price_dict(
+        self,
+        decimal_dollars,
+        integer_cents,
+        expected_result=None,
+        expect_raises=None,
+    ):
+        cm = contextlib.nullcontext()
+        if expect_raises:
+            cm = self.assertRaises(expect_raises)
+        with cm:
+            actual_result = make_list_price_dict(
+                decimal_dollars=decimal_dollars,
+                integer_cents=integer_cents,
+            )
+        if not expect_raises:
+            assert actual_result == expected_result

--- a/enterprise_access/apps/subsidy_access_policy/tests/test_subsidy_api.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/test_subsidy_api.py
@@ -145,9 +145,9 @@ class TransactionsForLearnerTests(TestCase):
 
         self.assertEqual(
             {
-                'content-1': {str(cherry_policy.uuid): [mock_pie_transactions[0]]},
-                'content-2': {str(apple_policy.uuid): [mock_pie_transactions[1]]},
-                'content-3': {str(german_chocolate_policy.uuid): [mock_cake_transactions[0]]},
+                'content-1': {cherry_policy: [mock_pie_transactions[0]]},
+                'content-2': {apple_policy: [mock_pie_transactions[1]]},
+                'content-3': {german_chocolate_policy: [mock_cake_transactions[0]]},
             },
             result,
         )


### PR DESCRIPTION
This basically adds a fallback branch when calculating the list_price to serialize into the can-redeem endpoint.  The fallback logic relies on a net new call to enterprise-catalog to fetch content metadata containing price information agnostic of any catalog or customer.

![Screenshot 2025-02-26 at 4 50 18 PM](https://github.com/user-attachments/assets/0996129c-cca6-4e51-ba7d-25c608b2a8c1)

ENT-9660

Local Dev Testing
===

For this manual test, I created an learner credit plan with only an assignable budget, but no assignments.

```
GET /api/v1/policy-redemption/enterprise-customer/298629a4-0fbf-44db-bcfb-9c604eca0bc8/can-redeem/?content_key=course-v1%3AedX%2BDemoX%2BDemo_Course
```

<details>
<summary>can-redeem response BEFORE commit has null list_price</summary>

```json
[
    {
        "content_key": "course-v1:edX+DemoX+Demo_Course",
        "list_price": null,
        "redemptions": [],
        "has_successful_redemption": false,
        "redeemable_subsidy_access_policy": null,
        "can_redeem": false,
        "reasons": [
            {
                "reason": "reason_learner_not_assigned_content",
                "user_message": "You can't enroll right now because this course is not assigned to you.",
                "policy_uuids": [
                    "8b460a30-ff5d-4810-8b56-18689677d672"
                ],
                "metadata": {
                    "enterprise_administrators": [
                        {
                            "email": "[edx@example.com](mailto:edx@example.com)",
                            "lms_user_id": 3
                        }
                    ]
                }
            }
        ]
    }
]
```
</details>

<details>
<summary>can-redeem response AFTER commit has populated list_price</summary>

```json
[
    {
        "content_key": "course-v1:edX+DemoX+Demo_Course",
        "list_price": {
            "usd": 149.0,
            "usd_cents": 14900
        },
        "redemptions": [],
        "has_successful_redemption": false,
        "redeemable_subsidy_access_policy": null,
        "can_redeem": false,
        "reasons": [
            {
                "reason": "reason_learner_not_assigned_content",
                "user_message": "You can't enroll right now because this course is not assigned to you.",
                "policy_uuids": [
                    "8b460a30-ff5d-4810-8b56-18689677d672"
                ],
                "metadata": {
                    "enterprise_administrators": [
                        {
                            "email": "[edx@example.com](mailto:edx@example.com)",
                            "lms_user_id": 3
                        }
                    ]
                }
            }
        ]
    }
]
```
</details>

Stage testing plan
===

This URL currently returns null list_price, but it should become non-null after merging:

https://enterprise-access.stage.edx.org/api/v1/policy-redemption/enterprise-customer/b705ea3b-f2ab-484f-83b9-78cf488f1704/can-redeem/?content_key=course-v1%3Aedx%2B101010%2B1T2025

Prod testing plan
===

This URL currently returns null list_price, but it should become non-null after merging:

https://enterprise-access.edx.org/api/v1/policy-redemption/enterprise-customer/89cbcdd9-c3cd-4dd7-8a33-2034b50b240e/can-redeem/?content_key=course-v1%3AUniversityofCambridge%2BSUP%2B3T2025