### PR TITLE
feat: optional catalog input during provisioning

### DIFF
--- a/enterprise_access/apps/api/serializers/provisioning.py
+++ b/enterprise_access/apps/api/serializers/provisioning.py
@@ -117,6 +117,8 @@ class ProvisioningRequestSerializer(BaseSerializer):
     )
     enterprise_catalog = EnterpriseCatalogRequestSerializer(
         help_text='Object describing the requested Enterprise Catalog.',
+        required=False,
+        allow_null=True,
     )
     customer_agreement = CustomerAgreementRequestSerializer(
         help_text='Object describing the requested Customer Agreement.',

--- a/enterprise_access/apps/api/v1/views/provisioning.py
+++ b/enterprise_access/apps/api/v1/views/provisioning.py
@@ -54,8 +54,8 @@ class ProvisioningCreateView(PermissionRequiredMixin, generics.CreateAPIView):
             record.get('user_email')
             for record in request_serializer.validated_data['pending_admins']
         ]
-        catalog_request_data = request_serializer.validated_data['enterprise_catalog']
-        customer_agreement_data = request_serializer.validated_data['customer_agreement']
+        catalog_request_data = request_serializer.validated_data.get('enterprise_catalog')
+        customer_agreement_data = request_serializer.validated_data.get('customer_agreement')
         subscription_plan_data = request_serializer.validated_data['subscription_plan']
 
         workflow_input_dict = ProvisionNewCustomerWorkflow.generate_input_dict(

--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -549,8 +549,6 @@ BRAZE_GROUPS_EMAIL_AUTO_REMINDER_DAY_85_CAMPAIGN = ''
 SALES_CONTRACT_REFERENCE_PROVIDER_NAME = 'Salesforce OpportunityLineItem'
 SALES_CONTRACT_REFERENCE_PROVIDER_SLUG = 'salesforce_opportunity_line_item'
 
-# Settings for creation of enterprise customers
-
 PROVISIONING_DEFAULTS = {
     'customer': {
         'site_domain': 'example.com',
@@ -578,6 +576,13 @@ PROVISIONING_DEFAULTS = {
     },
 }
 
+# Add a mapping from product_id to catalog_query_id
+PRODUCT_ID_TO_CATALOG_QUERY_ID_MAPPING = {
+    1: 1,  # Product 1 maps to catalog query 1
+    2: 2,
+    # Add more mappings as needed
+}
+
 CRISPY_ALLOWED_TEMPLATE_PACKS = "bootstrap5"
 CRISPY_TEMPLATE_PACK = "bootstrap5"
 
@@ -603,5 +608,6 @@ SSP_PRODUCTS = {
 
 # Enable the customer billing API endpoints under /api/v1/customer-billing/*
 ENABLE_CUSTOMER_BILLING_API = False
+STRIPE_API_KEY = None
 
 ################# End Self-Service Purchasing (SSP) settings #################

--- a/enterprise_access/settings/test.py
+++ b/enterprise_access/settings/test.py
@@ -75,3 +75,7 @@ KAFKA_TOPICS = [
     SUBSIDY_REDEMPTION_TOPIC_NAME,
 ]
 ################### End Kafka Related Settings ##############################
+
+PRODUCT_ID_TO_CATALOG_QUERY_ID_MAPPING = {
+    1: 42,
+}


### PR DESCRIPTION
The called of the subscription provisioning API is not required to specify the enterprise catalog record desired. If none is provided, we infer the catalog title based on a simple format, and infer the catalog query id based on the requested subscription plan product_id, which field *is* required. 

**Jira:**
ENT-10519

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
