### PR TITLE
feat: integrate algolia api keys into the bff base response

### DIFF
--- a/enterprise_access/apps/api/v1/tests/test_bff_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_bff_views.py
@@ -160,6 +160,8 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                     },
                 },
             ],
+            'secured_algolia_api_key': self.mock_secured_algolia_api_key,
+            'catalog_uuids_to_catalog_query_uuids': self.mock_catalog_uuids_to_catalog_query_uuids,
             'active_enterprise_customer': self.expected_enterprise_customer,
             'staff_enterprise_customer': None,
             'should_update_active_enterprise_customer_user': self.mock_should_update_active_enterprise_customer_user,
@@ -232,6 +234,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
     def test_dashboard_empty_state_with_permissions(
         self,
         mock_get_enterprise_customers_for_user,
+        mock_get_secured_algolia_api_key_for_user,
         mock_get_subscription_licenses_for_learner,
         mock_get_default_enrollment_intentions_learner_status,
         mock_get_enterprise_course_enrollments,
@@ -256,6 +259,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             'context': role_context,
         }])
         mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
+        mock_get_secured_algolia_api_key_for_user.return_value = self.mock_secured_algolia_api_key_response
         mock_get_subscription_licenses_for_learner.return_value = self.mock_subscription_licenses_data
         mock_get_default_enrollment_intentions_learner_status.return_value =\
             self.mock_default_enterprise_enrollment_intentions_learner_status_data
@@ -284,6 +288,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
     def test_dashboard_with_subscriptions(
         self,
         mock_get_enterprise_customers_for_user,
+        mock_get_secured_algolia_api_key_for_user,
         mock_get_default_enrollment_intentions_learner_status,
         mock_get_subscription_licenses_for_learner,
         mock_get_enterprise_course_enrollments,
@@ -296,6 +301,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             'context': self.mock_enterprise_customer_uuid,
         }])
         mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
+        mock_get_secured_algolia_api_key_for_user.return_value = self.mock_secured_algolia_api_key_response
         mock_subscription_licenses_data = {
             'customer_agreement': self.mock_customer_agreement,
             'results': [self.mock_subscription_license],
@@ -337,6 +343,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
     def test_dashboard_with_subscriptions_license_activation(
         self,
         mock_get_enterprise_customers_for_user,
+        mock_get_secured_algolia_api_key_for_user,
         mock_get_default_enrollment_intentions_learner_status,
         mock_get_subscription_licenses_for_learner,
         mock_get_enterprise_course_enrollments,
@@ -351,6 +358,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             'context': self.mock_enterprise_customer_uuid,
         }])
         mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
+        mock_get_secured_algolia_api_key_for_user.return_value = self.mock_secured_algolia_api_key_response
         mock_assigned_subscription_license = {
             **self.mock_subscription_license,
             'status': 'assigned',
@@ -408,6 +416,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
         mock_get_default_enrollment_intentions_learner_status,
         mock_get_subscription_licenses_for_learner,
         mock_get_enterprise_customers_for_user,
+        mock_get_secured_algolia_api_key_for_user,
         mock_get_enterprise_course_enrollments,
         mock_get_enterprise_customer_data,
         mock_auto_apply_license,
@@ -462,6 +471,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             'results': mock_linked_enterprise_customer_users,
         }
         mock_get_enterprise_customers_for_user.return_value = mock_enterprise_learner_response_data
