### PR TITLE
fix: pass page_size query param to learner-licenses API

### DIFF
--- a/enterprise_access/apps/api_client/license_manager_client.py
+++ b/enterprise_access/apps/api_client/license_manager_client.py
@@ -221,6 +221,7 @@ class LicenseManagerUserApiClient(BaseUserApiClient):
         """
         query_params = {
             'enterprise_customer_uuid': enterprise_customer_uuid,
+            'page_size': 100,
             **kwargs,
         }
         url = self.learner_licenses_endpoint

--- a/enterprise_access/apps/api_client/tests/test_license_manager_client.py
+++ b/enterprise_access/apps/api_client/tests/test_license_manager_client.py
@@ -191,7 +191,10 @@ class TestLicenseManagerUserApiClient(MockLicenseManagerMetadataMixin):
 
         # Assert query parameters are correctly set
         parsed_params = parse_qs(parsed_url.query)
-        expected_params = {'enterprise_customer_uuid': [self.mock_enterprise_customer_uuid]}
+        expected_params = {
+            'enterprise_customer_uuid': [self.mock_enterprise_customer_uuid],
+            'page_size': ['100'],
+        }
         self.assertEqual(parsed_params, expected_params)
 
         # Assert headers are correctly set


### PR DESCRIPTION
**Description:**

The `learner-licenses` API request to `license-manager` currently does not pass a `page_size` query param; it seems the API itself is only paginating with 10 rows per page, despite the base `PAGE_SIZE` param in the `license-manager` settings appearing to be 100 already.

Either way, we are opting to explicitly pass a `?page_size=` query param in both the BFF API layer _and_ Learner Portal ([PR](https://github.com/openedx/frontend-app-learner-portal-enterprise/pull/1374)) for parity.

**Jira:**
TBD

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
