### PR TITLE
fix: account for casing in forced redemption

### DIFF
--- a/enterprise_access/apps/content_assignments/api.py
+++ b/enterprise_access/apps/content_assignments/api.py
@@ -319,7 +319,10 @@ def allocate_assignments(
     content_quantity = content_price_cents * -1
 
     if known_lms_user_ids:
-        lms_user_ids_by_email = dict(zip(learner_emails_to_allocate, known_lms_user_ids))
+        lms_user_ids_by_email = dict(zip(
+            [email.lower() for email in learner_emails_to_allocate],
+            known_lms_user_ids
+        ))
         emails_by_lms_user_id = dict(zip(known_lms_user_ids, learner_emails_to_allocate))
     else:
         lms_user_ids_by_email, emails_by_lms_user_id = _map_allocation_emails_with_lms_user_ids(

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -19,7 +19,6 @@ from simple_history.models import HistoricalRecords
 from enterprise_access.apps.api_client.lms_client import LmsApiClient
 from enterprise_access.apps.content_assignments import api as assignments_api
 from enterprise_access.apps.content_assignments.constants import LearnerContentAssignmentStateChoices
-from enterprise_access.apps.core.models import User
 from enterprise_access.cache_utils import request_cache, versioned_cache_key
 from enterprise_access.utils import format_traceback, is_none, is_not_none, localized_utcnow
 
@@ -159,7 +158,7 @@ class SubsidyAccessPolicy(TimeStampedModel):
         ),
     )
     learner_credit_request_config = models.OneToOneField(
-        'subsidy_request.LearnerCreditRequestConfiguration',  # pylint: disable=all
+        'subsidy_request.LearnerCreditRequestConfiguration',
         related_name="learner_credit_config",
         on_delete=models.SET_NULL,
         null=True,

--- a/enterprise_access/apps/subsidy_access_policy/tests/test_forced_redemption.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/test_forced_redemption.py
@@ -231,7 +231,7 @@ class ForcedPolicyRedemptionAssignmentTests(BaseForcedRedemptionTestCase):
         test that we can force redemption.
         """
         policy = self._new_assignment_budget()
-        self._setup_redemption_state(user_email='alice@foo.com')
+        self._setup_redemption_state(user_email='Alice@foo.com')
 
         forced_redemption_record = ForcedPolicyRedemptionFactory(
             subsidy_access_policy=policy,
@@ -258,6 +258,6 @@ class ForcedPolicyRedemptionAssignmentTests(BaseForcedRedemptionTestCase):
 
         assignment = LearnerContentAssignment.objects.filter(lms_user_id=self.lms_user_id).first()
         self.assertEqual(assignment.content_key, self.course_run_key)
-        self.assertEqual(assignment.learner_email, 'alice@foo.com')
+        self.assertEqual(assignment.learner_email, 'Alice@foo.com')
         mock_send_email.delay.assert_called_once_with(assignment.uuid)
         mock_pending_learner_task.delay.assert_called_once_with(assignment.uuid)

--- a/enterprise_access/apps/subsidy_request/models.py
+++ b/enterprise_access/apps/subsidy_request/models.py
@@ -14,7 +14,6 @@ from model_utils.models import SoftDeletableModel, TimeStampedModel
 from simple_history.models import HistoricalRecords
 from simple_history.utils import bulk_update_with_history
 
-from enterprise_access.apps.subsidy_access_policy.models import SubsidyAccessPolicy
 from enterprise_access.apps.subsidy_request.constants import (
     SUBSIDY_REQUEST_BULK_OPERATION_BATCH_SIZE,
     SubsidyRequestStates,
@@ -340,7 +339,7 @@ class LearnerCreditRequest(SubsidyRequest):
     """
 
     assignment = models.OneToOneField(
-        'content_assignments.LearnerContentAssignment',  # pylint: disable=all
+        'content_assignments.LearnerContentAssignment',
         related_name="credit_request",
         on_delete=models.SET_NULL,
         null=True,


### PR DESCRIPTION
**Description:**
We have to account for email inputs with uppercase characters in the forced redemption `known_lms_user_ids` use case.

**Jira:**
ENT-10385

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
