### PR TITLE
feat: list_price is always populated in can_redeem

### DIFF
--- a/enterprise_access/apps/api_client/enterprise_catalog_client.py
+++ b/enterprise_access/apps/api_client/enterprise_catalog_client.py
@@ -1,6 +1,8 @@
 """
 API client for enterprise-catalog service.
 """
+from urllib.parse import urljoin
+
 import backoff
 from django.conf import settings
 
@@ -10,10 +12,14 @@ from enterprise_access.apps.api_client.constants import autoretry_for_exceptions
 
 class EnterpriseCatalogApiClient(BaseOAuthClient):
     """
-    API client for calls to the enterprise catalog service.
+    V2 API client for calls to the enterprise catalog service.
     """
-    api_base_url = settings.ENTERPRISE_CATALOG_URL + '/api/v2/'
-    enterprise_catalog_endpoint = api_base_url + 'enterprise-catalogs/'
+    api_version = 'v2'
+
+    def __init__(self):
+        self.api_base_url = urljoin(settings.ENTERPRISE_CATALOG_URL, f'api/{self.api_version}/')
+        self.enterprise_catalog_endpoint = urljoin(self.api_base_url, 'enterprise-catalogs/')
+        super().__init__()
 
     @backoff.on_exception(wait_gen=backoff.expo, exception=autoretry_for_exceptions)
     def contains_content_items(self, catalog_uuid, content_ids):
@@ -84,3 +90,37 @@ class EnterpriseCatalogApiClient(BaseOAuthClient):
         response = self.client.get(endpoint)
         response.raise_for_status()
         return response.json()['count']
+
+    def content_metadata(self, content_id):
+        raise NotImplementedError('There is currently no v2 API implementation for this endpoint.')
+
+
+class EnterpriseCatalogApiV1Client(EnterpriseCatalogApiClient):
+    """
+    V1 API client for calls to the enterprise catalog service.
+    """
+    api_version = 'v1'
+
+    def __init__(self):
+        super().__init__()
+        self.content_metadata_endpoint = urljoin(self.api_base_url, 'content-metadata/')
+
+    @backoff.on_exception(wait_gen=backoff.expo, exception=autoretry_for_exceptions)
+    def content_metadata(self, content_id, coerce_to_parent_course=False):
+        """
+        Fetch catalog-/customer-agnostic content metadata.
+
+        Arguments:
+            content_id (str): ID of content to fetch.
+
+        Returns:
+            dict: serialized content metadata, or None if not found.
+        """
+        query_params = {}
+        if coerce_to_parent_course:
+            query_params |= {'coerce_to_parent_course': True}
+        kwargs = {'params': query_params} if query_params else {}
+        endpoint = self.content_metadata_endpoint + content_id
+        response = self.client.get(endpoint, **kwargs)
+        response.raise_for_status()
+        return response.json()

--- a/enterprise_access/apps/content_metadata/tests/test_api.py
+++ b/enterprise_access/apps/content_metadata/tests/test_api.py
@@ -6,6 +6,7 @@ from unittest import mock
 from uuid import uuid4
 
 from django.test import TestCase
+from edx_django_utils.cache import TieredCache
 from requests.exceptions import HTTPError
 
 from enterprise_access.apps.content_metadata import api
@@ -15,10 +16,15 @@ class TestContentMetadataApi(TestCase):
     """
     Tests the content_metadata/api.py functions.
     """
+    def tearDown(self):
+        super().tearDown()
+        # Clear the cache to prevent cache bleed across tests.
+        TieredCache.dangerous_clear_all_tiers()
+
     @mock.patch('enterprise_access.apps.content_metadata.api.EnterpriseCatalogApiClient', autospec=True)
-    def test_get_and_cache_metadata_happy_path(self, mock_client_class):
+    def test_get_and_cache_catalog_content_metadata_happy_path(self, mock_client_class):
         content_keys = ['course+A', 'course+B']
