### PR TITLE
feat: make LearnerCreditRequest fields editable in django admin

### DIFF
--- a/enterprise_access/apps/subsidy_request/admin.py
+++ b/enterprise_access/apps/subsidy_request/admin.py
@@ -181,7 +181,8 @@ class LearnerCreditRequestAdmin(BaseSubsidyRequestAdmin, admin.ModelAdmin):
     )
 
     read_only_fields = (
-        'assignment',
+        'uuid',
+        'get_course_partners',
     )
 
     fields = (
@@ -197,7 +198,7 @@ class LearnerCreditRequestAdmin(BaseSubsidyRequestAdmin, admin.ModelAdmin):
         model = models.LearnerCreditRequest
 
     def get_readonly_fields(self, request, obj=None):
-        return super().read_only_fields + self.read_only_fields
+        return self.read_only_fields
 
     def get_fields(self, request, obj=None):
         return super().fields + self.fields


### PR DESCRIPTION
**Description:**
This PR updates the Django admin interface for the LearnerCreditRequest model.

The changes ensure that most fields are now editable in the admin form. uuid remains read-only. The get_course_partners field also remains read-only as it's a display method for formatted data, not a directly editable model field. 

![image](https://github.com/user-attachments/assets/f8ad4f0a-c180-48df-bad1-6ae094f46be2)


**Jira:**
ENT-XXXX

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
