### PR TITLE
feat: configurable automatically_nudge_assignments batch size

### DIFF
--- a/enterprise_access/apps/content_assignments/management/commands/automatically_nudge_assignments.py
+++ b/enterprise_access/apps/content_assignments/management/commands/automatically_nudge_assignments.py
@@ -56,6 +56,14 @@ class Command(BaseCommand):
             metavar='NUM_DAYS',
             help='The amount of days before the course start date to send a nudge email through braze',
         )
+        parser.add_argument(
+            '--batch_size',
+            type=int,
+            dest='batch_size',
+            default=50,
+            metavar='ASSIGNMENTS_PER_BATCH',
+            help='The amount of days before the course start date to send a nudge email through braze',
+        )
 
     @staticmethod
     def to_datetime(value):
@@ -75,6 +83,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         dry_run = options['dry_run']
         days_before_course_start_date = options['days_before_course_start_date']
+        batch_size = options['batch_size']
 
         for assignment_configuration in AssignmentConfiguration.objects.filter(active=True):
             if not hasattr(assignment_configuration, 'subsidy_access_policy'):
@@ -120,7 +129,7 @@ class Command(BaseCommand):
                 )
                 continue
 
-            paginator = Paginator(accepted_assignments, 100)
+            paginator = Paginator(accepted_assignments, batch_size)
             for page_number in paginator.page_range:
                 assignments = paginator.page(page_number)
 


### PR DESCRIPTION
**Description:**
Currently the `automatically_nudge_assignments` job queries content metadata in batches of 100 from `enterprise-catalog`.  This has begun to fail recently because the list of course keys used to query has exceeded the maximum length of a url.  This change makes the batch size configurable, with a conservative default batch size.

**Jira:**
[ENT-10403](https://2u-internal.atlassian.net/browse/ENT-10403)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
