### PR TITLE
feat: expose base BFF APIs for search, academy, and skills quiz routes

### DIFF
--- a/enterprise_access/apps/api/v1/tests/test_bff_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_bff_views.py
@@ -11,7 +11,13 @@ from rest_framework.reverse import reverse
 
 from enterprise_access.apps.api_client.tests.test_utils import MockLicenseManagerMetadataMixin
 from enterprise_access.apps.bffs.constants import COURSE_ENROLLMENT_STATUSES
-from enterprise_access.apps.bffs.tests.utils import TestHandlerContextMixin, mock_dashboard_dependencies
+from enterprise_access.apps.bffs.tests.utils import (
+    TestHandlerContextMixin,
+    mock_academy_dependencies,
+    mock_dashboard_dependencies,
+    mock_search_dependencies,
+    mock_skills_quiz_dependencies,
+)
 from enterprise_access.apps.core.constants import (
     BFF_READ_PERMISSION,
     SYSTEM_ENTERPRISE_ADMIN_ROLE,
@@ -183,6 +189,15 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                 COURSE_ENROLLMENT_STATUSES.COMPLETED: [],
                 COURSE_ENROLLMENT_STATUSES.SAVED_FOR_LATER: [],
             },
+        }
+        self.mock_search_route_response_data = {
+            **self.mock_common_response_data,
+        }
+        self.mock_academy_route_response_data = {
+            **self.mock_common_response_data,
+        }
+        self.mock_skills_quiz_route_response_data = {
+            **self.mock_common_response_data,
         }
 
     @ddt.data(
@@ -388,19 +403,19 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
         self.assertEqual(response.json(), expected_response_data)
 
     def _set_up_mock_dashboard_with_subscriptions_license_auto_apply_data(
-            self,
-            mock_get_default_enrollment_intentions_learner_status,
-            mock_get_subscription_licenses_for_learner,
-            mock_get_enterprise_customers_for_user,
-            mock_get_enterprise_course_enrollments,
-            mock_get_enterprise_customer_data,
-            mock_auto_apply_license,
-            identity_provider,
-            is_staff_request_user,
-            has_plan_for_auto_apply,
-            has_existing_activated_license,
-            has_existing_revoked_license,
-            auto_apply_with_universal_link,
+        self,
+        mock_get_default_enrollment_intentions_learner_status,
+        mock_get_subscription_licenses_for_learner,
+        mock_get_enterprise_customers_for_user,
+        mock_get_enterprise_course_enrollments,
+        mock_get_enterprise_customer_data,
+        mock_auto_apply_license,
+        identity_provider,
+        is_staff_request_user,
+        has_plan_for_auto_apply,
+        has_existing_activated_license,
+        has_existing_revoked_license,
+        auto_apply_with_universal_link,
     ):
         """
         This function facilitate mocking of the dashboard_with_subscriptions_license_auto_apply
@@ -877,3 +892,96 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
              'license_uuid': mock_activated_subscription_license['uuid'], 'is_default_auto_enrollment': True},
         ]
         self.assertEqual(expected_payload, actual_payload_arg)
+
+    @mock_search_dependencies
+    def test_search_base_response(
+        self,
+        mock_get_enterprise_customers_for_user,
+        mock_get_default_enrollment_intentions_learner_status,
+        mock_get_subscription_licenses_for_learner,
+    ):
+        """
+        Test the search route.
+        """
+        self.set_jwt_cookie([{
+            'system_wide_role': SYSTEM_ENTERPRISE_LEARNER_ROLE,
+            'context': self.mock_enterprise_customer_uuid,
+        }])
+        mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
+        mock_get_subscription_licenses_for_learner.return_value = self.mock_subscription_licenses_data
+        mock_get_default_enrollment_intentions_learner_status.return_value =\
+            self.mock_default_enterprise_enrollment_intentions_learner_status_data
+
+        query_params = {
+            'enterprise_customer_slug': self.mock_enterprise_customer_slug,
+        }
+        url = reverse('api:v1:learner-portal-bff-search')
+        url += f"?{urlencode(query_params)}"
+
+        response = self.client.post(url)
+        expected_status_code = status.HTTP_200_OK
+
+        self.assertEqual(response.status_code, expected_status_code)
+        self.assertEqual(response.json(), self.mock_search_route_response_data)
+
+    @mock_academy_dependencies
+    def test_academy_base_response(
+        self,
+        mock_get_enterprise_customers_for_user,
+        mock_get_default_enrollment_intentions_learner_status,
+        mock_get_subscription_licenses_for_learner,
+    ):
+        """
+        Test the academy route.
+        """
+        self.set_jwt_cookie([{
+            'system_wide_role': SYSTEM_ENTERPRISE_LEARNER_ROLE,
+            'context': self.mock_enterprise_customer_uuid,
+        }])
+        mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
+        mock_get_subscription_licenses_for_learner.return_value = self.mock_subscription_licenses_data
+        mock_get_default_enrollment_intentions_learner_status.return_value =\
+            self.mock_default_enterprise_enrollment_intentions_learner_status_data
+
+        query_params = {
+            'enterprise_customer_slug': self.mock_enterprise_customer_slug,
+        }
+        url = reverse('api:v1:learner-portal-bff-academy')
+        url += f"?{urlencode(query_params)}"
+
+        response = self.client.post(url)
+        expected_status_code = status.HTTP_200_OK
+
+        self.assertEqual(response.status_code, expected_status_code)
+        self.assertEqual(response.json(), self.mock_academy_route_response_data)
+
+    @mock_skills_quiz_dependencies
+    def test_skills_quiz_base_response(
+        self,
+        mock_get_enterprise_customers_for_user,
+        mock_get_default_enrollment_intentions_learner_status,
+        mock_get_subscription_licenses_for_learner,
+    ):
+        """
+        Test the skills quiz route.
+        """
+        self.set_jwt_cookie([{
+            'system_wide_role': SYSTEM_ENTERPRISE_LEARNER_ROLE,
+            'context': self.mock_enterprise_customer_uuid,
+        }])
+        mock_get_enterprise_customers_for_user.return_value = self.mock_enterprise_learner_response_data
+        mock_get_subscription_licenses_for_learner.return_value = self.mock_subscription_licenses_data
+        mock_get_default_enrollment_intentions_learner_status.return_value =\
+            self.mock_default_enterprise_enrollment_intentions_learner_status_data
+
+        query_params = {
+            'enterprise_customer_slug': self.mock_enterprise_customer_slug,
+        }
+        url = reverse('api:v1:learner-portal-bff-skills-quiz')
+        url += f"?{urlencode(query_params)}"
+
+        response = self.client.post(url)
+        expected_status_code = status.HTTP_200_OK
+
+        self.assertEqual(response.status_code, expected_status_code)
+        self.assertEqual(response.json(), self.mock_skills_quiz_route_response_data)

--- a/enterprise_access/apps/api/v1/tests/test_bff_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_bff_views.py
@@ -8,6 +8,7 @@ import ddt
 from django.core.cache import cache as django_cache
 from rest_framework import status
 from rest_framework.reverse import reverse
+from pytest_dictsdiff import check_objects
 
 from enterprise_access.apps.api_client.tests.test_utils import MockLicenseManagerMetadataMixin
 from enterprise_access.apps.bffs.constants import COURSE_ENROLLMENT_STATUSES
@@ -277,7 +278,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                 'detail': f'Missing: {BFF_READ_PERMISSION}',
             }
         self.assertEqual(response.status_code, expected_status_code)
-        self.assertEqual(response.json(), expected_response_data)
+        assert check_objects(response.json(), expected_response_data)
 
     @mock_dashboard_dependencies
     def test_dashboard_with_subscriptions(
@@ -329,7 +330,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                 },
             },
         })
-        self.assertEqual(response.json(), expected_response_data)
+        assert check_objects(response.json(), expected_response_data)
 
     @mock_dashboard_dependencies
     @mock.patch('enterprise_access.apps.api_client.license_manager_client.LicenseManagerUserApiClient.activate_license')
@@ -400,7 +401,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                 },
             },
         })
-        self.assertEqual(response.json(), expected_response_data)
+        assert check_objects(response.json(), expected_response_data)
 
     def _set_up_mock_dashboard_with_subscriptions_license_auto_apply_data(
         self,
@@ -751,7 +752,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                 },
             },
         })
-        self.assertEqual(response.json(), expected_response_data)
+        assert check_objects(response.json(), expected_response_data)
 
     @mock_dashboard_dependencies
     def test_dashboard_with_enrollments(
@@ -819,7 +820,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
                 COURSE_ENROLLMENT_STATUSES.SAVED_FOR_LATER: [],
             },
         })
-        self.assertEqual(response.json(), expected_response_data)
+        assert check_objects(response.json(), expected_response_data)
 
     @mock_dashboard_dependencies
     @mock.patch('enterprise_access.apps.api_client.lms_client.LmsApiClient.bulk_enroll_enterprise_learners')
@@ -922,7 +923,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
         expected_status_code = status.HTTP_200_OK
 
         self.assertEqual(response.status_code, expected_status_code)
-        self.assertEqual(response.json(), self.mock_search_route_response_data)
+        assert check_objects(response.json(), self.mock_search_route_response_data)
 
     @mock_academy_dependencies
     def test_academy_base_response(
@@ -953,7 +954,7 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
         expected_status_code = status.HTTP_200_OK
 
         self.assertEqual(response.status_code, expected_status_code)
-        self.assertEqual(response.json(), self.mock_academy_route_response_data)
+        assert check_objects(response.json(), self.mock_academy_route_response_data)
 
     @mock_skills_quiz_dependencies
     def test_skills_quiz_base_response(
@@ -984,4 +985,4 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
         expected_status_code = status.HTTP_200_OK
 
         self.assertEqual(response.status_code, expected_status_code)
-        self.assertEqual(response.json(), self.mock_skills_quiz_route_response_data)
+        assert check_objects(response.json(), self.mock_skills_quiz_route_response_data)

--- a/enterprise_access/apps/api/v1/tests/test_bff_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_bff_views.py
@@ -6,9 +6,9 @@ from urllib.parse import urlencode
 
 import ddt
 from django.core.cache import cache as django_cache
+from pytest_dictsdiff import check_objects
 from rest_framework import status
 from rest_framework.reverse import reverse
-from pytest_dictsdiff import check_objects
 
 from enterprise_access.apps.api_client.tests.test_utils import MockLicenseManagerMetadataMixin
 from enterprise_access.apps.bffs.constants import COURSE_ENROLLMENT_STATUSES

--- a/enterprise_access/apps/api/v1/tests/test_bff_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_bff_views.py
@@ -16,7 +16,7 @@ from enterprise_access.apps.bffs.tests.utils import (
     mock_academy_dependencies,
     mock_dashboard_dependencies,
     mock_search_dependencies,
-    mock_skills_quiz_dependencies,
+    mock_skills_quiz_dependencies
 )
 from enterprise_access.apps.core.constants import (
     BFF_READ_PERMISSION,

--- a/enterprise_access/apps/api/v1/views/bffs/common.py
+++ b/enterprise_access/apps/api/v1/views/bffs/common.py
@@ -93,7 +93,9 @@ class BaseBFFViewSet(ViewSet):
 
         # Build the response data and status code
         response_builder = response_builder_class(context)
-        response_data, status_code = response_builder.build()
+
+        response_builder.build()
+        response_data, status_code = response_builder.serialize()
 
         ordered_representation = OrderedDict(response_data)
 

--- a/enterprise_access/apps/api/v1/views/bffs/learner_portal.py
+++ b/enterprise_access/apps/api/v1/views/bffs/learner_portal.py
@@ -10,17 +10,12 @@ from rest_framework.response import Response
 
 from enterprise_access.apps.api.utils import get_or_fetch_enterprise_uuid_for_bff_request
 from enterprise_access.apps.api.v1.views.bffs.common import COMMON_BFF_QUERY_PARAMETERS, BaseBFFViewSet
-from enterprise_access.apps.bffs.handlers import (
-    DashboardHandler,
-    SearchHandler,
-    AcademyHandler,
-    SkillsQuizHandler,
-)
+from enterprise_access.apps.bffs.handlers import AcademyHandler, DashboardHandler, SearchHandler, SkillsQuizHandler
 from enterprise_access.apps.bffs.response_builder import (
     LearnerAcademyResponseBuilder,
     LearnerDashboardResponseBuilder,
     LearnerSearchResponseBuilder,
-    LearnerSkillsQuizResponseBuilder,
+    LearnerSkillsQuizResponseBuilder
 )
 from enterprise_access.apps.bffs.serializers import (
     LearnerAcademyRequestSerializer,
@@ -30,7 +25,7 @@ from enterprise_access.apps.bffs.serializers import (
     LearnerSearchRequestSerializer,
     LearnerSearchResponseSerializer,
     LearnerSkillsQuizRequestSerializer,
-    LearnerSkillsQuizResponseSerializer,
+    LearnerSkillsQuizResponseSerializer
 )
 from enterprise_access.apps.core.constants import BFF_READ_PERMISSION
 
@@ -129,7 +124,7 @@ class LearnerPortalBFFViewSet(BaseBFFViewSet):
             response_builder_class=LearnerAcademyResponseBuilder,
         )
         return Response(response_data, status=status_code)
-    
+
     @extend_schema(
         tags=['Learner Portal BFF'],
         summary='Skills Quiz route',

--- a/enterprise_access/apps/api/v1/views/bffs/learner_portal.py
+++ b/enterprise_access/apps/api/v1/views/bffs/learner_portal.py
@@ -10,11 +10,27 @@ from rest_framework.response import Response
 
 from enterprise_access.apps.api.utils import get_or_fetch_enterprise_uuid_for_bff_request
 from enterprise_access.apps.api.v1.views.bffs.common import COMMON_BFF_QUERY_PARAMETERS, BaseBFFViewSet
-from enterprise_access.apps.bffs.handlers import DashboardHandler
-from enterprise_access.apps.bffs.response_builder import LearnerDashboardResponseBuilder
+from enterprise_access.apps.bffs.handlers import (
+    DashboardHandler,
+    SearchHandler,
+    AcademyHandler,
+    SkillsQuizHandler,
+)
+from enterprise_access.apps.bffs.response_builder import (
+    LearnerAcademyResponseBuilder,
+    LearnerDashboardResponseBuilder,
+    LearnerSearchResponseBuilder,
+    LearnerSkillsQuizResponseBuilder,
+)
 from enterprise_access.apps.bffs.serializers import (
+    LearnerAcademyRequestSerializer,
+    LearnerAcademyResponseSerializer,
     LearnerDashboardRequestSerializer,
-    LearnerDashboardResponseSerializer
+    LearnerDashboardResponseSerializer,
+    LearnerSearchRequestSerializer,
+    LearnerSearchResponseSerializer,
+    LearnerSkillsQuizRequestSerializer,
+    LearnerSkillsQuizResponseSerializer,
 )
 from enterprise_access.apps.core.constants import BFF_READ_PERMISSION
 
@@ -51,5 +67,95 @@ class LearnerPortalBFFViewSet(BaseBFFViewSet):
             request=request,
             handler_class=DashboardHandler,
             response_builder_class=LearnerDashboardResponseBuilder,
+        )
+        return Response(response_data, status=status_code)
+
+    @extend_schema(
+        tags=['Learner Portal BFF'],
+        summary='Search route',
+        request=LearnerSearchRequestSerializer,
+        parameters=COMMON_BFF_QUERY_PARAMETERS,
+        responses={
+            status.HTTP_200_OK: OpenApiResponse(
+                response=LearnerSearchResponseSerializer,
+                description='Sample response for the learner search route.',
+            ),
+        },
+        description='Retrieves, transforms, and processes data for the learner search route.',
+    )
+    @action(detail=False, methods=['post'])
+    @permission_required(BFF_READ_PERMISSION, fn=get_or_fetch_enterprise_uuid_for_bff_request)
+    def search(self, request, *args, **kwargs):
+        """
+        Retrieves, transforms, and processes data for the learner search route.
+        Args:
+            request (Request): The request object.
+        Returns:
+            Response: The response data formatted by the response builder.
+        """
+        response_data, status_code = self.load_route_data_and_build_response(
+            request=request,
+            handler_class=SearchHandler,
+            response_builder_class=LearnerSearchResponseBuilder,
+        )
+        return Response(response_data, status=status_code)
+
+    @extend_schema(
+        tags=['Learner Portal BFF'],
+        summary='Academy route',
+        request=LearnerAcademyRequestSerializer,
+        parameters=COMMON_BFF_QUERY_PARAMETERS,
+        responses={
+            status.HTTP_200_OK: OpenApiResponse(
+                response=LearnerAcademyResponseSerializer,
+                description='Sample response for the learner academy route.',
+            ),
+        },
+        description='Retrieves, transforms, and processes data for the learner academy route.',
+    )
+    @action(detail=False, methods=['post'])
+    @permission_required(BFF_READ_PERMISSION, fn=get_or_fetch_enterprise_uuid_for_bff_request)
+    def academy(self, request, *args, **kwargs):
+        """
+        Retrieves, transforms, and processes data for the learner academy detail route.
+        Args:
+            request (Request): The request object.
+        Returns:
+            Response: The response data formatted by the response builder.
+        """
+        response_data, status_code = self.load_route_data_and_build_response(
+            request=request,
+            handler_class=AcademyHandler,
+            response_builder_class=LearnerAcademyResponseBuilder,
+        )
+        return Response(response_data, status=status_code)
+    
+    @extend_schema(
+        tags=['Learner Portal BFF'],
+        summary='Skills Quiz route',
+        request=LearnerSkillsQuizRequestSerializer,
+        parameters=COMMON_BFF_QUERY_PARAMETERS,
+        responses={
+            status.HTTP_200_OK: OpenApiResponse(
+                response=LearnerSkillsQuizResponseSerializer,
+                description='Sample response for the learner skills quiz route.',
+            ),
+        },
+        description='Retrieves, transforms, and processes data for the learner skills quiz route.',
+    )
+    @action(detail=False, methods=['post'], url_path='skills-quiz')
+    @permission_required(BFF_READ_PERMISSION, fn=get_or_fetch_enterprise_uuid_for_bff_request)
+    def skills_quiz(self, request, *args, **kwargs):
+        """
+        Retrieves, transforms, and processes data for the learner skills quiz route.
+        Args:
+            request (Request): The request object.
+        Returns:
+            Response: The response data formatted by the response builder.
+        """
+        response_data, status_code = self.load_route_data_and_build_response(
+            request=request,
+            handler_class=SkillsQuizHandler,
+            response_builder_class=LearnerSkillsQuizResponseBuilder,
         )
         return Response(response_data, status=status_code)

--- a/enterprise_access/apps/bffs/handlers.py
+++ b/enterprise_access/apps/bffs/handlers.py
@@ -718,3 +718,30 @@ class DashboardHandler(LearnerDashboardDataMixin, BaseLearnerPortalHandler):
                 user_message="Could not load and/or processing the learner dashboard.",
                 developer_message=f"Failed to load and/or processing the learner dashboard data: {e}",
             )
+
+
+class SearchHandler(BaseLearnerPortalHandler):
+    """
+    A handler class for processing the learner search route.
+
+    Extends `BaseLearnerPortalHandler` to handle the loading and processing
+    of data specific to the learner search.
+    """
+
+
+class AcademyHandler(BaseLearnerPortalHandler):
+    """
+    A handler class for processing the learner academy detail route.
+
+    Extends `BaseLearnerPortalHandler` to handle the loading and processing
+    of data specific to the learner academy detail route.
+    """
+
+
+class SkillsQuizHandler(BaseLearnerPortalHandler):
+    """
+    A handler class for processing the learner skills quiz route.
+
+    Extends `BaseLearnerPortalHandler` to handle the loading and processing
+    of data specific to the learner skills quiz route.
+    """

--- a/enterprise_access/apps/bffs/response_builder.py
+++ b/enterprise_access/apps/bffs/response_builder.py
@@ -84,7 +84,7 @@ class BaseResponseBuilder:
         try:
             serializer = self.serializer_class(data=self.response_data)
             serializer.is_valid(raise_exception=True)
-            return serializer.validated_data, self.status_code
+            return serializer.data, self.status_code
         except Exception as exc:  # pylint: disable=broad-except
             logger.exception('Could not serialize the response data.')
             self.context.add_warning(

--- a/enterprise_access/apps/bffs/response_builder.py
+++ b/enterprise_access/apps/bffs/response_builder.py
@@ -3,16 +3,16 @@ Response Builder Module for bffs app
 """
 
 import logging
-
 from typing import Type
+
 from rest_framework.serializers import Serializer
 
 from enterprise_access.apps.bffs.mixins import BaseLearnerDataMixin, LearnerDashboardDataMixin
 from enterprise_access.apps.bffs.serializers import (
+    LearnerAcademyResponseSerializer,
     LearnerDashboardResponseSerializer,
     LearnerSearchResponseSerializer,
-    LearnerAcademyResponseSerializer,
-    LearnerSkillsQuizResponseSerializer,
+    LearnerSkillsQuizResponseSerializer
 )
 
 logger = logging.getLogger(__name__)
@@ -164,8 +164,6 @@ class LearnerDashboardResponseBuilder(BaseLearnerResponseBuilder, LearnerDashboa
             'all_enrollments_by_status': self.all_enrollments_by_status,
         })
 
