### PR TITLE
feat: expose `display_reason` derived from `reasons`

### DIFF
--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -694,6 +694,10 @@ class SubsidyAccessPolicyCanRedeemElementResponseSerializer(serializers.Serializ
             "List of reasons why each of the enterprise's subsidy access policies are not redeemable, grouped by reason"
         )
     )
+    display_reason = serializers.CharField(
+        allow_null=True,
+        help_text="A single, user-facing description of the most salient reason for non-redeemability.",
+    )
 
 
 # pylint: disable=abstract-method

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -1910,6 +1910,7 @@ class TestSubsidyAccessPolicyCanRedeemView(BaseCanRedeemTestMixin, APITestWithMo
         assert response_list[0]["redeemable_subsidy_access_policy"]["uuid"] == str(self.redeemable_policy.uuid)
         assert response_list[0]["can_redeem"] is True
         assert len(response_list[0]["reasons"]) == 0
+        assert response_list[0]['display_reason'] is None
 
         # Check the response for the second content_key given.
         assert response_list[1]["content_key"] == test_content_key_2
@@ -1922,6 +1923,7 @@ class TestSubsidyAccessPolicyCanRedeemView(BaseCanRedeemTestMixin, APITestWithMo
         assert response_list[1]["redeemable_subsidy_access_policy"]["uuid"] == str(self.redeemable_policy.uuid)
         assert response_list[1]["can_redeem"] is True
         assert len(response_list[1]["reasons"]) == 0
+        assert response_list[1]['display_reason'] is None
 
     @mock.patch('enterprise_access.apps.subsidy_access_policy.subsidy_api.get_and_cache_transactions_for_learner')
     @mock.patch('enterprise_access.apps.api.v1.views.subsidy_access_policy.LmsApiClient', return_value=mock.MagicMock())
@@ -2120,6 +2122,7 @@ class TestSubsidyAccessPolicyCanRedeemView(BaseCanRedeemTestMixin, APITestWithMo
                 "policy_uuids": [str(self.redeemable_policy.uuid)],
             },
         ]
+        assert response_list[0]['display_reason'] == expected_user_message
 
         # Check the response for the second content_key given.
         assert response_list[1]["content_key"] == test_content_key_2
@@ -2139,6 +2142,7 @@ class TestSubsidyAccessPolicyCanRedeemView(BaseCanRedeemTestMixin, APITestWithMo
                 "policy_uuids": [str(self.redeemable_policy.uuid)],
             },
         ]
+        assert response_list[1]["display_reason"] == expected_user_message
 
     @mock.patch('enterprise_access.apps.subsidy_access_policy.subsidy_api.get_and_cache_transactions_for_learner')
     def test_can_redeem_policy_existing_redemptions(self, mock_transactions_cache_for_learner):
