### PR TITLE
fix: forced redemption assignment email lookup

### DIFF
--- a/enterprise_access/apps/subsidy_access_policy/admin/__init__.py
+++ b/enterprise_access/apps/subsidy_access_policy/admin/__init__.py
@@ -421,6 +421,27 @@ class ForcedPolicyRedemptionAdmin(DjangoQLSearchMixin, SimpleHistoryAdmin):
     Admin class for the forced redemption model/logic.
     """
     form = ForcedPolicyRedemptionForm
+
+    djangoql_completion_enabled_by_default = False
+    search_fields = [
+        'uuid',
+        'subsidy_access_policy__uuid',
+        'lms_user_id',
+        'course_run_key',
+    ]
+
+    list_display = [
+        'uuid',
+        'policy_uuid',
+        'lms_user_id',
+        'course_run_key',
+        'redeemed_at',
+        'errored_at',
+    ]
+    list_filter = [
+        'redeemed_at',
+        'errored_at',
+    ]
     autocomplete_fields = [
         'subsidy_access_policy',
     ]


### PR DESCRIPTION
**Description:**
This fixes a problem with forced redemption, where we can't create assignments for some lms user ids because the user has never auth'd into enterprise-access (typically because they're new, or have never visited the learner portal). The fix switches the lookup of user email (based on lms user id) to the `LmsApiClient()` instead of the `core.User` model.
This also required the addition of an optional kwarg to `allocate_assignments()`, which allows us to skip the mapping of lms user id <-> email if the caller already knows the lms user id(s) of the learner emails being allocated (which the forced redemption flow will always know).

Additionally, makes the django admin UI much more friendly and usable.

**Jira:**
TODO

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
