### PR TITLE
update: add course_title and course_partners while creating LearnerCreditRequest

### DIFF
--- a/enterprise_access/apps/subsidy_request/tasks.py
+++ b/enterprise_access/apps/subsidy_request/tasks.py
@@ -28,11 +28,11 @@ def _get_course_partners(course_data):
 
 
 @shared_task(base=LoggedTaskWithRetry)
-def update_course_info_for_subsidy_request_task(subsidy_type, subsidy_request_uuid):
+def update_course_info_for_subsidy_request_task(model_name, subsidy_request_uuid):
     """
     Get course info (e.g. title, partners) from lms and update subsidy_request with it.
     """
-    subsidy_model = get_subsidy_model(subsidy_type)
+    subsidy_model = apps.get_model('subsidy_request', model_name)
     subsidy_request = subsidy_model.objects.get(uuid=subsidy_request_uuid)
 
     discovery_client = DiscoveryApiClient()


### PR DESCRIPTION
**Description:**
Previously, the async task to update `course_title` and `course_partners` was only triggered for `LicenseRequest` and `CouponCodeRequest` models. This meant that `LearnerCreditRequest` objects did not have their course metadata automatically populated after creation.

This PR updates the signal handler and async task invocation so that `LearnerCreditRequest` is also supported. Now, when a `LearnerCreditRequest` is created, the task will be triggered to fetch and update the `course_title` and `course_partners` fields, ensuring consistent metadata across all subsidy request types.

**Jira:**
ENT-XXXX

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