-        return self.serialize()
-
 
 class LearnerSearchResponseBuilder(BaseLearnerResponseBuilder):
     """
@@ -177,6 +175,7 @@ class LearnerSearchResponseBuilder(BaseLearnerResponseBuilder):
 
     serializer_class = LearnerSearchResponseSerializer
 
+
 class LearnerAcademyResponseBuilder(BaseLearnerResponseBuilder):
     """
     A response builder for the learner academy route.
@@ -186,6 +185,7 @@ class LearnerAcademyResponseBuilder(BaseLearnerResponseBuilder):
     """
 
     serializer_class = LearnerAcademyResponseSerializer
+
 
 class LearnerSkillsQuizResponseBuilder(BaseLearnerResponseBuilder):
     """

--- a/enterprise_access/apps/bffs/serializers.py
+++ b/enterprise_access/apps/bffs/serializers.py
@@ -249,7 +249,7 @@ class SubscriptionsSerializer(BaseBffSerializer):
     subscription_licenses_by_status = SubscriptionLicenseStatusSerializer(required=False)
     subscription_license = SubscriptionLicenseSerializer(required=False, allow_null=True)
     subscription_plan = SubscriptionPlanSerializer(required=False, allow_null=True)
-    show_expiration_notifications = serializers.BooleanField(required=False)
+    show_expiration_notifications = serializers.BooleanField(required=False, default=False)
 
 
 class EnterpriseCustomerUserSubsidiesSerializer(BaseBffSerializer):
