### PR TITLE
build: pin edx-braze-client<1

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -16,3 +16,8 @@ backports.zoneinfo; python_version<'3.9'
 
 # confluent-kafka 2.7.0 increased CPU usage
 confluent-kafka<2.6.2
+
+# pinning braze-client below version 1, which will likely introduce a breaking-change
+# as the package is converted to an openedx plugin.
+# https://github.com/edx/braze-client/pull/30
+edx-braze-client<1


### PR DESCRIPTION
ENT-10153

pinning braze-client below version 1, which will likely introduce a breaking-change
as the package is converted to an openedx plugin.
see https://github.com/edx/braze-client/pull/30

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