@@ -2206,6 +2210,7 @@ class TestSubsidyAccessPolicyCanRedeemView(BaseCanRedeemTestMixin, APITestWithMo
         self.assertIsNone(response_list[0]["redeemable_subsidy_access_policy"])
         self.assertFalse(response_list[0]["can_redeem"])
         self.assertEqual(response_list[0]["reasons"], [])
+        assert response_list[0]["display_reason"] is None
 
         # We call this to fetch the list_price
         self.mock_get_content_metadata.assert_called_once_with("course-v1:demox+1234+2T2023")
@@ -2280,6 +2285,7 @@ class TestSubsidyAccessPolicyCanRedeemView(BaseCanRedeemTestMixin, APITestWithMo
         assert response_list[0]["redeemable_subsidy_access_policy"]["uuid"] == str(self.redeemable_policy.uuid)
         assert response_list[0]["can_redeem"] is True
         assert response_list[0]["reasons"] == []
+        assert response_list[0]["display_reason"] is None
 
     @mock.patch('enterprise_access.apps.subsidy_access_policy.subsidy_api.get_and_cache_transactions_for_learner')
     @mock.patch('enterprise_access.apps.api.v1.views.subsidy_access_policy.LmsApiClient')
@@ -2379,6 +2385,7 @@ class TestSubsidyAccessPolicyCanRedeemView(BaseCanRedeemTestMixin, APITestWithMo
                 "policy_uuids": [str(self.redeemable_policy.uuid)],
             },
         ]
+        assert response_list[0]["display_reason"] == MissingSubsidyAccessReasonUserMessages.BEYOND_ENROLLMENT_DEADLINE
 
     @mock.patch('enterprise_access.apps.subsidy_access_policy.subsidy_api.get_versioned_subsidy_client')
     def test_can_redeem_subsidy_client_http_error(self, mock_get_client):
@@ -2902,6 +2909,7 @@ class TestAssignedSubsidyAccessPolicyCanRedeemView(BaseCanRedeemTestMixin, APITe
             str(self.assigned_learner_credit_policy.uuid)
         assert response_list[0]["can_redeem"] is True
         assert len(response_list[0]["reasons"]) == 0
+        assert response_list[0]["display_reason"] is None
 
     @mock.patch('enterprise_access.apps.api.v1.views.subsidy_access_policy.LmsApiClient')
     @mock.patch('enterprise_access.apps.subsidy_access_policy.subsidy_api.get_and_cache_transactions_for_learner')
@@ -3003,6 +3011,7 @@ class TestAssignedSubsidyAccessPolicyCanRedeemView(BaseCanRedeemTestMixin, APITe
             },
         ]
         assert response_list[0]["reasons"] == expected_reasons
+        assert response_list[0]["display_reason"] == expected_message
 
     @mock.patch('enterprise_access.apps.api.v1.views.subsidy_access_policy.LmsApiClient')
     @mock.patch('enterprise_access.apps.subsidy_access_policy.subsidy_api.get_and_cache_transactions_for_learner')
@@ -3067,6 +3076,7 @@ class TestAssignedSubsidyAccessPolicyCanRedeemView(BaseCanRedeemTestMixin, APITe
         assert response_list[0]["redeemable_subsidy_access_policy"] is None
         assert response_list[0]["can_redeem"] is False
         assert response_list[0]["reasons"][0]["reason"] == REASON_CONTENT_NOT_IN_CATALOG
+        assert response_list[0]["display_reason"] == MissingSubsidyAccessReasonUserMessages.CONTENT_NOT_IN_CATALOG
 
     @mock.patch('enterprise_access.apps.content_assignments.api.get_and_cache_content_metadata')
     @mock.patch('enterprise_access.apps.subsidy_access_policy.subsidy_api.get_and_cache_transactions_for_learner')

--- a/enterprise_access/apps/subsidy_access_policy/utils.py
+++ b/enterprise_access/apps/subsidy_access_policy/utils.py
@@ -44,6 +44,21 @@ def create_idempotency_key_for_transaction(subsidy_uuid, **metadata):
     return f'{LEDGERED_SUBSIDY_IDEMPOTENCY_KEY_PREFIX}-{subsidy_uuid}-{hashed_metadata}'
 
 
+def sort_subsidy_access_policies_for_redemption(queryset):
+    """
+    Sorts the query set during can-redeem by the following parameters
+           - priority (of type)
+           - expiration, sooner to expire first
+           - balance, lower balance first
+    """
+    if queryset.count() <= 1:
+        return queryset
+    return sorted(
+        queryset,
+        key=lambda p: (p.priority, p.subsidy_expiration_datetime, p.subsidy_balance())
+    )
+
+
 class ProxyAwareHistoricalRecords(HistoricalRecords):
     """
     This specialized HistoricalRecords model field is to be used specifically for tracking history on instances of proxy


### PR DESCRIPTION
**Description:**
Exposes a net new field from the `SubsidyAccessPolicyCanRedeemElementResponseSerializer`, `display_reason`. The intent of this new field is to isolate a failed redemption reason to the client without naively picking the zero indexed value. 

The logic within `evaluate_policies` was also updated to bring sorting logic implemented downstream, higher in the call stack to correctly sort policies for both redeemable and non-redeemable policies.

Can-redeem response:
![Screenshot 2025-05-09 at 1 01 30 PM](https://github.com/user-attachments/assets/5d06f27a-a820-49cd-ae0b-b8c4e198e70e)



**Jira:**
[ENT-10268](https://2u-internal.atlassian.net/browse/ENT-10268)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
