### PR TITLE
feat: include LearnerCreditRequest object in can_request response

### DIFF
--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -774,6 +774,11 @@ class SubsidyAccessPolicyCanRequestElementResponseSerializer(serializers.Seriali
             "content_key and lms_user_id."
         )
     )
+    existing_request = LearnerCreditRequestSerializer(
+        required=False,
+        allow_null=True,
+        help_text="The existing learner credit request object if one exists."
+    )
 
 
 # pylint: disable=abstract-method

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -15,6 +15,7 @@ from requests.exceptions import HTTPError
 from rest_framework import status
 from rest_framework.reverse import reverse
 
+from enterprise_access.apps.api.serializers.subsidy_requests import LearnerCreditRequestSerializer
 from enterprise_access.apps.api_client.tests.test_utils import MockResponse
 from enterprise_access.apps.content_assignments.constants import (
     AssignmentAutomaticExpiredReason,
@@ -1826,7 +1827,8 @@ class TestSubsidyAccessPolicyRedeemViewset(APITestWithMocks):
         response_data = response.json()
         self.assertFalse(response_data.get('can_request'))
         self.assertIn("already have an active request", response_data.get('reason'))
-        self.assertEqual(response_data.get('existing_request'), str(existing_request.uuid))
+        expected_serialized = LearnerCreditRequestSerializer(existing_request).data
+        self.assertEqual(response_data.get('existing_request'), expected_serialized)
 
 
 class BaseCanRedeemTestMixin:

--- a/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/v1/views/subsidy_access_policy.py
@@ -981,7 +981,7 @@ class SubsidyAccessPolicyRedeemViewset(UserDetailsFromJwtMixin, PermissionRequir
             return Response({
                 'can_request': False,
                 'reason': f"You already have an active request for this course in state: {existing_request.state}",
-                'existing_request': str(existing_request.uuid)
+                'existing_request': serializers.LearnerCreditRequestSerializer(existing_request).data
             }, status=400)
 
         # Sort policies to find the best one for redemption


### PR DESCRIPTION
**Description:**
Added LearnerCreditRequest (LCR) data to the can_request response to support frontend logic for learner credit workflows.

**Jira:**
ENT-XXXX

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