+        mock_get_secured_algolia_api_key_for_user.return_value = self.mock_secured_algolia_api_key_response
         mock_auto_applied_subscription_license = {
             **self.mock_subscription_license,
             'status': 'activated',
@@ -644,6 +654,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
     def test_dashboard_with_subscriptions_license_auto_apply(
         self,
         mock_get_enterprise_customers_for_user,
+        mock_get_secured_algolia_api_key_for_user,
         mock_get_default_enrollment_intentions_learner_status,
         mock_get_subscription_licenses_for_learner,
         mock_get_enterprise_course_enrollments,
@@ -673,6 +684,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             mock_get_default_enrollment_intentions_learner_status=mock_get_default_enrollment_intentions_learner_status,
             mock_get_subscription_licenses_for_learner=mock_get_subscription_licenses_for_learner,
             mock_get_enterprise_customers_for_user=mock_get_enterprise_customers_for_user,
+            mock_get_secured_algolia_api_key_for_user=mock_get_secured_algolia_api_key_for_user,
             mock_get_enterprise_course_enrollments=mock_get_enterprise_course_enrollments,
             mock_get_enterprise_customer_data=mock_get_enterprise_customer_data,
             mock_auto_apply_license=mock_auto_apply_license,
@@ -758,6 +770,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
     def test_dashboard_with_enrollments(
         self,
         mock_get_enterprise_customers_for_user,
+        mock_get_secured_algolia_api_key_for_user,
         mock_get_subscription_licenses_for_learner,
         mock_get_default_enrollment_intentions_learner_status,
         mock_get_enterprise_course_enrollments,
@@ -770,6 +783,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             'context': self.mock_enterprise_customer_uuid,
         }])
         mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
+        mock_get_secured_algolia_api_key_for_user.return_value = self.mock_secured_algolia_api_key_response
         mock_get_subscription_licenses_for_learner.return_value = self.mock_subscription_licenses_data
         mock_get_default_enrollment_intentions_learner_status.return_value =\
             self.mock_default_enterprise_enrollment_intentions_learner_status_data
@@ -827,6 +841,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
     def test_dashboard_with_default_enrollment_realizations(
         self,
         mock_get_enterprise_customers_for_user,
+        mock_get_secured_algolia_api_key_for_user,
         mock_get_default_enrollment_intentions_learner_status,
         mock_get_subscription_licenses_for_learner,
         mock_get_enterprise_course_enrollments,
@@ -840,6 +855,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             'context': self.mock_enterprise_customer_uuid,
         }])
         mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
+        mock_get_secured_algolia_api_key_for_user.return_value = self.mock_secured_algolia_api_key_response
 
         mock_activated_subscription_license = {
             **self.mock_subscription_license,
@@ -898,6 +914,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
     def test_search_base_response(
         self,
         mock_get_enterprise_customers_for_user,
+        mock_get_secured_algolia_api_key_for_user,
         mock_get_default_enrollment_intentions_learner_status,
         mock_get_subscription_licenses_for_learner,
     ):
@@ -909,6 +926,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             'context': self.mock_enterprise_customer_uuid,
         }])
         mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
+        mock_get_secured_algolia_api_key_for_user.return_value = self.mock_secured_algolia_api_key_response
         mock_get_subscription_licenses_for_learner.return_value = self.mock_subscription_licenses_data
         mock_get_default_enrollment_intentions_learner_status.return_value =\
             self.mock_default_enterprise_enrollment_intentions_learner_status_data
@@ -929,6 +947,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
     def test_academy_base_response(
         self,
         mock_get_enterprise_customers_for_user,
+        mock_get_secured_algolia_api_key_for_user,
         mock_get_default_enrollment_intentions_learner_status,
         mock_get_subscription_licenses_for_learner,
     ):
@@ -940,6 +959,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             'context': self.mock_enterprise_customer_uuid,
         }])
         mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
+        mock_get_secured_algolia_api_key_for_user.return_value = self.mock_secured_algolia_api_key_response
         mock_get_subscription_licenses_for_learner.return_value = self.mock_subscription_licenses_data
         mock_get_default_enrollment_intentions_learner_status.return_value =\
             self.mock_default_enterprise_enrollment_intentions_learner_status_data
@@ -960,6 +980,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
     def test_skills_quiz_base_response(
         self,
         mock_get_enterprise_customers_for_user,
+        mock_get_secured_algolia_api_key_for_user,
         mock_get_default_enrollment_intentions_learner_status,
         mock_get_subscription_licenses_for_learner,
     ):
@@ -971,6 +992,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
             'context': self.mock_enterprise_customer_uuid,
         }])
         mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