@@ -331,6 +331,24 @@ class LearnerDashboardRequestSerializer(BFFRequestSerializer):
     """
 
 
+class LearnerSearchRequestSerializer(BFFRequestSerializer):
+    """
+    Serializer for the learner search request.
+    """
+
+
+class LearnerAcademyRequestSerializer(BFFRequestSerializer):
+    """
+    Serializer for the learner academy detail request.
+    """
+
+
+class LearnerSkillsQuizRequestSerializer(BFFRequestSerializer):
+    """
+    Serializer for the learner skills quiz request.
+    """
+
+
 class LearnerEnrollmentsByStatusSerializer(BaseBffSerializer):
     """
     Serializer for subscription license status.
@@ -349,3 +367,21 @@ class LearnerDashboardResponseSerializer(BaseLearnerPortalResponseSerializer):
 
     enterprise_course_enrollments = EnterpriseCourseEnrollmentSerializer(many=True)
     all_enrollments_by_status = LearnerEnrollmentsByStatusSerializer()
+
+
+class LearnerSearchResponseSerializer(BaseLearnerPortalResponseSerializer):
+    """
+    Serializer for the learner search response.
+    """
+
+
+class LearnerAcademyResponseSerializer(BaseLearnerPortalResponseSerializer):
+    """
+    Serializer for the learner academy detail response.
+    """
+
+
+class LearnerSkillsQuizResponseSerializer(BaseLearnerPortalResponseSerializer):
+    """
+    Serializer for the learner skills quiz response.
+    """

