### PR TITLE
fix: updated LearnerCreditRequestSerializer to resolve schema generation error

### DIFF
--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -628,7 +628,7 @@ class SubsidyAccessPolicyCreditsAvailableResponseSerializer(SubsidyAccessPolicyR
         """
         Return serialized learner credit requests associated with the user and policy's enterprise customer,
         filtered by the specific learner credit request configuration associated with this policy.
-        
+
         Returns:
             list: Serialized learner credit requests if policy has BNR enabled and user is authenticated.
                 Empty list otherwise.

--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -13,6 +13,7 @@ from opaque_keys.edx.keys import CourseKey
 from requests.exceptions import HTTPError
 from rest_framework import serializers
 
+from enterprise_access.apps.api.serializers.subsidy_requests import LearnerCreditRequestSerializer
 from enterprise_access.apps.content_assignments.content_metadata_api import get_content_metadata_for_assignments
 from enterprise_access.apps.subsidy_access_policy.constants import (
     CENTS_PER_DOLLAR,
@@ -20,10 +21,9 @@ from enterprise_access.apps.subsidy_access_policy.constants import (
     PolicyTypes
 )
 from enterprise_access.apps.subsidy_access_policy.models import SubsidyAccessPolicy
-
-from enterprise_access.apps.api.serializers.subsidy_requests import LearnerCreditRequestSerializer
 from enterprise_access.apps.subsidy_request.constants import SubsidyRequestStates
 from enterprise_access.apps.subsidy_request.models import LearnerCreditRequest
+
 from .content_assignments.assignment import (
     LearnerContentAssignmentResponseSerializer,
     LearnerContentAssignmentWithLearnerAcknowledgedResponseSerializer

--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -592,7 +592,7 @@ class SubsidyAccessPolicyCreditsAvailableResponseSerializer(SubsidyAccessPolicyR
         source='subsidy_expiration_datetime',
     )
     learner_content_assignments = serializers.SerializerMethodField('get_assignments_serializer')
-    
+
     learner_requests = serializers.SerializerMethodField('get_learner_requests')
 
     group_associations = serializers.SerializerMethodField()
@@ -622,7 +622,7 @@ class SubsidyAccessPolicyCreditsAvailableResponseSerializer(SubsidyAccessPolicyR
             context=context,
         )
         return serializer.data
-    
+
     @extend_schema_field(LearnerCreditRequestSerializer(many=True))
     def get_learner_requests(self, obj):
         """

--- a/enterprise_access/apps/api/serializers/subsidy_requests.py
+++ b/enterprise_access/apps/api/serializers/subsidy_requests.py
@@ -5,6 +5,7 @@ import logging
 
 from rest_framework import serializers
 
+from enterprise_access.apps.content_assignments.models import LearnerContentAssignment
 from enterprise_access.apps.subsidy_request.models import (
     CouponCodeRequest,
     LearnerCreditRequest,
@@ -147,7 +148,7 @@ class LearnerCreditRequestSerializer(SubsidyRequestSerializer):
         allow_null=True,
     )
     assignment = serializers.PrimaryKeyRelatedField(
-        queryset='content_assignments.LearnerContentAssignment.objects.all()',
+        queryset=LearnerContentAssignment.objects.all(),
         required=False,
         allow_null=True,
     )

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -1705,6 +1705,7 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
             'remaining_balance': 5000,
             'subsidy_expiration_date': '2030-01-01 12:00:00Z',
             'learner_content_assignments': [expected_learner_content_assignment],
+            'learner_requests': [],
             'group_associations': [str(TEST_ENTERPRISE_GROUP_UUID)],
             'policy_type': 'AssignedLearnerCreditAccessPolicy',
             'enterprise_customer_uuid': self.enterprise_uuid,


### PR DESCRIPTION
**Description:**
The `queryset` argument in the `assignment` field of the `LearnerCreditRequestSerializer` was set as a string. This caused an `AttributeError` during API schema generation, preventing the Redoc site from working properly. This commit updates the serializer to use the correct `QuerySet` object, resolving the error.

**Jira:**
[ENT-10463 - [enterprise-access] Redoc site not working](https://2u-internal.atlassian.net/browse/ENT-10463)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
