### PR TITLE
feat: exposed bnr_enabled field in SubsidyAccessPolicyResponseSerializer

### DIFF
--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -194,6 +194,7 @@ class SubsidyAccessPolicyResponseSerializer(serializers.ModelSerializer):
             'late_redemption_allowed_until',
             'is_late_redemption_allowed',
             'created',
+            'bnr_enabled',
         ]
         read_only_fields = fields
 

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -324,7 +324,8 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
             'group_associations': [str(enterprise_group_uuid)],
             'late_redemption_allowed_until': None,
             'is_late_redemption_allowed': False,
-            'created': self.redeemable_policy.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+            'created': self.redeemable_policy.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+            'bnr_enabled': False,
         }, response.json())
 
     @ddt.data(
@@ -420,7 +421,8 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
                 'group_associations': [],
                 'late_redemption_allowed_until': None,
                 'is_late_redemption_allowed': False,
-                'created': self.non_redeemable_policy.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                'created': self.non_redeemable_policy.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                'bnr_enabled': False,
             },
             {
                 'access_method': 'direct',
@@ -453,6 +455,7 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
                 'late_redemption_allowed_until': None,
                 'is_late_redemption_allowed': False,
                 'created': self.redeemable_policy.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                'bnr_enabled': False,
             },
         ]
 
@@ -555,6 +558,7 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
             'late_redemption_allowed_until': None,
             'is_late_redemption_allowed': False,
             'created': self.redeemable_policy.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+            'bnr_enabled': False,
         }
         self.assertEqual(expected_response, response.json())
 
@@ -671,6 +675,7 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
             'group_associations': [],
             'is_late_redemption_allowed': False,
             'created': policy_for_edit.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+            'bnr_enabled': False,
         }
 
         if 'retired' in request_payload:

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -372,9 +372,9 @@ class SubsidyAccessPolicy(TimeStampedModel):
     @property
     def bnr_enabled(self):
         """
-        Returns True if learner_credit_request_config exists, otherwise False.
+        Returns True if learner_credit_request_config exists and is active, otherwise False.
         """
-        return self.learner_credit_request_config and self.learner_credit_request_config.active
+        return bool(self.learner_credit_request_config and self.learner_credit_request_config.active)
 
     @classmethod
     def has_bnr_enabled_policy_for_enterprise(cls, enterprise_customer_uuid):


### PR DESCRIPTION
**Description:**
Added `bnr_enabled` field in `SubsidyAccessPolicyResponseSerializer`. Now api/v1/subsidy-access-policies/{policy_uuid}/ will return
```json
HTTP 200 OK
Allow: GET, PUT, PATCH, DELETE, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "uuid": "a12d4d9b-3d3b-4e5a-902d-a36d18a3fc82",
    "policy_type": "PerLearnerSpendCreditAccessPolicy",
    "display_name": "per learner credit access policy",
    "description": "per learner credit access policy for BNR",
    "active": true,
    "retired": false,
    "retired_at": null,
    "enterprise_customer_uuid": "7af27a1d-8012-4985-b89f-9c8bdd46b3a2",
    "catalog_uuid": "7802e2b4-2f62-4f80-a46c-963c06396377",
    "subsidy_uuid": "746d7570-811e-42c1-9a2e-e0801b266596",
    "access_method": "direct",
    "per_learner_enrollment_limit": null,
    "per_learner_spend_limit": 100,
    "spend_limit": 100,
    "subsidy_active_datetime": "2023-10-29T14:50:25Z",
    "subsidy_expiration_datetime": "2027-10-30T14:50:31Z",
    "is_subsidy_active": true,
    "aggregates": {
        "amount_redeemed_usd_cents": 0,
        "amount_redeemed_usd": 0.0,
        "amount_allocated_usd_cents": 0,
        "amount_allocated_usd": 0.0,
        "spend_available_usd_cents": 100,
        "spend_available_usd": 1.0
    },
    "assignment_configuration": null,
    "group_associations": [],
    "late_redemption_allowed_until": null,
    "is_late_redemption_allowed": false,
    "created": "2025-05-09T10:21:06.050466Z",
    "bnr_enabled": true
}
```

**Jira:**
ENT-XXXX

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