--- a/enterprise_access/apps/bffs/tests/test_response_builders.py
+++ b/enterprise_access/apps/bffs/tests/test_response_builders.py
@@ -2,14 +2,12 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 import ddt
-from rest_framework import status
 from pytest_dictsdiff import check_objects
+from rest_framework import status
 
 from enterprise_access.apps.api_client.tests.test_license_manager_client import MockLicenseManagerMetadataMixin
 from enterprise_access.apps.bffs.response_builder import BaseLearnerResponseBuilder, BaseResponseBuilder
-from enterprise_access.apps.bffs.serializers import (
-    BaseResponseSerializer,
-)
+from enterprise_access.apps.bffs.serializers import BaseResponseSerializer
 from enterprise_access.apps.bffs.tests.utils import TestHandlerContextMixin
 
 

--- a/enterprise_access/apps/bffs/tests/test_response_builders.py
+++ b/enterprise_access/apps/bffs/tests/test_response_builders.py
@@ -20,6 +20,7 @@ class MockResponseBuilder(BaseResponseBuilder):
 
     serializer_class = BaseResponseSerializer
 
+
 @ddt.ddt
 class TestBaseResponseBuilder(TestHandlerContextMixin):
     """

--- a/enterprise_access/apps/bffs/tests/test_response_builders.py
+++ b/enterprise_access/apps/bffs/tests/test_response_builders.py
@@ -3,15 +3,22 @@ from unittest.mock import MagicMock
 
 import ddt
 from rest_framework import status
+from pytest_dictsdiff import check_objects
 
 from enterprise_access.apps.api_client.tests.test_license_manager_client import MockLicenseManagerMetadataMixin
 from enterprise_access.apps.bffs.response_builder import BaseLearnerResponseBuilder, BaseResponseBuilder
 from enterprise_access.apps.bffs.serializers import (
-    EnterpriseCustomerUserSubsidiesSerializer,
-    SubscriptionLicenseStatusSerializer
+    BaseResponseSerializer,
 )
 from enterprise_access.apps.bffs.tests.utils import TestHandlerContextMixin
 
+
+class MockResponseBuilder(BaseResponseBuilder):
+    """
+    A mock response builder class that extends BaseResponseBuilder.
+    """
+
+    serializer_class = BaseResponseSerializer
 
 @ddt.ddt
 class TestBaseResponseBuilder(TestHandlerContextMixin):
@@ -32,8 +39,9 @@ class TestBaseResponseBuilder(TestHandlerContextMixin):
             data=mock_context_data,
         )
         mock_handler_context_instance = mock_handler_context.return_value
-        base_response_builder = BaseResponseBuilder(mock_handler_context_instance)
-        response_data, status_code = base_response_builder.build()
+        base_response_builder = MockResponseBuilder(mock_handler_context_instance)
+        base_response_builder.build()
+        response_data, status_code = base_response_builder.serialize()
         expected_response_data = {
             'enterprise_customer': self.mock_enterprise_customer,
             'enterprise_features': {'feature_flag': True},
@@ -41,9 +49,11 @@ class TestBaseResponseBuilder(TestHandlerContextMixin):
             'staff_enterprise_customer': self.mock_staff_enterprise_customer,
             'active_enterprise_customer': self.mock_active_enterprise_customer,
             'should_update_active_enterprise_customer_user': self.mock_should_update_active_enterprise_customer_user,
+            'errors': [],
+            'warnings': [],
         }
-        self.assertEqual(response_data, expected_response_data)
         self.assertEqual(status_code, status.HTTP_200_OK)
+        assert check_objects(response_data, expected_response_data)
 
     @ddt.data(
         {
@@ -77,7 +87,7 @@ class TestBaseResponseBuilder(TestHandlerContextMixin):
             data=mock_context_data,
         )
         mock_handler_context_instance = mock_handler_context.return_value
-        base_response_builder = BaseResponseBuilder(mock_handler_context_instance)
+        base_response_builder = MockResponseBuilder(mock_handler_context_instance)
         expected_output = {
             'enterprise_customer': self.mock_enterprise_customer,
             'enterprise_features': {'feature_flag': True},
@@ -96,8 +106,10 @@ class TestBaseResponseBuilder(TestHandlerContextMixin):
             mock_handler_context_instance.warnings.append(self.mock_warning)
             expected_output['warnings'] = [self.mock_warning]
         base_response_builder.add_errors_warnings_to_response()
-        response_data, _ = base_response_builder.build()
-        self.assertEqual(response_data, expected_output)
+        base_response_builder.build()
+        response_data, _ = base_response_builder.serialize()
+
+        assert check_objects(response_data, expected_output)
 
     # TODO Revisit this function in ENT-9633 to determine if 200 is ok for a nested errored response
     @ddt.data(
@@ -118,7 +130,7 @@ class TestBaseResponseBuilder(TestHandlerContextMixin):
         else:
             mock_handler_context.return_value = self.mock_handler_context
         mock_handler_context_instance = mock_handler_context.return_value
-        base_response_builder = BaseResponseBuilder(mock_handler_context_instance)
+        base_response_builder = MockResponseBuilder(mock_handler_context_instance)
         expected_output = status_code if status_code else status.HTTP_200_OK
         response_status_code = base_response_builder.status_code
         self.assertEqual(response_status_code, expected_output)
@@ -126,6 +138,9 @@ class TestBaseResponseBuilder(TestHandlerContextMixin):
 
 @ddt.ddt
 class TestBaseLearnerResponseBuilder(TestBaseResponseBuilder, MockLicenseManagerMetadataMixin):
+    """
+    Test suite for BaseLearnerResponseBuilder.
+    """
     def setUp(self):
         super().setUp()
         self.mock_enterprise_catalog_uuid_1 = self.faker.uuid4()

--- a/enterprise_access/apps/bffs/tests/utils.py
+++ b/enterprise_access/apps/bffs/tests/utils.py
@@ -286,6 +286,7 @@ def mock_academy_dependencies(func):
         return func(self, *args, **kwargs)
     return wrapper
 
+
 def mock_skills_quiz_dependencies(func):
     """
     Mock the service dependencies for the academy route.

