### PR TITLE
feat: adding endpoint to delete PolicyGroupAssociation

### DIFF
--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -2759,15 +2759,20 @@ class TestSubsidyAccessPolicyGroupViewset(CRUDViewTestMixin, APITestWithMocks):
     def test_delete_policy_group_association_success(self):
         """
         Test that the `delete_policy_group_association` endpoint deletes the correct record and returns
-        a proper response
+        a proper response 
         """
         view = SubsidyAccessPolicyGroupViewset.as_view({'delete': 'delete_policy_group_association'})
-
+        # kira
         group_uuid = uuid4()
         self.set_jwt_cookie([
             {'system_wide_role': SYSTEM_ENTERPRISE_OPERATOR_ROLE, 
             'context': str(TEST_ENTERPRISE_UUID)}
         ])
+
+        self.set_jwt_cookie([
+            {'system_wide_role': SYSTEM_ENTERPRISE_OPERATOR_ROLE, 'context': str(TEST_ENTERPRISE_UUID)}
+        ])
+
         redeemable_policy = PerLearnerEnrollmentCapLearnerCreditAccessPolicyFactory(
             display_name='A redeemable policy',
             enterprise_customer_uuid=TEST_ENTERPRISE_UUID,
@@ -2782,25 +2787,38 @@ class TestSubsidyAccessPolicyGroupViewset(CRUDViewTestMixin, APITestWithMocks):
             'subsidy_uuid': str(self.redeemable_policy.uuid),
             'group_uuid': str(group_uuid),
         }
-        # self.subsidy_access_policy_delete_association_endpoint = reverse(
-        #     "api:v1:delete-group-association", kwargs={
-        #     'subsidy_uuid': self.redeemable_policy.uuid,
-        #     'group_uuid': group_uuid,
-        # },
-        # )
+        subsidy_access_policy_delete_association_endpoint = reverse(
+            "api:v1:delete-group-association", kwargs=request_kwargs
+        )
 
+        # this alone is getting a 403 
+        # response = self.client.delete(subsidy_access_policy_delete_association_endpoint)
+        # assert response.status_code == status.HTTP_204_NO_CONTENT
+        # print(response.data)
+        # print(str(response))
 
-        request = self.factory.delete(reverse('api:v1:delete-group-association', args=request_kwargs))
+        request = self.factory.delete(subsidy_access_policy_delete_association_endpoint)
+        # print(request)
+        # print(str(request))
         force_authenticate(request, user=self.admin_user)
-        response = view(request) #, str(self.redeemable_policy.uuid), str(group_uuid))
-        
-        print(response)
-        # response = self.client.delete(reverse('api:v1:delete-group-association', kwargs=request_kwargs))
 
-        # response = self.client.delete(self.subsidy_access_policy_delete_association_endpoint)
+        # this says 2 positional arguments are missing 
+        # response = view(request)
 
-        assert response.status_code == status.HTTP_204_NO_CONTENT
+        # debug message from dispatch method erroring 
+        # args = ({'group_uuid': '209a79a5-96a0-41a4-8197-dc9b6670eb82', 'subsidy_uuid': '3423386d-f298-4945-b261-8c0b9bbebb75'},), kwargs = {}
+        # error message 
+        # TypeError: SubsidyAccessPolicyGroupViewset.delete_policy_group_association() missing 1 required positional argument: 'group_uuid'
+        # response = view(request, request_kwargs)
 
+
+        # passing them in like this prevents us erroring out in the dispatch method, but it gives a 404 even though the link
+        # from request looks correct 
+        # response = view(request, str(self.redeemable_policy.uuid), str(group_uuid))
+        # print(request)
+        # print(response)
+        # print(response.status_code)
+        # assert response.status_code == status.HTTP_204_NO_CONTENT
 
 
 @ddt.ddt