+        mock_get_secured_algolia_api_key_for_user.return_value = self.mock_secured_algolia_api_key_response
         mock_get_subscription_licenses_for_learner.return_value = self.mock_subscription_licenses_data
         mock_get_default_enrollment_intentions_learner_status.return_value =\
             self.mock_default_enterprise_enrollment_intentions_learner_status_data

--- a/enterprise_access/apps/bffs/response_builder.py
+++ b/enterprise_access/apps/bffs/response_builder.py
@@ -61,6 +61,8 @@ class BaseResponseBuilder:
             self.context.should_update_active_enterprise_customer_user
         )
         self.response_data['enterprise_features'] = self.context.enterprise_features
+        self.response_data['secured_algolia_api_key'] = self.context.secured_algolia_api_key
+        self.response_data['catalog_uuids_to_catalog_query_uuids'] = self.context.catalog_uuids_to_catalog_query_uuids
 
     def add_errors_warnings_to_response(self):
         """

--- a/enterprise_access/apps/bffs/serializers.py
+++ b/enterprise_access/apps/bffs/serializers.py
@@ -171,6 +171,11 @@ class BaseResponseSerializer(BaseBffSerializer):
     active_enterprise_customer = EnterpriseCustomerSerializer(required=False, allow_null=True)
     staff_enterprise_customer = EnterpriseCustomerSerializer(required=False, allow_null=True)
     should_update_active_enterprise_customer_user = serializers.BooleanField()
+    secured_algolia_api_key = serializers.CharField(required=False, allow_null=True)
+    catalog_uuids_to_catalog_query_uuids = serializers.DictField(
+        child=serializers.UUIDField(),
+        help_text='Mapping of catalog UUIDs to catalog query UUIDs.',
+    )
     errors = ErrorSerializer(many=True, required=False, default=list)
     warnings = WarningSerializer(many=True, required=False, default=list)
     enterprise_features = serializers.DictField(required=False, default=dict)

--- a/enterprise_access/apps/bffs/tests/test_response_builders.py
+++ b/enterprise_access/apps/bffs/tests/test_response_builders.py
@@ -32,6 +32,8 @@ class TestBaseResponseBuilder(TestHandlerContextMixin):
             'all_linked_enterprise_customer_users': self.mock_all_linked_enterprise_customer_users,
             'staff_enterprise_customer': self.mock_staff_enterprise_customer,
             'active_enterprise_customer': self.mock_active_enterprise_customer,
+            'secured_algolia_api_key': self.mock_secured_algolia_api_key,
+            'catalog_uuids_to_catalog_query_uuids': self.mock_catalog_uuids_to_catalog_query_uuids,
             'should_update_active_enterprise_customer_user': self.mock_should_update_active_enterprise_customer_user,
         }
         mock_handler_context.return_value = self.get_mock_handler_context(
@@ -47,6 +49,8 @@ class TestBaseResponseBuilder(TestHandlerContextMixin):
             'all_linked_enterprise_customer_users': self.mock_all_linked_enterprise_customer_users,
             'staff_enterprise_customer': self.mock_staff_enterprise_customer,
             'active_enterprise_customer': self.mock_active_enterprise_customer,
+            'secured_algolia_api_key': self.mock_secured_algolia_api_key,
+            'catalog_uuids_to_catalog_query_uuids': self.mock_catalog_uuids_to_catalog_query_uuids,
             'should_update_active_enterprise_customer_user': self.mock_should_update_active_enterprise_customer_user,
             'errors': [],
             'warnings': [],
@@ -80,6 +84,8 @@ class TestBaseResponseBuilder(TestHandlerContextMixin):
             'all_linked_enterprise_customer_users': self.mock_all_linked_enterprise_customer_users,
             'staff_enterprise_customer': self.mock_staff_enterprise_customer,
             'active_enterprise_customer': self.mock_active_enterprise_customer,
+            'secured_algolia_api_key': self.mock_secured_algolia_api_key,
+            'catalog_uuids_to_catalog_query_uuids': self.mock_catalog_uuids_to_catalog_query_uuids,
             'should_update_active_enterprise_customer_user': self.mock_should_update_active_enterprise_customer_user,
         }
         mock_handler_context.return_value = self.get_mock_handler_context(
@@ -93,6 +99,8 @@ class TestBaseResponseBuilder(TestHandlerContextMixin):
             'all_linked_enterprise_customer_users': self.mock_all_linked_enterprise_customer_users,
             'staff_enterprise_customer': self.mock_staff_enterprise_customer,
             'active_enterprise_customer': self.mock_active_enterprise_customer,
+            'secured_algolia_api_key': self.mock_secured_algolia_api_key,
+            'catalog_uuids_to_catalog_query_uuids': self.mock_catalog_uuids_to_catalog_query_uuids,
             'should_update_active_enterprise_customer_user': self.mock_should_update_active_enterprise_customer_user,
             'errors': [],
             'warnings': [],
@@ -163,6 +171,8 @@ class TestBaseLearnerResponseBuilder(TestBaseResponseBuilder, MockLicenseManager
             'all_linked_enterprise_customer_users': self.mock_all_linked_enterprise_customer_users,
             'staff_enterprise_customer': self.mock_staff_enterprise_customer,
             'active_enterprise_customer': self.mock_active_enterprise_customer,
+            'secured_algolia_api_key': self.mock_secured_algolia_api_key,
+            'catalog_uuids_to_catalog_query_uuids': self.mock_catalog_uuids_to_catalog_query_uuids,
             'should_update_active_enterprise_customer_user': self.mock_should_update_active_enterprise_customer_user,
         }
         mock_handler_context.return_value = self.get_mock_handler_context(
@@ -203,6 +213,8 @@ class TestBaseLearnerResponseBuilder(TestBaseResponseBuilder, MockLicenseManager
             'staff_enterprise_customer': self.mock_staff_enterprise_customer,
             'active_enterprise_customer': self.mock_active_enterprise_customer,
             'all_linked_enterprise_customer_users': self.mock_all_linked_enterprise_customer_users,
+            'secured_algolia_api_key': self.mock_secured_algolia_api_key,
+            'catalog_uuids_to_catalog_query_uuids': self.mock_catalog_uuids_to_catalog_query_uuids,
             'should_update_active_enterprise_customer_user': self.mock_should_update_active_enterprise_customer_user,
             'errors': [],
             'warnings': [],

--- a/enterprise_access/utils.py
+++ b/enterprise_access/utils.py
@@ -4,8 +4,10 @@ Utils for any app in the enterprise-access project.
 import logging
 import traceback
 from datetime import datetime, timedelta
+from typing import Optional
 
 from django.apps import apps
+from django.utils import dateparse, timezone
 from pytz import UTC
 
 from enterprise_access.apps.content_assignments.constants import AssignmentAutomaticExpiredReason
@@ -285,3 +287,24 @@ def get_course_run_metadata_for_assignment(assignment, content_metadata):
 
     # For course-based assignments, return metadata for the advertised course run
     return get_advertised_course_run_metadata(content_metadata)
+
+
+def determine_timeout_offset(
+        date_str: str,
+        epsilon_seconds: int = 10,
+) -> int:
+    """
+    Returns the number of seconds until the given datetime string,
+    minus an optional epsilon buffer.
+
+    Args:
+        date_str (str): The target datetime in ISO 8601 format.
+        epsilon_seconds (int): Number of seconds to subtract from the offset (default: 10).
+
+    Returns:
+        int: Number of seconds until the target time, minus epsilon. Returns 0 if already passed.
+    """
+    parsed_time: Optional[datetime] = dateparse.parse_datetime(date_str)
+    if not parsed_time:
+        raise ValueError(f"Invalid date string: {date_str}")
+    return max(0, int((parsed_time - timezone.now()).total_seconds() - epsilon_seconds))


### PR DESCRIPTION
**Description:**
Adds the algolia secured api key response from enterprise catalog to the root BFF response. This involves updating the serializer, context and response builder.

**Jira:**
[ENT-10085](https://2u-internal.atlassian.net/browse/ENT-10085)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