--- a/enterprise_access/apps/bffs/tests/utils.py
+++ b/enterprise_access/apps/bffs/tests/utils.py
@@ -7,10 +7,7 @@ from django.test import RequestFactory, TestCase
 from faker import Faker
 from rest_framework import status
 
-from enterprise_access.apps.api_client.tests.test_constants import DATE_FORMAT_ISO_8601, DATE_FORMAT_ISO_8601_MS
-from enterprise_access.apps.content_assignments.tests.test_utils import mock_course_run_1
 from enterprise_access.apps.core.tests.factories import UserFactory
-from enterprise_access.utils import _days_from_now
 
 
 class TestHandlerContextMixin(TestCase):
@@ -109,13 +106,14 @@ class TestHandlerContextMixin(TestCase):
             'enterprise_notification_banner': None,
             'reply_to': None,
             'sender_alias': None,
+            'disable_search': False,
+            'show_integration_warning': False,
         }
         self.mock_active_enterprise_customer = {
             **self.mock_enterprise_customer
         }
         self.mock_all_linked_enterprise_customer_users = [{
             'id': 1,
-            'user_id': 3,
             'enterprise_customer': self.mock_enterprise_customer,
             'active': self.mock_enterprise_customer.get('active'),
         }]

--- a/enterprise_access/apps/bffs/tests/utils.py
+++ b/enterprise_access/apps/bffs/tests/utils.py
@@ -265,3 +265,32 @@ def mock_dashboard_dependencies(func):
     def wrapper(self, *args, **kwargs):
         return func(self, *args, **kwargs)
     return wrapper
