### PR TITLE
fix: learner profile error response

### DIFF
--- a/enterprise_access/apps/admin_portal_learner_profile/serializers.py
+++ b/enterprise_access/apps/admin_portal_learner_profile/serializers.py
@@ -40,6 +40,7 @@ class ErrorOrField(serializers.Field):
         return self.base_field.to_representation(value)
 
 
+# pylint: disable=abstract-method
 class AdminLearnerProfileRequestSerializer(serializers.Serializer):
     """Serializer for validating admin learner profile query parameters."""
     user_email = serializers.EmailField(required=True, help_text="The email address of the learner.")
@@ -47,6 +48,7 @@ class AdminLearnerProfileRequestSerializer(serializers.Serializer):
     enterprise_customer_uuid = serializers.UUIDField(required=True, help_text="The UUID of the enterprise customer.")
 
 
+# pylint: disable=abstract-method
 class AdminLearnerProfileResponseSerializer(serializers.Serializer):
     """Serializer for structuring the admin learner profile response."""
     subscriptions = ErrorOrField(

--- a/enterprise_access/apps/admin_portal_learner_profile/serializers.py
+++ b/enterprise_access/apps/admin_portal_learner_profile/serializers.py
@@ -8,7 +8,38 @@ from rest_framework import serializers
 logger = logging.getLogger(__name__)
 
 
-# pylint: disable=abstract-method
+class ErrorOrField(serializers.Field):
+    """
+    A field that wraps an existing field (base_field) to allow either its normal value
+    or an error dictionary in the form {"error": "error text"}.
+    """
+    def __init__(self, base_field, **kwargs):
+        self.base_field = base_field
+        super().__init__(**kwargs)
+
+    def to_internal_value(self, data):
+        '''
+        Validate the input data. If it's an error dictionary, return it as-is.'
+        '''
+        # If the value is an error dictionary, validate its structure.
+        if isinstance(data, dict) and "error" in data:
+            return data
+
+        # Otherwise, delegate validation to the base field.
+        return self.base_field.to_internal_value(data)
+
+    def to_representation(self, value):
+        '''
+        Serialize the value. If it's an error dictionary, return it as-is.'
+        '''
+        # If the value is already an error dict, return as-is.
+        if isinstance(value, dict) and "error" in value:
+            return value
+
+        # Otherwise, let the base field handle serialization.
+        return self.base_field.to_representation(value)
+
+
 class AdminLearnerProfileRequestSerializer(serializers.Serializer):
     """Serializer for validating admin learner profile query parameters."""
     user_email = serializers.EmailField(required=True, help_text="The email address of the learner.")
@@ -16,13 +47,27 @@ class AdminLearnerProfileRequestSerializer(serializers.Serializer):
     enterprise_customer_uuid = serializers.UUIDField(required=True, help_text="The UUID of the enterprise customer.")
 
 
-# pylint: disable=abstract-method
 class AdminLearnerProfileResponseSerializer(serializers.Serializer):
     """Serializer for structuring the admin learner profile response."""
-    subscriptions = serializers.ListField(help_text="Details of the learner's subscription licenses.", required=False)
-    group_memberships = serializers.ListField(help_text="Flex group memberships for the learner.", required=False)
-    enrollments = serializers.DictField(
-        child=serializers.ListField(),
-        help_text="Course enrollments for the learner.",
+    subscriptions = ErrorOrField(
+        base_field=serializers.ListField(
+            help_text="Details of the learner's subscription licenses.",
+            required=False
+        ),
+        required=False
+    )
+    group_memberships = ErrorOrField(
+        base_field=serializers.ListField(
+            help_text="Flex group memberships for the learner.",
+            required=False
+        ),
+        required=False
+    )
+    enrollments = ErrorOrField(
+        base_field=serializers.DictField(
+            child=serializers.ListField(),
+            help_text="Course enrollments for the learner.",
+            required=False
+        ),
         required=False
     )

--- a/enterprise_access/apps/api/v1/tests/test_admin_portal_learner_profile.py
+++ b/enterprise_access/apps/api/v1/tests/test_admin_portal_learner_profile.py
@@ -2,6 +2,7 @@
 """
 Tests for AdminPortalLearnerProfileViewset.
 """
+import requests
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
@@ -11,6 +12,10 @@ from rest_framework.test import APIRequestFactory, force_authenticate
 
 from enterprise_access.apps.api.v1.views.admin_portal_learner_profile import AdminLearnerProfileViewSet
 
+
+class MockedErrorfulApiClient:
+    def __init__(self):
+        raise requests.exceptions.HTTPError('Mocked HTTPError')
 
 class TestAdminPortalLearnerProfileView(TestCase):
     """Unit tests for AdminLearnerProfileViewSet."""
@@ -130,3 +135,28 @@ class TestAdminPortalLearnerProfileView(TestCase):
         self.assertEqual(len(response.data['subscriptions']), 1)
         self.assertEqual(len(response.data['group_memberships']), 1)
         self.assertEqual(len(response.data['enrollments'].get('in_progress')), 1)
+
+    @patch('enterprise_access.apps.admin_portal_learner_profile.api.LicenseManagerApiClient')
+    @patch('enterprise_access.apps.admin_portal_learner_profile.api.LmsApiClient')
+    def test_errors_are_formatted_as_strings(
+        self, MockLmsApiClient, MockLicenseManagerApiClient
+    ):
+        # Mock the API clients to raise an HTTPError
+        MockLicenseManagerApiClient.side_effect = MockedErrorfulApiClient
+        MockLmsApiClient.side_effect = MockedErrorfulApiClient
+
+        request = self.authenticate_request({
+            'user_email': 'test@example.com',
+            'lms_user_id': '456',
+            'enterprise_customer_uuid': '123e4567-e89b-12d3-a456-426614174000'
+        })
+
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('subscriptions', response.data)
+        self.assertIn('group_memberships', response.data)
+        self.assertIn('enrollments', response.data)
+        self.assertEqual(response.data['subscriptions']['error'], 'Failed to fetch subscriptions')
+        self.assertEqual(response.data['group_memberships']['error'], 'Failed to fetch group memberships')
+        self.assertEqual(response.data['enrollments']['error'], 'Failed to fetch enrollments')

--- a/enterprise_access/apps/api/v1/tests/test_admin_portal_learner_profile.py
+++ b/enterprise_access/apps/api/v1/tests/test_admin_portal_learner_profile.py
@@ -17,6 +17,7 @@ class MockedErrorfulApiClient:
     def __init__(self):
         raise requests.exceptions.HTTPError('Mocked HTTPError')
 
+
 class TestAdminPortalLearnerProfileView(TestCase):
     """Unit tests for AdminLearnerProfileViewSet."""
 

--- a/enterprise_access/apps/api/v1/tests/test_admin_portal_learner_profile.py
+++ b/enterprise_access/apps/api/v1/tests/test_admin_portal_learner_profile.py
@@ -2,8 +2,8 @@
 """
 Tests for AdminPortalLearnerProfileViewset.
 """
-import requests
 from unittest.mock import patch
+import requests
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase

--- a/enterprise_access/apps/api/v1/tests/test_admin_portal_learner_profile.py
+++ b/enterprise_access/apps/api/v1/tests/test_admin_portal_learner_profile.py
@@ -3,8 +3,8 @@
 Tests for AdminPortalLearnerProfileViewset.
 """
 from unittest.mock import patch
-import requests
 
+import requests
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from rest_framework import status


### PR DESCRIPTION
**Description:**
Fixes a bug where the Learner Portal endpoint does not return error messages in the expected format.

**Important:**
The code was generated with some help of AI, which was reviewed by me. However the review here should also have extra scrutiny that there's no weirdness in the code.

**Jira:**
[ENT-10214](https://2u-internal.atlassian.net/browse/ENT-10214)

**How to test:**
1. test that existing API response has not been broken
    - Grab a suitable enterprise customer and learner
    - Go to /api-docs/
    - Execute the /v1/admin-view/learner_profile/ endpoint with the required arguments
    - Make sure expected results are returned
2. test that error response is now as expected
    - Fabricate HTTP errors when the `EnterpriseAccess` code requests subscriptions, group memberships, and enrollments
        - To do this, you can go to the file enterprise_access/apps/admin_portal_learner_profile/api.py in the repo locally, and in the try block for each method, raise an `requests.exceptions.HTTPError`
    - The correct response per field should look like `  "subscriptions": { "error": "Failed to fetch subscriptions" },`
    - The error message should not just be "error" (that happens if the response is serialized incorrectly)
    - The error message for the "enrollments" field should be a string, not be an array of individual characters
    

**Merge checklist:**
- [x] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
