### PR TITLE
fix: update integration warning logic to check active LMS integrations

### DIFF
--- a/enterprise_access/apps/api/v1/tests/test_bff_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_bff_views.py
@@ -149,7 +149,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                     'enterprise_customer': {
                         **self.mock_enterprise_customer_2,
                         'disable_search': False,
-                        'show_integration_warning': True,
+                        'show_integration_warning': False,
                     },
                 },
             ],
@@ -421,7 +421,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             **self.expected_enterprise_customer,
             'identity_provider': mock_identity_provider,
             'identity_providers': mock_identity_providers,
-            'show_integration_warning': bool(identity_provider)
+            'active_integrations': self.mock_enterprise_customer['active_integrations'],
         }
         staff_enterprise_customer = None
         active_enterprise_customer = mock_enterprise_customer_with_auto_apply

--- a/enterprise_access/apps/bffs/handlers.py
+++ b/enterprise_access/apps/bffs/handlers.py
@@ -206,11 +206,12 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
         """
         # Learner Portal is enabled, so transform the enterprise customer data.
         identity_provider = enterprise_customer.get("identity_provider")
+        active_integrations = enterprise_customer.get("active_integrations")
         disable_search = bool(
             not enterprise_customer.get("enable_integrated_customer_learner_portal_search", False) and
             identity_provider
         )
-        show_integration_warning = bool(not disable_search and identity_provider)
+        show_integration_warning = bool(not disable_search and active_integrations)
 
         return {
             **enterprise_customer,

--- a/enterprise_access/apps/bffs/tests/test_handlers.py
+++ b/enterprise_access/apps/bffs/tests/test_handlers.py
@@ -61,7 +61,7 @@ class TestBaseLearnerPortalHandler(TestHandlerContextMixin):
         self.expected_enterprise_customer_2 = {
             **self.mock_enterprise_customer_2,
             'disable_search': False,
-            'show_integration_warning': True,
+            'show_integration_warning': False,
         }
         self.mock_subscription_licenses_data = {
             'customer_agreement': None,

--- a/enterprise_access/apps/bffs/tests/utils.py
+++ b/enterprise_access/apps/bffs/tests/utils.py
@@ -96,7 +96,13 @@ class TestHandlerContextMixin(TestCase):
                 'email': 'admin@example.com',
                 'lms_user_id': 12,
             }],
-            'active_integrations': [],
+            'active_integrations': [{
+                'channel_code': self.faker.lexify(text='????').upper(),
+                'created': f"{self.faker.date_time_this_year().isoformat()}Z",
+                'modified': f"{self.faker.date_time_this_month().isoformat()}Z",
+                'display_name': f'{self.faker.company()} Integration',
+                'active': self.faker.boolean(chance_of_getting_true=90)
+            }],
             'enterprise_customer_catalogs': [],
             'identity_provider': 'mock_idp',
             'identity_providers': [{
@@ -128,6 +134,7 @@ class TestHandlerContextMixin(TestCase):
             'uuid': self.mock_enterprise_customer_uuid_2,
             'slug': self.mock_enterprise_customer_slug_2,
             'name': 'Mock Enterprise Customer 2',
+            'active_integrations': [],
         }
         self.mock_enterprise_learner_response_data = {
             'results': [


### PR DESCRIPTION
**Description:**
Adjust the display logic for the Integration Warning modal in the Learner Portal. Previously, the modal displayed when search was enabled and an identity provider was configured. This resulted in confusion for customers who did not have an LMS integration but saw the modal due to having SSO enabled.

Changes:
- Update the condition to display the Integration Warning modal only if the enterprise customer has an active LMS integration.
- Use the active_integrations field from the BFF or direct LMS API call as the new condition.
- Ensure customers without LMS integrations do not see the modal, regardless of SSO setup.

**Jira:**
[ENT-10068 - IntegrationWarning showing for a customer with search enabled and no identity provider.](https://2u-internal.atlassian.net/browse/ENT-10068)
