### PR TITLE
fix: bug fix for can_redeem course_price

### DIFF
--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -819,10 +819,13 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
                         raise ContentPriceNullException(
                             'Failed to obtain content metadata from enterprise-catalog.'
                         ) from exc
-                    decimal_dollars = (
-                        course_metadata['normalized_metadata_by_run'].get(content_key, {}).get('content_price') or
-                        course_metadata['normalized_metadata'].get('content_price')
-                    )
+                    content_price_1 = course_metadata['normalized_metadata_by_run'].get(
+                        content_key, {}).get('content_price')
+                    content_price_2 = course_metadata['normalized_metadata'].get('content_price')
+                    if content_price_1 is not None:
+                        decimal_dollars = content_price_1
+                    else:
+                        decimal_dollars = content_price_2
                     if decimal_dollars is None:
                         raise ContentPriceNullException('Failed to obtain content price from enterprise-catalog.')
                     list_price_dict = make_list_price_dict(decimal_dollars=decimal_dollars)

--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -703,7 +703,7 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
         url_path='enterprise-customer/(?P<enterprise_customer_uuid>[^/.]+)/can-redeem',
         pagination_class=None,
     )
-    def can_redeem(self, request, enterprise_customer_uuid):
+    def can_redeem(self, request, enterprise_customer_uuid):  # pylint: disable=too-many-statements
         """
         Within a specified enterprise customer, retrieves a single, redeemable access policy (or null)
         for each ``content_key`` in a provided list of content keys.
@@ -817,7 +817,8 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
                         course_metadata = get_and_cache_content_metadata(content_key, coerce_to_parent_course=True)
                     except HTTPError as exc:
                         raise ContentPriceNullException(
-                            'Failed to obtain content metadata from enterprise-catalog.'
+                            f'Failed to obtain content metadata from enterprise-catalog'
+                            f' with customer {enterprise_customer_uuid}.'
                         ) from exc
                     content_price_1 = course_metadata['normalized_metadata_by_run'].get(
                         content_key, {}).get('content_price')
@@ -827,11 +828,16 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
                     else:
                         decimal_dollars = content_price_2
                     if decimal_dollars is None:
-                        raise ContentPriceNullException('Failed to obtain content price from enterprise-catalog.')
+                        raise ContentPriceNullException(
+                            f'Failed to obtain content price from enterprise-catalog'
+                            f' with customer {enterprise_customer_uuid}.'
+                        )
                     list_price_dict = make_list_price_dict(decimal_dollars=decimal_dollars)
             except ContentPriceNullException as exc:
                 raise RedemptionRequestException(
-                    detail=f'Could not determine list price for content_key: {content_key}',
+                    detail=(
+                        f'Could not determine list price for content_key {content_key}'
+                        f' in customer {enterprise_customer_uuid}')
                 ) from exc
 
             element_response = {

--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -703,7 +703,7 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
         url_path='enterprise-customer/(?P<enterprise_customer_uuid>[^/.]+)/can-redeem',
         pagination_class=None,
     )
-    def can_redeem(self, request, enterprise_customer_uuid):  # pylint: disable=too-many-statements
+    def can_redeem(self, request, enterprise_customer_uuid):
         """
         Within a specified enterprise customer, retrieves a single, redeemable access policy (or null)
         for each ``content_key`` in a provided list of content keys.
@@ -818,26 +818,22 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
                     except HTTPError as exc:
                         raise ContentPriceNullException(
                             f'Failed to obtain content metadata from enterprise-catalog'
-                            f' with customer {enterprise_customer_uuid}.'
+                            f' with enterprise customer {enterprise_customer_uuid}.'
                         ) from exc
-                    content_price_1 = course_metadata['normalized_metadata_by_run'].get(
-                        content_key, {}).get('content_price')
-                    content_price_2 = course_metadata['normalized_metadata'].get('content_price')
-                    if content_price_1 is not None:
-                        decimal_dollars = content_price_1
-                    else:
-                        decimal_dollars = content_price_2
-                    if decimal_dollars is None:
+                    if (decimal_dollars := course_metadata['normalized_metadata_by_run'].get(
+                            content_key, {}).get('content_price')) is None:
+                        decimal_dollars = course_metadata['normalized_metadata'].get('content_price')
+                    if (decimal_dollars is None):
                         raise ContentPriceNullException(
                             f'Failed to obtain content price from enterprise-catalog'
-                            f' with customer {enterprise_customer_uuid}.'
+                            f' with enterprise customer {enterprise_customer_uuid}.'
                         )
                     list_price_dict = make_list_price_dict(decimal_dollars=decimal_dollars)
             except ContentPriceNullException as exc:
                 raise RedemptionRequestException(
                     detail=(
                         f'Could not determine list price for content_key {content_key}'
-                        f' in customer {enterprise_customer_uuid}')
+                        f' with enterprise customer {enterprise_customer_uuid}')
                 ) from exc
 
             element_response = {


### PR DESCRIPTION
**Description:**
A bug ticket came through on-call that surfaced a bug when the course_price is 0. With this line of code, if the first check of the OR condition evaluated to 0.0 it would read as falsy even though this is a valid imput, which would automatically set the decimal_dollars value to whatever the second check was, which in this case was None which resulted in us throwing an exception. 

```
decimal_dollars = (
     course_metadata['normalized_metadata_by_run'].get(content_key, {}).get('content_price') or
     course_metadata['normalized_metadata'].get('content_price')
)
```

**Jira:**
[ENT-10180
](https://2u-internal.atlassian.net/browse/ENT-10180)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
