### PR TITLE
fix: ensure `get_pending_enterprise_group_memberships` always returns a list

### DIFF
--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -13,6 +13,7 @@ from opaque_keys.edx.keys import CourseKey
 from requests.exceptions import HTTPError
 from rest_framework import serializers
 
+from enterprise_access.apps.api.serializers.subsidy_requests import LearnerCreditRequestSerializer
 from enterprise_access.apps.content_assignments.content_metadata_api import get_content_metadata_for_assignments
 from enterprise_access.apps.subsidy_access_policy.constants import (
     CENTS_PER_DOLLAR,
@@ -20,10 +21,9 @@ from enterprise_access.apps.subsidy_access_policy.constants import (
     PolicyTypes
 )
 from enterprise_access.apps.subsidy_access_policy.models import SubsidyAccessPolicy
-
-from enterprise_access.apps.api.serializers.subsidy_requests import LearnerCreditRequestSerializer
 from enterprise_access.apps.subsidy_request.constants import SubsidyRequestStates
 from enterprise_access.apps.subsidy_request.models import LearnerCreditRequest
+
 from .content_assignments.assignment import (
     LearnerContentAssignmentResponseSerializer,
     LearnerContentAssignmentWithLearnerAcknowledgedResponseSerializer
@@ -592,7 +592,6 @@ class SubsidyAccessPolicyCreditsAvailableResponseSerializer(SubsidyAccessPolicyR
         source='subsidy_expiration_datetime',
     )
     learner_content_assignments = serializers.SerializerMethodField('get_assignments_serializer')
-    
     learner_requests = serializers.SerializerMethodField('get_learner_requests')
 
     group_associations = serializers.SerializerMethodField()
@@ -622,13 +621,13 @@ class SubsidyAccessPolicyCreditsAvailableResponseSerializer(SubsidyAccessPolicyR
             context=context,
         )
         return serializer.data
-    
+
     @extend_schema_field(LearnerCreditRequestSerializer(many=True))
     def get_learner_requests(self, obj):
         """
         Return serialized learner credit requests associated with the user and policy's enterprise customer,
         filtered by the specific learner credit request configuration associated with this policy.
-        
+
         Returns:
             list: Serialized learner credit requests if policy has BNR enabled and user is authenticated.
                 Empty list otherwise.

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -1705,6 +1705,7 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
             'remaining_balance': 5000,
             'subsidy_expiration_date': '2030-01-01 12:00:00Z',
             'learner_content_assignments': [expected_learner_content_assignment],
+            'learner_requests': [],
             'group_associations': [str(TEST_ENTERPRISE_GROUP_UUID)],
             'policy_type': 'AssignedLearnerCreditAccessPolicy',
             'enterprise_customer_uuid': self.enterprise_uuid,

--- a/enterprise_access/apps/api_client/lms_client.py
+++ b/enterprise_access/apps/api_client/lms_client.py
@@ -634,13 +634,12 @@ class LmsApiClient(BaseOAuthClient):
                             'recent_action': recent_action,
                             'user_email': user_email,
                         })
-            return results
         except requests.exceptions.HTTPError:
             logger.exception('Failed to fetch data from LMS. URL: [%s].', url)
         except KeyError:
             logger.exception('Incorrect data received from LMS. [%s]', url)
 
-        return None
+        return results
 
     def update_pending_learner_status(self, enterprise_group_uuid, learner_email):
         """

--- a/enterprise_access/apps/enterprise_groups/management/commands/groups_reminder_emails.py
+++ b/enterprise_access/apps/enterprise_groups/management/commands/groups_reminder_emails.py
@@ -61,4 +61,13 @@ class Command(BaseCommand):
                 pending_enterprise_customer_user["enterprise_customer_name"] = enterprise_customer_data["name"]
                 pending_enterprise_customer_user["enterprise_group_uuid"] = enterprise_group_uuid
                 pecu_email_properties.append(pending_enterprise_customer_user)
+
+            if not pecu_email_properties:
+                LOGGER.info(
+                    "No pending enterprise customer users found for enterprise group %s.",
+                    enterprise_group_uuid
+                )
+                # No pending enterprise customer users found for enterprise group, skip sending reminder emails.
+                continue
+
             send_group_reminder_emails.delay(pecu_email_properties)


### PR DESCRIPTION
**Description:**

Ensures the `get_pending_enterprise_group_memberships` method in `LmsApiClient` returns an empty list vs. `None` to prevent attempting to iterate over `None` in downstream code paths.

**Jira:**
[ENT-10474](https://2u-internal.atlassian.net/browse/ENT-10474)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