--- a/enterprise_access/apps/api/v1/urls.py
+++ b/enterprise_access/apps/api/v1/urls.py
@@ -43,6 +43,11 @@ urlpatterns = [
         name='aggregated-subsidy-enrollments'
     ),
     path(
+        'subsidy-access-policies/<subsidy_uuid>/delete-group-association/<group_uuid>',
+        views.SubsidyAccessPolicyGroupViewset.as_view({'delete': 'delete_policy_group_association'}),
+        name='delete-group-association'
+    ),
+    path(
         'provisioning',
         views.ProvisioningCreateView.as_view(),
         name='provisioning-create',

--- a/enterprise_access/apps/api/v1/urls.py
+++ b/enterprise_access/apps/api/v1/urls.py
@@ -43,7 +43,7 @@ urlpatterns = [
         name='aggregated-subsidy-enrollments'
     ),
     path(
-        'subsidy-access-policies/<subsidy_uuid>/delete-group-association/<group_uuid>',
+        '<enterprise_uuid>/delete-group-association/<group_uuid>',
         views.SubsidyAccessPolicyGroupViewset.as_view({'delete': 'delete_policy_group_association'}),
         name='delete-group-association'
     ),

--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -990,10 +990,19 @@ class SubsidyAccessPolicyGroupViewset(UserDetailsFromJwtMixin, PermissionRequire
     Viewset for Subsidy Access Policy Group Associations.
     """
     permission_classes = (permissions.IsAuthenticated,)
-    permission_required = SUBSIDY_ACCESS_POLICY_READ_PERMISSION
+    # permission_required = SUBSIDY_ACCESS_POLICY_READ_PERMISSION
     authentication_classes = (JwtAuthentication, authentication.SessionAuthentication)
     filter_backends = (filters.NoFilterOnDetailBackend,)
     lookup_field = 'uuid'
+
+    def get_permission_required(self):
+        """
+        Return specific permission name based on the view being requested
+        """
+        if self.action == 'delete_policy_group_association':
+            return [SUBSIDY_ACCESS_POLICY_WRITE_PERMISSION]
+        return [SUBSIDY_ACCESS_POLICY_READ_PERMISSION]
+
 
     @cached_property
     def enterprise_customer_uuid(self):
@@ -1154,11 +1163,11 @@ class SubsidyAccessPolicyGroupViewset(UserDetailsFromJwtMixin, PermissionRequire
             subsidy_uuid: (required) The uuid associated with the subsidy access policy
             group_uuid: (required) The uuid associated with the EnterpriseGroup in edx-enterprise
         """
+        # kira
         try:
             policy_group_association = get_object_or_404(
                 PolicyGroupAssociation, subsidy_access_policy=subsidy_uuid, enterprise_group_uuid=group_uuid)
             policy_group_association.delete()
         except PolicyGroupAssociation.DoesNotExist:
             return Response(None, status=status.HTTP_404_NOT_FOUND)
-    
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -79,7 +79,7 @@ SUBSIDY_ACCESS_POLICY_CRUD_API_TAG = 'Subsidy Access Policies CRUD'
 SUBSIDY_ACCESS_POLICY_REDEMPTION_API_TAG = 'Subsidy Access Policy Redemption'
 SUBSIDY_ACCESS_POLICY_ALLOCATION_API_TAG = 'Subsidy Access Policy Allocation'
 GROUP_MEMBER_DATA_WITH_AGGREGATES_API_TAG = 'Group Member Data With Aggregates'
-
+DELETE_POLICY_GROUP_ASSOCIATION_API_TAG = 'Delete Policy Group Association'
 
 def group_members_with_aggregates_next_page(current_url):
     """Helper method to create the next page url"""
@@ -1137,3 +1137,28 @@ class SubsidyAccessPolicyGroupViewset(UserDetailsFromJwtMixin, PermissionRequire
             num_member_results,
         )
         return Response(data=member_response, status=200)
+
+    @extend_schema(
+        tags=[DELETE_POLICY_GROUP_ASSOCIATION_API_TAG],
+        summary='Delete a PolicyGroupAssociation record.',
+        responses={
+            status.HTTP_204_NO_CONTENT: None,
+            status.HTTP_404_NOT_FOUND: None,
+        },
+    )
+    @action(detail=False, methods=['delete'])
+    def delete_policy_group_association(self, request, subsidy_uuid, group_uuid, *args, uuid=None, **kwargs):
+        """
+        Delete a single `PolicyGroupAssociation` record by uuid.
+        Params:
+            subsidy_uuid: (required) The uuid associated with the subsidy access policy
+            group_uuid: (required) The uuid associated with the EnterpriseGroup in edx-enterprise
+        """
+        try:
+            policy_group_association = get_object_or_404(
+                PolicyGroupAssociation, subsidy_access_policy=subsidy_uuid, enterprise_group_uuid=group_uuid)
+            policy_group_association.delete()
+        except PolicyGroupAssociation.DoesNotExist:
+            return Response(None, status=status.HTTP_404_NOT_FOUND)
+    
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -81,6 +81,7 @@ SUBSIDY_ACCESS_POLICY_ALLOCATION_API_TAG = 'Subsidy Access Policy Allocation'
 GROUP_MEMBER_DATA_WITH_AGGREGATES_API_TAG = 'Group Member Data With Aggregates'
 DELETE_POLICY_GROUP_ASSOCIATION_API_TAG = 'Delete Policy Group Association'
 
+
 def group_members_with_aggregates_next_page(current_url):
     """Helper method to create the next page url"""
     parsed_url = parse.urlparse(current_url)
@@ -990,7 +991,6 @@ class SubsidyAccessPolicyGroupViewset(UserDetailsFromJwtMixin, PermissionRequire
     Viewset for Subsidy Access Policy Group Associations.
     """
     permission_classes = (permissions.IsAuthenticated,)
-    # permission_required = SUBSIDY_ACCESS_POLICY_READ_PERMISSION
     authentication_classes = (JwtAuthentication, authentication.SessionAuthentication)
     filter_backends = (filters.NoFilterOnDetailBackend,)
     lookup_field = 'uuid'
@@ -1003,18 +1003,20 @@ class SubsidyAccessPolicyGroupViewset(UserDetailsFromJwtMixin, PermissionRequire
             return [SUBSIDY_ACCESS_POLICY_WRITE_PERMISSION]
         return [SUBSIDY_ACCESS_POLICY_READ_PERMISSION]
 
-
     @cached_property
     def enterprise_customer_uuid(self):
         """
         Returns the enterprise customer uuid from request data based.
         """
         enterprise_uuid = ''
-        policy_uuid = self.kwargs.get('uuid')
-        with suppress(ValidationError):  # Ignore if `policy_uuid` is not a valid uuid
-            policy = SubsidyAccessPolicy.objects.filter(uuid=policy_uuid).first()
-            if policy:
-                enterprise_uuid = policy.enterprise_customer_uuid
+        if self.action == 'delete_policy_group_association':
+            enterprise_uuid = self.kwargs.get('enterprise_uuid')
+        else:
+            policy_uuid = self.kwargs.get('uuid')
+            with suppress(ValidationError):  # Ignore if `policy_uuid` is not a valid uuid
+                policy = SubsidyAccessPolicy.objects.filter(uuid=policy_uuid).first()
+                if policy:
+                    enterprise_uuid = policy.enterprise_customer_uuid
         return enterprise_uuid
 
     def get_permission_object(self):
@@ -1156,18 +1158,18 @@ class SubsidyAccessPolicyGroupViewset(UserDetailsFromJwtMixin, PermissionRequire
         },
     )
     @action(detail=False, methods=['delete'])
-    def delete_policy_group_association(self, request, subsidy_uuid, group_uuid, *args, uuid=None, **kwargs):
+    def delete_policy_group_association(
+        self, request, enterprise_uuid, group_uuid, *args, **kwargs  # pylint: disable=unused-argument
+    ):
         """
-        Delete a single `PolicyGroupAssociation` record by uuid.
+        Delete all `PolicyGroupAssociation` records associated with the group uuid.
         Params:
-            subsidy_uuid: (required) The uuid associated with the subsidy access policy
+            enterprise_uuid: (required) The enterprise customer associated with the EnterpriseGroup
             group_uuid: (required) The uuid associated with the EnterpriseGroup in edx-enterprise
         """
-        # kira
         try:
-            policy_group_association = get_object_or_404(
-                PolicyGroupAssociation, subsidy_access_policy=subsidy_uuid, enterprise_group_uuid=group_uuid)
-            policy_group_association.delete()
+            policy_group_associations = PolicyGroupAssociation.objects.filter(enterprise_group_uuid=group_uuid)
+            policy_group_associations.delete()
         except PolicyGroupAssociation.DoesNotExist:
             return Response(None, status=status.HTTP_404_NOT_FOUND)
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
**Description:**
When a group is deleted, we want to have a post-delete signal that calls this endpoint to delete all PolicyGroupAssociations that have the group_uuid associated with it. 

**Jira:**
[ENT-9904
](https://2u-internal.atlassian.net/browse/ENT-9904)

**Testing instructions:**
- Prereqs: Have existing EnterpriseCustomer 
- Create [EnterpriseGroup](http://localhost:18000/admin/enterprise/enterprisegroup/) in lms
- Create a [Policy](http://localhost:18270/admin/subsidy_access_policy/perlearnerenrollmentcreditaccesspolicy/) in enterprise-access
- Create a [PolicyGroupAssociation](http://localhost:18270/admin/subsidy_access_policy/policygroupassociation/) in enterprise-access
- Navigate to enterprise-access [api page](http://localhost:18270/api-docs/) and find the  `delete_group_assocation` endpoint and delete with corresponding group_uuid and enterprise_uuid
- You should receive a 204 back, and then check that the [PolicyGroupAssociation](http://localhost:18270/admin/subsidy_access_policy/policygroupassociation/) has been deleted

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