+
+
+def mock_search_dependencies(func):
+    """
+    Mock the service dependencies for the search route.
+    """
+    @mock_common_dependencies
+    def wrapper(self, *args, **kwargs):
+        return func(self, *args, **kwargs)
+    return wrapper
+
+
+def mock_academy_dependencies(func):
+    """
+    Mock the service dependencies for the academy route.
+    """
+    @mock_common_dependencies
+    def wrapper(self, *args, **kwargs):
+        return func(self, *args, **kwargs)
+    return wrapper
+
+def mock_skills_quiz_dependencies(func):
+    """
+    Mock the service dependencies for the academy route.
+    """
+    @mock_common_dependencies
+    def wrapper(self, *args, **kwargs):
+        return func(self, *args, **kwargs)
+    return wrapper

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -183,7 +183,7 @@ edx-drf-extensions==10.5.0
     # via
     #   -r requirements/base.in
     #   edx-rbac
-edx-enterprise-subsidy-client==2.0.0
+edx-enterprise-subsidy-client==2.0.1
     # via -r requirements/base.in
 edx-event-bus-kafka==6.0.0
     # via -r requirements/base.in
@@ -225,7 +225,7 @@ jsonschema==4.23.0
     # via drf-spectacular
 jsonschema-specifications==2024.10.1
     # via jsonschema
-kombu==5.5.0
+kombu==5.5.1
     # via celery
 markupsafe==3.0.2
     # via jinja2
@@ -280,7 +280,7 @@ python-slugify==8.0.4
     # via code-annotations
 python3-openid==3.2.0
     # via social-auth-core
-pytz==2025.1
+pytz==2025.2
     # via
     #   -r requirements/base.in
     #   drf-yasg
@@ -307,7 +307,7 @@ requests==2.32.3
     #   social-auth-core
 requests-oauthlib==2.0.0
     # via social-auth-core
-rpds-py==0.23.1
+rpds-py==0.24.0
     # via
     #   jsonschema
     #   referencing
@@ -340,7 +340,7 @@ stevedore==5.4.1
     #   edx-opaque-keys
 text-unidecode==1.3
     # via python-slugify
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   django-countries
     #   edx-opaque-keys

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -136,6 +136,10 @@ defusedxml==0.7.1
     #   -r requirements/validation.txt
     #   python3-openid
     #   social-auth-core
+dictdiffer==0.9.0
+    # via
+    #   -r requirements/validation.txt
+    #   pytest-dictsdiff
 diff-cover==9.2.4
     # via -r requirements/dev.in
 dill==0.3.9
@@ -274,7 +278,7 @@ edx-drf-extensions==10.5.0
     # via
     #   -r requirements/validation.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==2.0.0
+edx-enterprise-subsidy-client==2.0.1
     # via -r requirements/validation.txt
 edx-event-bus-kafka==6.0.0
     # via -r requirements/validation.txt
@@ -300,7 +304,7 @@ edx-toggles==5.3.0
     #   edx-event-bus-kafka
 factory-boy==3.3.3
     # via -r requirements/validation.txt
