### PR TITLE
feat: client methods to create customer agreement and subs plan

### DIFF
--- a/enterprise_access/apps/api_client/lms_client.py
+++ b/enterprise_access/apps/api_client/lms_client.py
@@ -200,7 +200,7 @@ class LmsApiClient(BaseOAuthClient):
             'slug': slug,
             'country': country,
             'site': {
-                'domain': settings.DEFAULT_CUSTOMER_SITE,
+                'domain': settings.PROVISIONING_DEFAULTS['customer']['site_domain'],
             },
             **kwargs,
         }
@@ -373,10 +373,11 @@ class LmsApiClient(BaseOAuthClient):
         Returns:
             A create enterprise catalog dict.
         """
+        query_id = catalog_query_id or settings.PROVISIONING_DEFAULTS['catalog']['catalog_query_id']
         payload = {
             'enterprise_customer': enterprise_customer_uuid,
             'title': catalog_title,
-            'enterprise_catalog_query': catalog_query_id,
+            'enterprise_catalog_query': query_id,
         }
 
         response = self.client.post(

--- a/enterprise_access/apps/api_client/tests/test_lms_client.py
+++ b/enterprise_access/apps/api_client/tests/test_lms_client.py
@@ -500,7 +500,7 @@ class TestLmsApiClient(TestCase):
         self.assertEqual(response_payload, mock_created_customer_payload)
         expected_url = 'http://edx-platform.example.com/enterprise/api/v1/enterprise-customer/'
         expected_input = {
-            'site': {'domain': settings.DEFAULT_CUSTOMER_SITE},
+            'site': {'domain': settings.PROVISIONING_DEFAULTS['customer']['site_domain']},
             **customer_input,
         }
         mock_post.assert_called_once_with(
@@ -608,7 +608,7 @@ class TestLmsApiClient(TestCase):
 
         expected_url = 'http://edx-platform.example.com/enterprise/api/v1/enterprise-customer/'
         expected_input = {
-            'site': {'domain': settings.DEFAULT_CUSTOMER_SITE},
+            'site': {'domain': settings.PROVISIONING_DEFAULTS['customer']['site_domain']},
             **customer_input,
         }
         mock_post.assert_called_once_with(

--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -541,4 +541,17 @@ SALES_CONTRACT_REFERENCE_PROVIDER_NAME = 'Salesforce OpportunityLineItem'
 SALES_CONTRACT_REFERENCE_PROVIDER_SLUG = 'salesforce_opportunity_line_item'
 
 # Settings for creation of enterprise customers
-DEFAULT_CUSTOMER_SITE = 'example.com'
+
+PROVISIONING_DEFAULTS = {
+    'customer': {
+        'site_domain': 'example.com',
+    },
+    'subscription': {
+        'is_active': True,
+        'product_id': 1,
+        'for_internal_use_only': True,
+    },
+    'catalog': {
+        'catalog_query_id': 1,
+    },
+}


### PR DESCRIPTION
ENT-10004
License-manager client methods to get/create customer agreements, and create subscription plans.

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
