### PR TITLE
fix: ensure get_assignments_serializer is annotated as a list of assignments

### DIFF
--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -592,7 +592,7 @@ class SubsidyAccessPolicyCreditsAvailableResponseSerializer(SubsidyAccessPolicyR
 
     group_associations = serializers.SerializerMethodField()
 
-    @extend_schema_field(LearnerContentAssignmentWithLearnerAcknowledgedResponseSerializer)
+    @extend_schema_field(LearnerContentAssignmentWithLearnerAcknowledgedResponseSerializer(many=True))
     def get_assignments_serializer(self, obj):
         """
         Return serialized assignments if the policy access method is of the 'assigned' type


### PR DESCRIPTION
**Description:**

https://enterprise-access.edx.org/api/schema/redoc/#tag/Subsidy-Access-Policy-Redemption/operation/api_v1_policy_redemption_credits_available_list

The `learner_content_assignments` property within the credits-available API response is annotated as a single assignment object vs. a list of assignments:

<img width="462" alt="image" src="https://github.com/user-attachments/assets/a4e98bb3-3545-4183-ae25-f337fec83f5a" />

As such, the auto-generated TypeScript definitions within Learner Portal, consuming this service's Open API schema are incorrectly suggesting `learnerContentAssignments` is an object vs. an array, blocking the ability to properly type a service function.

**Jira:**

N/A

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