-        customer_uuid = uuid4()
+        catalog_uuid = uuid4()
         # Mock results from the catalog content metadata API endpoint.
         mock_result = {
             'count': 2,
@@ -29,17 +35,17 @@ class TestContentMetadataApi(TestCase):
         mock_client = mock_client_class.return_value
         mock_client.catalog_content_metadata.return_value = mock_result
 
-        metadata_list = api.get_and_cache_catalog_content_metadata(customer_uuid, content_keys)
+        metadata_list = api.get_and_cache_catalog_content_metadata(catalog_uuid, content_keys)
 
         self.assertEqual(mock_client.catalog_content_metadata.call_count, 1)
         # tease apart the call args, because the client is passed a set() of content keys to fetch
         call_args, _ = mock_client.catalog_content_metadata.call_args_list[0]
-        self.assertEqual(call_args[0], customer_uuid)
+        self.assertEqual(call_args[0], catalog_uuid)
         self.assertEqual(sorted(call_args[1]), sorted(content_keys))
         self.assertEqual(metadata_list, mock_result['results'])
 
         # ask again to hit the cache, ensure that we're still at only one client fetch
-        metadata_list = api.get_and_cache_catalog_content_metadata(customer_uuid, content_keys)
+        metadata_list = api.get_and_cache_catalog_content_metadata(catalog_uuid, content_keys)
 
         self.assertEqual(mock_client.catalog_content_metadata.call_count, 1)
         self.assertEqual(metadata_list, mock_result['results'])
@@ -60,13 +66,13 @@ class TestContentMetadataApi(TestCase):
             ],
         }
 
-        new_metadata_list = api.get_and_cache_catalog_content_metadata(customer_uuid, new_content_keys)
+        new_metadata_list = api.get_and_cache_catalog_content_metadata(catalog_uuid, new_content_keys)
 
         # Should only have requested courses C and D via the client
         # tease apart the call args, because the client is passed a set() of content keys to fetch
         self.assertEqual(mock_client.catalog_content_metadata.call_count, 2)
         call_args, _ = mock_client.catalog_content_metadata.call_args_list[1]
-        self.assertEqual(call_args[0], customer_uuid)
+        self.assertEqual(call_args[0], catalog_uuid)
         self.assertEqual(sorted(call_args[1]), ['course+C', 'course+D'])
 
         # And there will be results for courses B and C, but no result for course D
@@ -79,16 +85,67 @@ class TestContentMetadataApi(TestCase):
         )
 
     @mock.patch('enterprise_access.apps.content_metadata.api.EnterpriseCatalogApiClient', autospec=True)
-    def test_get_and_cache_metadata_http_error(self, mock_client_class):
+    def test_get_and_cache_catalog_content_metadata_http_error(self, mock_client_class):
         content_keys = ['course+A', 'course+B']
-        customer_uuid = uuid4()
+        catalog_uuid = uuid4()
         mock_client = mock_client_class.return_value
         mock_client.catalog_content_metadata.side_effect = HTTPError('oh barnacles')
 
         with self.assertRaisesRegex(HTTPError, 'oh barnacles'):
-            api.get_and_cache_catalog_content_metadata(customer_uuid, content_keys)
+            api.get_and_cache_catalog_content_metadata(catalog_uuid, content_keys)
 
         # tease apart the call args, because the client is passed a set() of content keys to fetch
         call_args, _ = mock_client.catalog_content_metadata.call_args_list[0]
-        self.assertEqual(call_args[0], customer_uuid)
+        self.assertEqual(call_args[0], catalog_uuid)
         self.assertEqual(sorted(call_args[1]), sorted(content_keys))
+
+    @mock.patch('enterprise_access.apps.content_metadata.api.EnterpriseCatalogApiV1Client', autospec=True)
+    def test_get_and_cache_content_metadata_happy_path(self, mock_client_class):
+        content_key = 'course+A'
+        # Mock results from the content metadata API endpoint.
+        mock_result = {
+            'key': 'course+A',
+            'data': 'things',
+        }
+        mock_client = mock_client_class.return_value
+        mock_client.content_metadata.return_value = mock_result
+
+        metadata = api.get_and_cache_content_metadata(content_key)
+
+        self.assertEqual(mock_client.content_metadata.call_count, 1)
+        call_args, _ = mock_client.content_metadata.call_args_list[0]
+        self.assertEqual(call_args[0], content_key)
+        self.assertEqual(metadata, mock_result)
+
+        # ask again to hit the cache, ensure that we're still at only one client fetch
+        metadata = api.get_and_cache_content_metadata(content_key)
+
+        self.assertEqual(mock_client.content_metadata.call_count, 1)
+        self.assertEqual(metadata, mock_result)
+
+        # Now get-and-cache again, but this time request key is different.
+        new_content_key = 'course+B'
+        new_mock_result = {
+            'key': 'course+B',
+            'data': 'things',
+        }
+        mock_client.content_metadata.return_value = new_mock_result
+
+        new_metadata = api.get_and_cache_content_metadata(new_content_key)
+
+        self.assertEqual(mock_client.content_metadata.call_count, 2)
+        call_args, _ = mock_client.content_metadata.call_args_list[-1]
+        self.assertEqual(call_args[0], new_content_key)
+        self.assertEqual(new_metadata, new_mock_result)
+
+    @mock.patch('enterprise_access.apps.content_metadata.api.EnterpriseCatalogApiV1Client', autospec=True)
+    def test_get_and_cache_content_metadata_http_error(self, mock_client_class):
+        content_key = 'course+A'
+        mock_client = mock_client_class.return_value
+        mock_client.content_metadata.side_effect = HTTPError('oh barnacles')
+
+        with self.assertRaisesRegex(HTTPError, 'oh barnacles'):
+            api.get_and_cache_content_metadata(content_key)
+
+        call_args, _ = mock_client.content_metadata.call_args_list[0]
+        self.assertEqual(call_args[0], content_key)