-faker==37.0.2
+faker==37.1.0
     # via
     #   -r requirements/validation.txt
     #   factory-boy
@@ -382,7 +386,7 @@ keyring==25.6.0
     # via
     #   -r requirements/validation.txt
     #   twine
-kombu==5.5.0
+kombu==5.5.1
     # via
     #   -r requirements/validation.txt
     #   celery
@@ -552,6 +556,8 @@ pytest==8.3.5
     #   pytest-django
 pytest-cov==6.0.0
     # via -r requirements/validation.txt
+pytest-dictsdiff==0.5.8
+    # via -r requirements/validation.txt
 pytest-django==4.10.0
     # via -r requirements/validation.txt
 python-dateutil==2.9.0.post0
@@ -568,7 +574,7 @@ python3-openid==3.2.0
     # via
     #   -r requirements/validation.txt
     #   social-auth-core
-pytz==2025.1
+pytz==2025.2
     # via
     #   -r requirements/validation.txt
     #   drf-yasg
@@ -620,7 +626,7 @@ rich==13.9.4
     # via
     #   -r requirements/validation.txt
     #   twine
-rpds-py==0.23.1
+rpds-py==0.24.0
     # via
     #   -r requirements/validation.txt
     #   jsonschema
@@ -685,7 +691,7 @@ tox==4.24.2
     # via -r requirements/validation.txt
 twine==6.1.0
     # via -r requirements/validation.txt
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -r requirements/validation.txt
     #   django-countries

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -140,6 +140,10 @@ defusedxml==0.7.1
     #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
+dictdiffer==0.9.0
+    # via
+    #   -r requirements/test.txt
+    #   pytest-dictsdiff
 dill==0.3.9
     # via
     #   -r requirements/test.txt
@@ -280,7 +284,7 @@ edx-drf-extensions==10.5.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==2.0.0
+edx-enterprise-subsidy-client==2.0.1
     # via -r requirements/test.txt
 edx-event-bus-kafka==6.0.0
     # via -r requirements/test.txt
@@ -304,7 +308,7 @@ edx-toggles==5.3.0
     #   edx-event-bus-kafka
 factory-boy==3.3.3
     # via -r requirements/test.txt
-faker==37.0.2
+faker==37.1.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -363,7 +367,7 @@ jsonschema-specifications==2024.10.1
     # via
     #   -r requirements/test.txt
     #   jsonschema
-kombu==5.5.0
+kombu==5.5.1
     # via
     #   -r requirements/test.txt
     #   celery
@@ -499,6 +503,8 @@ pytest==8.3.5
     #   pytest-django
 pytest-cov==6.0.0
     # via -r requirements/test.txt
+pytest-dictsdiff==0.5.8
+    # via -r requirements/test.txt
 pytest-django==4.10.0
     # via -r requirements/test.txt
 python-dateutil==2.9.0.post0
@@ -515,7 +521,7 @@ python3-openid==3.2.0
     # via
     #   -r requirements/test.txt
     #   social-auth-core
-pytz==2025.1
+pytz==2025.2
     # via
     #   -r requirements/test.txt
     #   drf-yasg
@@ -554,7 +560,7 @@ restructuredtext-lint==1.4.0
     # via doc8
 roman-numerals-py==3.1.0
     # via sphinx
-rpds-py==0.23.1
+rpds-py==0.24.0
     # via
     #   -r requirements/test.txt
     #   jsonschema
@@ -632,7 +638,7 @@ tomlkit==0.13.2
     #   pylint
 tox==4.24.2
     # via -r requirements/test.txt
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -r requirements/test.txt
     #   beautifulsoup4

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,7 +10,7 @@ wheel==0.45.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via
-    #   -c /home/runner/work/enterprise-access/enterprise-access/requirements/common_constraints.txt
+    #   -c /edx/app/enterprise-access/requirements/common_constraints.txt
     #   -r requirements/pip.in
-setuptools==77.0.3
+setuptools==78.1.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -216,7 +216,7 @@ edx-drf-extensions==10.5.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==2.0.0
+edx-enterprise-subsidy-client==2.0.1
     # via -r requirements/base.txt
 edx-event-bus-kafka==6.0.0
     # via -r requirements/base.txt
@@ -279,7 +279,7 @@ jsonschema-specifications==2024.10.1
     # via
     #   -r requirements/base.txt
     #   jsonschema
-kombu==5.5.0
+kombu==5.5.1
     # via
     #   -r requirements/base.txt
     #   celery
@@ -372,7 +372,7 @@ python3-openid==3.2.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-pytz==2025.1
+pytz==2025.2
     # via
     #   -r requirements/base.txt
     #   drf-yasg
@@ -405,7 +405,7 @@ requests-oauthlib==2.0.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-rpds-py==0.23.1
+rpds-py==0.24.0
     # via
     #   -r requirements/base.txt
     #   jsonschema
@@ -452,7 +452,7 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -r requirements/base.txt
     #   django-countries

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -131,6 +131,10 @@ defusedxml==0.7.1
     #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
+dictdiffer==0.9.0
+    # via
+    #   -r requirements/test.txt
+    #   pytest-dictsdiff
 dill==0.3.9
     # via
     #   -r requirements/test.txt
@@ -264,7 +268,7 @@ edx-drf-extensions==10.5.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==2.0.0
+edx-enterprise-subsidy-client==2.0.1
     # via -r requirements/test.txt
 edx-event-bus-kafka==6.0.0
     # via -r requirements/test.txt
@@ -290,7 +294,7 @@ edx-toggles==5.3.0
     #   edx-event-bus-kafka
 factory-boy==3.3.3
     # via -r requirements/test.txt
-faker==37.0.2
+faker==37.1.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -361,7 +365,7 @@ jsonschema-specifications==2024.10.1
     #   jsonschema
 keyring==25.6.0
     # via twine
-kombu==5.5.0
+kombu==5.5.1
     # via
     #   -r requirements/test.txt
     #   celery
