### PR TITLE
fix: better serializer and API docs for provisioning

### DIFF
--- a/enterprise_access/apps/api/serializers/provisioning.py
+++ b/enterprise_access/apps/api/serializers/provisioning.py
@@ -3,6 +3,7 @@ Serializers for the provisioning app.
 """
 import logging
 
+from django.conf import settings
 from django_countries.serializer_fields import CountryField
 from rest_framework import serializers
 
@@ -56,7 +57,9 @@ class EnterpriseCatalogRequestSerializer(BaseSerializer):
     title = serializers.CharField(
         help_text='The name of the Enterprise Catalog.',
     )
-    catalog_query_id = serializers.IntegerField(
+    catalog_query_id = serializers.ChoiceField(
+        choices=settings.PROVISIONING_DEFAULTS['catalog']['all_catalog_query_choices'],
+        default=settings.PROVISIONING_DEFAULTS['subscription']['trial_catalog_query_choices'],
         help_text='The id of the related Catalog Query.',
     )
 
@@ -76,13 +79,29 @@ class SubscriptionPlanRequestSerializer(BaseSerializer):
     """
     Subscription Plan serializer for provisioning requests.
     """
-    title = serializers.CharField()
-    salesforce_opportunity_line_item = serializers.CharField()
-    start_date = serializers.DateTimeField()
-    expiration_date = serializers.DateTimeField()
-    product_id = serializers.IntegerField()
-    desired_num_licenses = serializers.IntegerField()
-    enterprise_catalog_uuid = serializers.UUIDField(required=False, allow_null=True)
+    title = serializers.CharField(
+        help_text='The title of the subscription plan.',
+    )
+    salesforce_opportunity_line_item = serializers.CharField(
+        help_text='The Salesforce Opportunity Line Item id associated with this subscription plan.',
+    )
+    start_date = serializers.DateTimeField(
+        help_text='The date and time at which the subscription plan becomes usable.',
+    )
+    expiration_date = serializers.DateTimeField(
+        help_text='The date and time at which the subscription plan becomes unusable.'
+    )
+    product_id = serializers.ChoiceField(
+        choices=settings.PROVISIONING_DEFAULTS['subscription']['all_product_choices'],
+        help_text='The internal edX Enterprise Subscription Product record.',
+    )
+    desired_num_licenses = serializers.IntegerField(
+        help_text='The number of licenses to create for this plan.'
+    )
+    enterprise_catalog_uuid = serializers.UUIDField(
+        required=False, allow_null=True, default=None,
+        help_text='Optional. The enterprise catalog uuid associated with this subscription plan.',
+    )
 
 
 class ProvisioningRequestSerializer(BaseSerializer):
@@ -101,6 +120,8 @@ class ProvisioningRequestSerializer(BaseSerializer):
     )
     customer_agreement = CustomerAgreementRequestSerializer(
         help_text='Object describing the requested Customer Agreement.',
+        required=False,
+        allow_null=True,
     )
     subscription_plan = SubscriptionPlanRequestSerializer()
 

--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -559,6 +559,10 @@ PROVISIONING_DEFAULTS = {
         'is_active': True,
         'product_id': 1,
         'for_internal_use_only': True,
+        'all_product_choices': [
+            (1, 'Standard Paid'),
+            (2, 'Trial'),
+        ],
         'trial_product_choices': [
             (1, 'Standard Paid'),
         ],
@@ -568,6 +572,9 @@ PROVISIONING_DEFAULTS = {
     },
     'catalog': {
         'catalog_query_id': 1,
+        'all_catalog_query_choices': [
+            (2, 'All open courses'),
+        ],
     },
 }
 


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-10519
* expose the valid product_id choices in API docs/serailizer.
* add help text to clarify where sf_opp_line_item should be drawn from.
* customer_agreement should be an optional object in the payload (with optional fields inside)
* expose valid catalog_query_id field in API docs/serializer.

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