--- a/enterprise_access/apps/subsidy_access_policy/content_metadata_api.py
+++ b/enterprise_access/apps/subsidy_access_policy/content_metadata_api.py
@@ -111,21 +111,38 @@ def get_list_price_for_content(enterprise_customer_uuid, content_key, content_me
             raise ContentPriceNullException(f'Could not determine list price for {content_key}') from exc
 
     # Note that the "content_price" key is guaranteed to exist, but the value may be None.
-    return list_price_dict_from_usd_cents(content_metadata['content_price'])
+    return make_list_price_dict(integer_cents=content_metadata['content_price'])
 
 
-def list_price_dict_from_usd_cents(list_price_integer_cents):
+def make_list_price_dict(decimal_dollars=None, integer_cents=None):
     """
-    Helper to compute a list price dictionary given the non-negative price of the content in USD cents.
-    """
-    list_price_decimal_dollars = None
-    if list_price_integer_cents is not None:
-        list_price_decimal_dollars = Decimal(list_price_integer_cents) / 100
+    Helper to compute a list price dictionary given the non-negative price of the content.
 
-    return {
-        "usd": list_price_decimal_dollars,
-        "usd_cents": list_price_integer_cents,
-    }
+    Usage:
+        list_price_dict = make_list_price_dict(decimal_dollars=100.00)
+        list_price_dict = make_list_price_dict(integer_cents=10000)
+
+    Args:
+        decimal_dollars (float): Content price in USD dollars. Must only be specified if ``integer_cents`` is None.
+        integer_cents (int): Content price in USD cents. Must only be specified if ``decimal_dollars`` is None.
+
+    Raises:
+        ValueError if neither OR both arguments were specified.
+    """
+    if decimal_dollars is None and integer_cents is not None:
+        if not isinstance(integer_cents, int):
+            raise ValueError("`integer_cents` must be an integer.")
+        return {
+            "usd": Decimal(integer_cents) / 100,
+            "usd_cents": integer_cents,
+        }
+    elif decimal_dollars is not None and integer_cents is None:
+        return {
+            "usd": decimal_dollars,
+            "usd_cents": int(Decimal(decimal_dollars) * 100),
+        }
+    else:
+        raise ValueError("Only one of `decimal_dollars` or `integer_cents` can be passed.")
 
 
 def enroll_by_datetime(content_metadata):

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -52,7 +52,7 @@ from .content_metadata_api import (
     get_and_cache_catalog_contains_content,
     get_and_cache_content_metadata,
     get_list_price_for_content,
-    list_price_dict_from_usd_cents
+    make_list_price_dict
 )
 from .customer_api import get_and_cache_enterprise_learner_record
 from .exceptions import (
@@ -1391,7 +1391,7 @@ class AssignedLearnerCreditAccessPolicy(AssignedCreditPolicyMixin, SubsidyAccess
             return super().get_list_price(lms_user_id, content_key)
         # an assignment's content_quantity is always <= 0 to express the fact
         # that value has been consumed from a subsidy (though not necessarily fulfilled)
-        return list_price_dict_from_usd_cents(found_assignment.content_quantity * -1)
+        return make_list_price_dict(integer_cents=found_assignment.content_quantity * -1)
 
     def can_redeem(
         self, lms_user_id, content_key,

--- a/enterprise_access/apps/subsidy_access_policy/subsidy_api.py
+++ b/enterprise_access/apps/subsidy_access_policy/subsidy_api.py
@@ -134,7 +134,7 @@ def get_redemptions_by_content_and_policy_for_learner(policies, lms_user_id):
     """
     policies_by_subsidy_uuid = defaultdict(set)
     for policy in policies:
-        policies_by_subsidy_uuid[policy.subsidy_uuid].add(str(policy.uuid))
+        policies_by_subsidy_uuid[policy.subsidy_uuid].add(policy)
 
     result = defaultdict(lambda: defaultdict(list))
 
@@ -146,8 +146,15 @@ def get_redemptions_by_content_and_policy_for_learner(policies, lms_user_id):
             content_key = redemption['content_key']
             subsidy_access_policy_uuid = redemption['subsidy_access_policy_uuid']
 
-            if subsidy_access_policy_uuid in policies_with_subsidy:
-                result[content_key][subsidy_access_policy_uuid].append(redemption)
+            matching_policies = [
+                policy for policy in policies_with_subsidy
+                if str(policy.uuid) == subsidy_access_policy_uuid
+            ]
+            # We can assume there's at most one matching policy because the ``policies`` arg passed into this function
+            # should not contain duplicates.
+            matching_policy = matching_policies[0] if matching_policies else None
+            if matching_policy:
+                result[content_key][matching_policy].append(redemption)
             else:
                 logger.warning(
                     f"Transaction {transaction_uuid} has unmatched policy uuid for subsidy {subsidy_uuid}: "

--- a/enterprise_access/apps/subsidy_access_policy/tests/test_content_metadata_api.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/test_content_metadata_api.py
@@ -1,0 +1,73 @@
+"""
+Test content_metadata_api.py
+"""
+import contextlib
+
+import ddt
+from django.test import TestCase
+
+from enterprise_access.apps.subsidy_access_policy.content_metadata_api import make_list_price_dict
+
+
+@ddt.ddt
+class ContentMetadataApiTests(TestCase):
+    """
+    Test various functions inside content_metadata_api.py
+    """
+
+    @ddt.data(
+        # Standard happy path.
+        {
+            "decimal_dollars": 10.5,
+            "integer_cents": None,
+            "expected_result": {"usd": 10.5, "usd_cents": 1050},
+        },
+        # Standard happy path.
+        {
+            "decimal_dollars": None,
+            "integer_cents": 1050,
+            "expected_result": {"usd": 10.5, "usd_cents": 1050},
+        },
+        # Weird precision input just gets passed along as-is.
+        {
+            "decimal_dollars": 10.503,
+            "integer_cents": None,
+            "expected_result": {"usd": 10.503, "usd_cents": 1050},
+        },
+        # All None.
+        {
+            "decimal_dollars": None,
+            "integer_cents": None,
+            "expect_raises": ValueError,
+        },
+        # All defined.
+        {
+            "decimal_dollars": 10.5,
+            "integer_cents": 1050,
+            "expect_raises": ValueError,
+        },
+        # integer_cents not an integer.
+        {
+            "decimal_dollars": None,
+            "integer_cents": 10.5,
+            "expect_raises": ValueError,
+        },
+    )
+    @ddt.unpack
+    def test_make_list_price_dict(
+        self,
+        decimal_dollars,
+        integer_cents,
+        expected_result=None,
+        expect_raises=None,
+    ):
+        cm = contextlib.nullcontext()
+        if expect_raises:
+            cm = self.assertRaises(expect_raises)
+        with cm:
+            actual_result = make_list_price_dict(
+                decimal_dollars=decimal_dollars,
+                integer_cents=integer_cents,
+            )
+        if not expect_raises:
+            assert actual_result == expected_result

--- a/enterprise_access/apps/subsidy_access_policy/tests/test_subsidy_api.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/test_subsidy_api.py
@@ -145,9 +145,9 @@ class TransactionsForLearnerTests(TestCase):
 
         self.assertEqual(
             {
-                'content-1': {str(cherry_policy.uuid): [mock_pie_transactions[0]]},
-                'content-2': {str(apple_policy.uuid): [mock_pie_transactions[1]]},
-                'content-3': {str(german_chocolate_policy.uuid): [mock_cake_transactions[0]]},
+                'content-1': {cherry_policy: [mock_pie_transactions[0]]},
+                'content-2': {apple_policy: [mock_pie_transactions[1]]},
+                'content-3': {german_chocolate_policy: [mock_cake_transactions[0]]},
             },
             result,
         )


### PR DESCRIPTION
This re-introduces logic which had been reverted.  The logic remains the same, but depends on a fix to a buggy endpoint in enterprise-catalog.

Original commits:
* 158ea69516f40e8e6e642072900dc455cbd99479 (https://github.com/openedx/enterprise-access/pull/648)
* 07b11bc31b76026c562c06923b199e84c7734a64 (https://github.com/openedx/enterprise-access/pull/651)

Depends on this fix being deployed:

https://github.com/openedx/enterprise-catalog/pull/1041

ENT-9660