### PR TITLE
fix: skip pylint checking on some models files

### DIFF
--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -1,6 +1,10 @@
 """
 Models for subsidy_access_policy
 """
+# AED 2025-05-01: pylint runner is crashing in github actions
+# when this file is not disabled.
+# pylint: skip-file
+
 import logging
 import sys
 from contextlib import contextmanager

--- a/enterprise_access/apps/subsidy_request/models.py
+++ b/enterprise_access/apps/subsidy_request/models.py
@@ -1,4 +1,7 @@
 """ Models for subsidy_request. """
+# AED 2025-05-01: pylint runner is crashing in github actions
+# when this file is not disabled.
+# pylint: skip-file
 
 import collections
 from uuid import uuid4


### PR DESCRIPTION
**Description:**
I removed "skip-all" from a couple of files in a previous commit. The linter ran fine locally for me, but continues to crash in github actions for reasons unknown.

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
