### PR TITLE
fix: [assignment email] show actual course start date for courses which have not started

### DIFF
--- a/enterprise_access/apps/content_assignments/tasks.py
+++ b/enterprise_access/apps/content_assignments/tasks.py
@@ -211,7 +211,7 @@ class BrazeCampaignSender:
     def get_enrollment_deadline(self):
         return get_human_readable_date(self._enrollment_deadline_raw())
 
-    def get_start_date(self):
+    def get_start_date(self) -> str:
         """
         Checks if the start_date is matches the criteria set by `get_self_paced_normalized_start_date`
         for old start_dates, if so, return today's date, otherwise, return the start_date
@@ -219,19 +219,19 @@ class BrazeCampaignSender:
         start_date = self.normalized_metadata.get('start_date')
         end_date = self.normalized_metadata.get('end_date')
         course_run_metadata = get_course_run_metadata_for_assignment(self.assignment, self.course_metadata)
+        self_paced_normalized_start_date = get_self_paced_normalized_start_date(
+            start_date,
+            end_date,
+            course_run_metadata,
+        )
         logger.info(
-            f"[get_start_date] Assignment UUID: {self.assignment.uuid} - start_date: {start_date}, "
-            f"end_date: {end_date}, "
-            f"course_run_metadata: {course_run_metadata}"
+            f'[get_start_date] assignment_uuid={self.assignment.uuid} - '
+            f'actual_start_date="{start_date}" '
+            f'self_paced_normalized_start_date="{self_paced_normalized_start_date}" '
+            f'end_date="{end_date}" '
+            f'course_run_metadata=<{course_run_metadata}>'
         )
-        return get_human_readable_date(
-            get_self_paced_normalized_start_date(
-                start_date,
-                end_date,
-                course_run_metadata
-            ),
-            BRAZE_TIMESTAMP_FORMAT
-        )
+        return get_human_readable_date(self_paced_normalized_start_date, BRAZE_TIMESTAMP_FORMAT)
 
     def get_action_required_by_timestamp(self):
         """

--- a/enterprise_access/apps/content_assignments/utils.py
+++ b/enterprise_access/apps/content_assignments/utils.py
@@ -10,47 +10,57 @@ from enterprise_access.apps.content_assignments.constants import (
     BRAZE_TIMESTAMP_FORMAT,
     START_DATE_DEFAULT_TO_TODAY_THRESHOLD_DAYS
 )
+from enterprise_access.utils import localized_utcnow
 
 
-def is_within_minimum_start_date_threshold(curr_date, start_date):
+def is_within_minimum_start_date_threshold(
+    curr_date: datetime,
+    start_date: datetime,
+) -> bool:
     """
     Checks if today's date were set to a certain number of days in the past,
     offset_date_from_today, is the start_date before offset_date_from_today.
     """
-    start_date_datetime = parser.parse(start_date)
     offset_date_from_today = curr_date - timedelta(days=START_DATE_DEFAULT_TO_TODAY_THRESHOLD_DAYS)
-    return start_date_datetime < offset_date_from_today.replace(tzinfo=UTC)
+    return start_date < offset_date_from_today
 
 
-def has_time_to_complete(curr_date, end_date, weeks_to_complete):
+def has_time_to_complete(
+    curr_date: datetime,
+    end_date: datetime,
+    weeks_to_complete: int,
+) -> bool:
     """
     Checks if today's date were set to a certain number of weeks_to_complete in the future,
     offset_now_by_weeks_to_complete, is offset_now_by_weeks_to_complete date before the end_date
     """
-    end_date_datetime = parser.parse(end_date)
     offset_now_by_weeks_to_complete = curr_date + timedelta(weeks=weeks_to_complete)
-    return offset_now_by_weeks_to_complete.replace(tzinfo=UTC).strftime("%Y-%m-%d") <= \
-        end_date_datetime.strftime("%Y-%m-%d")
+    return offset_now_by_weeks_to_complete.date() <= end_date.date()
 
 
-def get_self_paced_normalized_start_date(start_date, end_date, course_metadata):
+def get_self_paced_normalized_start_date(
+    start_date: str,
+    end_date: str,
+    course_metadata: dict,
+) -> str:
     """
     Normalizes courses start_date far in the past based on a heuristic for the purpose of displaying a
     reasonable start_date in content assignment related emails.
 
     Heuristic:
-    For self-paced courses with a weeks_to_complete field too close to the end date to complete the course
-    or a start_date that is before today offset by the START_DATE_DEFAULT_TO_TODAY_THRESHOLD_DAYS should
-    default to today's date.
-    Otherwise, return the current start_date
+    For already started self-paced courses for which EITHER there is still enough time to
+    complete it before it ends, OR the course started a long time ago, we should display
+    today's date as the "start date".  Otherwise, return the actual start_date.
     """
-    curr_date = datetime.now()
+    curr_date = localized_utcnow()
     pacing_type = course_metadata.get('pacing_type', {}) or None
     weeks_to_complete = course_metadata.get('weeks_to_complete', {}) or None
     if not (start_date and end_date and pacing_type and weeks_to_complete):
         return curr_date.strftime(BRAZE_TIMESTAMP_FORMAT)
-    if pacing_type == "self_paced":
-        if has_time_to_complete(curr_date, end_date, weeks_to_complete) or \
-                is_within_minimum_start_date_threshold(curr_date, start_date):
+    start_date_datetime = parser.parse(start_date).astimezone(UTC)
+    end_date_datetime = parser.parse(end_date).astimezone(UTC)
+    if pacing_type == "self_paced" and start_date_datetime < curr_date:
+        if has_time_to_complete(curr_date, end_date_datetime, weeks_to_complete) or \
+                is_within_minimum_start_date_threshold(curr_date, start_date_datetime):
             return curr_date.strftime(BRAZE_TIMESTAMP_FORMAT)
     return start_date

--- a/enterprise_access/utils.py
+++ b/enterprise_access/utils.py
@@ -236,7 +236,7 @@ def get_normalized_metadata_for_assignment(assignment, content_metadata):
 
 
 def _curr_date(date_format=None):
-    curr_date = datetime.now()
+    curr_date = localized_utcnow()
     if not date_format:
         return curr_date
     return curr_date.strftime(date_format)


### PR DESCRIPTION
Emails to learners about course assignments previously displayed the current date as the course "start date" in this case:

* course is self-paced.
* end date is far enough in the future that there's enough time to complete.
* start date is in the future.

Displaying the current date rather than the actual course start date in this specific case was unintentional, and does not match the corresponding logic in the learner-portal.

ENT-10263