@@ -503,6 +507,8 @@ pytest==8.3.5
     #   pytest-django
 pytest-cov==6.0.0
     # via -r requirements/test.txt
+pytest-dictsdiff==0.5.8
+    # via -r requirements/test.txt
 pytest-django==4.10.0
     # via -r requirements/test.txt
 python-dateutil==2.9.0.post0
@@ -519,7 +525,7 @@ python3-openid==3.2.0
     # via
     #   -r requirements/test.txt
     #   social-auth-core
-pytz==2025.1
+pytz==2025.2
     # via
     #   -r requirements/test.txt
     #   drf-yasg
@@ -562,7 +568,7 @@ rfc3986==2.0.0
     # via twine
 rich==13.9.4
     # via twine
-rpds-py==0.23.1
+rpds-py==0.24.0
     # via
     #   -r requirements/test.txt
     #   jsonschema
@@ -622,7 +628,7 @@ tox==4.24.2
     # via -r requirements/test.txt
 twine==6.1.0
     # via -r requirements/quality.in
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -r requirements/test.txt
     #   django-countries

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -12,4 +12,5 @@ factory-boy
 freezegun
 pytest-cov
 pytest-django
+pytest_dictsdiff
 tox

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -122,6 +122,8 @@ defusedxml==0.7.1
     #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
+dictdiffer==0.9.0
+    # via pytest-dictsdiff
 dill==0.3.9
     # via pylint
 distlib==0.3.9
@@ -248,7 +250,7 @@ edx-drf-extensions==10.5.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==2.0.0
+edx-enterprise-subsidy-client==2.0.1
     # via -r requirements/base.txt
 edx-event-bus-kafka==6.0.0
     # via -r requirements/base.txt
@@ -272,7 +274,7 @@ edx-toggles==5.3.0
     #   edx-event-bus-kafka
 factory-boy==3.3.3
     # via -r requirements/test.in
-faker==37.0.2
+faker==37.1.0
     # via factory-boy
 fastavro==1.10.0
     # via
@@ -321,7 +323,7 @@ jsonschema-specifications==2024.10.1
     # via
     #   -r requirements/base.txt
     #   jsonschema
-kombu==5.5.0
+kombu==5.5.1
     # via
     #   -r requirements/base.txt
     #   celery
@@ -432,6 +434,8 @@ pytest==8.3.5
     #   pytest-django
 pytest-cov==6.0.0
     # via -r requirements/test.in
+pytest-dictsdiff==0.5.8
+    # via -r requirements/test.in
 pytest-django==4.10.0
     # via -r requirements/test.in
 python-dateutil==2.9.0.post0
@@ -448,7 +452,7 @@ python3-openid==3.2.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-pytz==2025.1
+pytz==2025.2
     # via
     #   -r requirements/base.txt
     #   drf-yasg
@@ -480,7 +484,7 @@ requests-oauthlib==2.0.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-rpds-py==0.23.1
+rpds-py==0.24.0
     # via
     #   -r requirements/base.txt
     #   jsonschema
@@ -532,7 +536,7 @@ tomlkit==0.13.2
     # via pylint
 tox==4.24.2
     # via -r requirements/test.in
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -r requirements/base.txt
     #   django-countries

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -160,6 +160,11 @@ defusedxml==0.7.1
     #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
+dictdiffer==0.9.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   pytest-dictsdiff
 dill==0.3.9
     # via
     #   -r requirements/quality.txt
@@ -341,7 +346,7 @@ edx-drf-extensions==10.5.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-rbac
-edx-enterprise-subsidy-client==2.0.0
+edx-enterprise-subsidy-client==2.0.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -378,7 +383,7 @@ factory-boy==3.3.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-faker==37.0.2
+faker==37.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -475,7 +480,7 @@ keyring==25.6.0
     # via
     #   -r requirements/quality.txt
     #   twine
-kombu==5.5.0
+kombu==5.5.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -656,6 +661,10 @@ pytest-cov==6.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+pytest-dictsdiff==0.5.8
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 pytest-django==4.10.0
     # via
     #   -r requirements/quality.txt
@@ -677,7 +686,7 @@ python3-openid==3.2.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   social-auth-core
-pytz==2025.1
+pytz==2025.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -735,7 +744,7 @@ rich==13.9.4
     # via
     #   -r requirements/quality.txt
     #   twine
-rpds-py==0.23.1
+rpds-py==0.24.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -813,7 +822,7 @@ tox==4.24.2
     #   -r requirements/test.txt
 twine==6.1.0
     # via -r requirements/quality.txt
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
### Description

* Refactors `BaseResponseBuilder` and `load_route_data_and_build_response` a bit to abstract some generic/re-usable logic to be common across all BFF API endpoints for any given page route, making it easier and more straightforward to create a new BFF API endpoint.
  * tl;dr; Each response builder subclass (e.g., `LearnerDashboardResponseBuilder`) must define a `serializer_class` attr for that page route's specific serializer but the actual serialization of the data itself is handled within `BaseResponseBuilder`'s newly added `serialize` method.
* Exposes additional BFF API endpoints for the following page routes in Learner Portal. Each of these API endpoints only contain the common data exposed across all page routes within the Learner Portal BFF. Route-specific data may be incrementally migrated/extended later on.
  * Search
  * Skills Quiz
  * Academy
* Installs and begins using `pytest_dictsdiff` ([GitHub](https://github.com/lukaszb/pytest-dictsdiff)) in BFF tests to improve developer experience around parsing diffs in BFF response objects. See example pytest output for mismatching diffs in [this issue](https://github.com/pytest-dev/pytest/issues/1531#issuecomment-723590313).

<img width="1505" alt="image" src="https://github.com/user-attachments/assets/f3cec694-5f05-4cc3-b1b8-8dbb1b60fe3e" />



### Jira
[ENT-10118](https://2u-internal.atlassian.net/browse/ENT-10118)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
