### PR TITLE
feat: base support for unauthn'd BFF viewsets and response builders

### DIFF
--- a/enterprise_access/apps/api/v1/tests/test_bff_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_bff_views.py
@@ -9,6 +9,7 @@ from django.core.cache import cache as django_cache
 from pytest_dictsdiff import check_objects
 from rest_framework import status
 from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
 
 from enterprise_access.apps.api_client.tests.test_utils import MockLicenseManagerMetadataMixin
 from enterprise_access.apps.bffs.constants import COURSE_ENROLLMENT_STATUSES
@@ -1055,3 +1056,40 @@ class TestLearnerPortalBFFViewSet(TestHandlerContextMixin, MockLicenseManagerMet
         self.assertEqual(
             response_data.get('has_bnr_enabled_policy'), expected_response_data.get('has_bnr_enabled_policy')
         )
+
+
+@ddt.ddt
+class TestUnauthenticatedPingBFFViewSet(TestHandlerContextMixin, APITest):
+    """
+    Test the base, unauthenticated BFF ping endpoint
+    """
+    def setUp(self):
+        """
+        Set up test client and any necessary test data.
+        """
+        super().setUp()
+        self.client = APIClient()
+        # Explicitly ensure no authentication
+        self.client.force_authenticate(user=None)
+
+    def test_ping_endpoint_unauthenticated_request(self):
+        """
+        Test that the ping endpoint can be accessed without authentication
+        and returns the expected response structure.
+        """
+        url = reverse('api:v1:bff-health-ping')
+
+        response = self.client.get(url)
+
+        # Should succeed without authentication
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Verify response structure and content
+        expected_response = {
+            'message': 'pong',
+            'timestamp': mock.ANY,
+            'status': 'healthy',
+            'service': 'enterprise-access-bff',
+        }
+
+        self.assertEqual(response.json(), expected_response)

--- a/enterprise_access/apps/api/v1/urls.py
+++ b/enterprise_access/apps/api/v1/urls.py
@@ -38,6 +38,7 @@ if settings.ENABLE_CUSTOMER_BILLING_API:
 
 # BFFs
 router.register('bffs/learner', views.LearnerPortalBFFViewSet, 'learner-portal-bff')
+router.register('bffs/health', views.PingViewSet, 'bff-health')
 
 # Other endpoints
 urlpatterns = [

--- a/enterprise_access/apps/api/v1/views/__init__.py
+++ b/enterprise_access/apps/api/v1/views/__init__.py
@@ -3,6 +3,7 @@ Top-level views module for convenience of maintaining
 existing imports of browse and request AND access policy views.
 """
 from .admin_portal_learner_profile import AdminLearnerProfileViewSet
+from .bffs.common import PingViewSet
 from .bffs.learner_portal import LearnerPortalBFFViewSet
 from .browse_and_request import (
     CouponCodeRequestViewSet,

--- a/enterprise_access/apps/api/v1/views/bffs/common.py
+++ b/enterprise_access/apps/api/v1/views/bffs/common.py
@@ -1,17 +1,21 @@
 """
 Base classes for BFF views.
 """
-
 import logging
 from collections import OrderedDict
+from datetime import datetime
 
-from drf_spectacular.utils import OpenApiParameter, OpenApiTypes
+from django.utils import timezone
+from drf_spectacular.utils import OpenApiParameter, OpenApiTypes, extend_schema
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework import status
+from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.throttling import AnonRateThrottle
 from rest_framework.viewsets import ViewSet
 
-from enterprise_access.apps.bffs.context import HandlerContext
+from enterprise_access.apps.bffs.context import BaseHandlerContext, HandlerContext
 from enterprise_access.apps.bffs.serializers import BaseResponseSerializer
 
 logger = logging.getLogger(__name__)
@@ -35,21 +39,26 @@ COMMON_BFF_QUERY_PARAMETERS = [
 ]
 
 
-class BaseBFFViewSet(ViewSet):
+class BaseBFFViewSetMixin:
     """
-    Base class for BFF viewsets.
+    Mixin class containing common BFF viewset functionality.
     """
 
-    authentication_classes = [JwtAuthentication]
-    permission_classes = [IsAuthenticated]
-
-    def load_route_data_and_build_response(self, request, handler_class, response_builder_class):
+    def _create_context(self, request, context_class):
         """
-        Handles the route and builds the response.
+        Creates the appropriate context for the request.
+
+        Args:
+            request: The incoming HTTP request
+            context_class: The context class to instantiate
+
+        Returns:
+            tuple: (context_instance, error_response_data, error_status_code)
+            If successful, error_response_data and error_status_code will be None
         """
         try:
-            # Create the context based on the request
-            context = HandlerContext(request=request)
+            context = context_class(request=request)
+            return context, None, None
         except Exception as exc:  # pylint: disable=broad-except
             logger.exception("Could not instantiate the handler context for the request.")
             error = {
@@ -57,32 +66,62 @@ class BaseBFFViewSet(ViewSet):
                 'developer_message': f'Could not create the handler context. Error: {exc}',
             }
             response_data = BaseResponseSerializer({'errors': [error]}).data
-            return response_data, status.HTTP_500_INTERNAL_SERVER_ERROR
+            return None, response_data, status.HTTP_500_INTERNAL_SERVER_ERROR
 
+    def _instantiate_handler(self, handler_class, context):
+        """
+        Instantiates the route handler.
+
+        Args:
+            handler_class: The handler class to instantiate
+            context: The context instance
+
+        Returns:
+            handler instance or None if failed
+        """
         try:
-            # Create the route handler
-            handler = handler_class(context)
+            return handler_class(context)
         except Exception as exc:  # pylint: disable=broad-except
+            # Get user ID safely - may not exist for unauthenticated contexts
+            user_id = getattr(context, 'lms_user_id', 'unauthenticated')
+            enterprise_uuid = getattr(context, 'enterprise_customer_uuid', 'unknown')
+
             logger.exception(
                 "Could not instantiate route handler (%s) for request user %s and enterprise customer %s.",
                 handler_class.__name__,
-                context.lms_user_id,
-                context.enterprise_customer_uuid,
+                user_id,
+                enterprise_uuid,
             )
             context.add_error(
                 user_message='An error occurred while processing the request.',
                 developer_message=f'Could not instantiate route handler ({handler_class.__name__}). Error: {exc}',
             )
+            return None
+
+    def _process_handler(self, handler, handler_class, context):
+        """
+        Processes the route handler.
+
+        Args:
+            handler: The handler instance
+            handler_class: The handler class (for logging)
+            context: The context instance
+        """
+        if not handler:
+            return
 
         try:
-            # Load and process route data
             handler.load_and_process()
         except Exception as exc:  # pylint: disable=broad-except
+            # Get user ID safely - may not exist for unauthenticated contexts
+            user_id = getattr(context, 'lms_user_id', 'unauthenticated')
+            enterprise_uuid = getattr(context, 'enterprise_customer_uuid', 'unknown')
+
             logger.exception(
                 "Could not load/process route handler (%s) for request user %s and enterprise customer %s.",
                 handler_class.__name__,
-                context.lms_user_id,
-                context.enterprise_customer_uuid,
+                user_id,
+                enterprise_uuid,
             )
             context.add_error(
                 user_message='An error occurred while processing the request.',
@@ -91,9 +130,18 @@ class BaseBFFViewSet(ViewSet):
                 ),
             )
 
-        # Build the response data and status code
-        response_builder = response_builder_class(context)
+    def _build_response(self, context, response_builder_class):
+        """
+        Builds the response data and status code.
 
+        Args:
+            context: The context instance
+            response_builder_class: The response builder class
+
+        Returns:
+            tuple: (response_data, status_code)
+        """
+        response_builder = response_builder_class(context)
         response_builder.build()
         response_data, status_code = response_builder.serialize()
 
@@ -108,3 +156,120 @@ class BaseBFFViewSet(ViewSet):
         ordered_representation['enterprise_features'] = enterprise_features
 
         return dict(ordered_representation), status_code
+
+    def load_route_data_and_build_response(self, request, handler_class, response_builder_class, context_class):
+        """
+        Handles the route and builds the response with the specified context class.
+
+        Args:
+            request: The incoming HTTP request
+            handler_class: The handler class to use
+            response_builder_class: The response builder class to use
+            context_class: The context class to use
+
+        Returns:
+            tuple: (response_data, status_code)
+        """
+        # Create the context based on the request
+        context, error_response, error_status = self._create_context(request, context_class)
+        if context is None:
+            return error_response, error_status
+
+        # Create and process the route handler
+        handler = self._instantiate_handler(handler_class, context)
+        self._process_handler(handler, handler_class, context)
+
+        # Build and return the response
+        return self._build_response(context, response_builder_class)
+
+
+class BaseBFFViewSet(BaseBFFViewSetMixin, ViewSet):
+    """
+    Base class for authenticated BFF viewsets.
+    """
+
+    authentication_classes = [JwtAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def load_route_data_and_build_response(self, request, handler_class, response_builder_class):
+        """
+        Handles the route and builds the response using HandlerContext for authenticated requests.
+        """
+        return super().load_route_data_and_build_response(
+            request, handler_class, response_builder_class, HandlerContext
+        )
+
+
+class BFFAnonRateThrottle(AnonRateThrottle):
+    """
+    Custom anonymous rate throttle for BFF endpoints.
+    """
+    scope = 'bff_unauthenticated'
+
+
+class BaseUnauthenticatedBFFViewSet(BaseBFFViewSetMixin, ViewSet):
+    """
+    Base class for unauthenticated BFF viewsets.
+    Uses BaseHandlerContext which doesn't store customer or user data.
+    """
+
+    authentication_classes = []
+    permission_classes = []
+    throttle_classes = [BFFAnonRateThrottle]
+
+    def load_route_data_and_build_response(self, request, handler_class, response_builder_class):
+        """
+        Handles the route and builds the response using BaseHandlerContext for unauthenticated requests.
+        """
+        return super().load_route_data_and_build_response(
+            request, handler_class, response_builder_class, BaseHandlerContext
+        )
+
+
+class PingViewSet(BaseUnauthenticatedBFFViewSet):
+    """
+    Simple ping viewset for health checks and unauthenticated service availability testing.
+    """
+
+    @extend_schema(
+        operation_id='ping_health_check',
+        summary='Health Check Ping',
+        description='Simple ping endpoint to check if the BFF service is running and responsive.',
+        responses={
+            200: {
+                'type': 'object',
+                'properties': {
+                    'message': {'type': 'string'},
+                    'timestamp': {'type': 'string', 'format': 'date-time'},
+                    'status': {'type': 'string'},
+                    'service': {'type': 'string'},
+                },
+                'example': {
+                    'message': 'pong',
+                    'timestamp': '2025-06-11T15:31:27Z',
+                    'status': 'healthy',
+                    'service': 'enterprise-access-bff'
+                }
+            }
+        },
+        tags=['Health Check']
+    )
+    @action(detail=False, methods=['get'], url_path='ping')
+    def ping(self, request):
+        """
+        Simple ping endpoint that returns a pong response.
+
+        This endpoint can be used for:
+        - Health checks
+        - Service availability monitoring
+        - Load balancer health probes
+        - Basic connectivity testing
+        """
+        response_data = {
+            'message': 'pong',
+            'timestamp': timezone.now().isoformat() + 'Z',
+            'status': 'healthy',
+            'service': 'enterprise-access-bff',
+        }
+
+        return Response(response_data, status=status.HTTP_200_OK)

--- a/enterprise_access/apps/bffs/response_builder.py
+++ b/enterprise_access/apps/bffs/response_builder.py
@@ -98,6 +98,17 @@ class BaseResponseBuilder:
             return self.serializer_class(self.response_data).data, self.status_code
 
 
+class UnauthenticatedBaseResponseBuilder(BaseResponseBuilder):
+    """
+    A ResponseBuilder class for unauthenticated requests, where we don't
+    expect customer or user inputs or outputs to exist.
+    """
+    def build(self):
+        """
+        Does no enterprise- or user- specific action by default.
+        """
+
+
 class BaseLearnerResponseBuilder(BaseResponseBuilder, BaseLearnerDataMixin):
     """
     A base response builder class for learner-focused routes.

--- a/enterprise_access/apps/bffs/serializers.py
+++ b/enterprise_access/apps/bffs/serializers.py
@@ -162,7 +162,15 @@ class EnterpriseCustomerUserSerializer(BaseBffSerializer):
     active = serializers.BooleanField()
 
 
-class BaseResponseSerializer(BaseBffSerializer):
+class MinimalBffResponseSerializer(BaseBffSerializer):
+    """
+    Every response serializer should come with errors and warnings.
+    """
+    errors = ErrorSerializer(many=True, required=False, default=list)
+    warnings = WarningSerializer(many=True, required=False, default=list)
+
+
+class BaseResponseSerializer(MinimalBffResponseSerializer):
     """
     Serializer for base response.
     """
@@ -177,8 +185,6 @@ class BaseResponseSerializer(BaseBffSerializer):
         child=serializers.UUIDField(),
         help_text='Mapping of catalog UUIDs to catalog query UUIDs.',
     )
-    errors = ErrorSerializer(many=True, required=False, default=list)
-    warnings = WarningSerializer(many=True, required=False, default=list)
     enterprise_features = serializers.DictField(required=False, default=dict)
 
 

--- a/enterprise_access/apps/bffs/tests/test_response_builders.py
+++ b/enterprise_access/apps/bffs/tests/test_response_builders.py
@@ -4,10 +4,16 @@ from unittest.mock import MagicMock
 import ddt
 from pytest_dictsdiff import check_objects
 from rest_framework import status
+from rest_framework.serializers import Serializer
 
 from enterprise_access.apps.api_client.tests.test_license_manager_client import MockLicenseManagerMetadataMixin
-from enterprise_access.apps.bffs.response_builder import BaseLearnerResponseBuilder, BaseResponseBuilder
-from enterprise_access.apps.bffs.serializers import BaseResponseSerializer
+from enterprise_access.apps.bffs.context import BaseHandlerContext
+from enterprise_access.apps.bffs.response_builder import (
+    BaseLearnerResponseBuilder,
+    BaseResponseBuilder,
+    UnauthenticatedBaseResponseBuilder
+)
+from enterprise_access.apps.bffs.serializers import BaseResponseSerializer, MinimalBffResponseSerializer
 from enterprise_access.apps.bffs.tests.utils import TestHandlerContextMixin
 
 
@@ -224,3 +230,180 @@ class TestBaseLearnerResponseBuilder(TestBaseResponseBuilder, MockLicenseManager
 
         self.assertEqual(response_data, expected_response)
         self.assertEqual(status_code, status.HTTP_200_OK)
+
+
+class MockUnauthenticatedBaseResponseBuilder(UnauthenticatedBaseResponseBuilder):
+    """
+    Test UnauthenticatedBaseResponseBuilder implementation.
+    """
+    serializer_class = MinimalBffResponseSerializer
+
+
+@ddt.ddt
+class TestUnauthenticatedBaseResponseBuilder(TestHandlerContextMixin):
+    """
+    Tests for UnauthenticatedBaseResponseBuilder with unauthenticated requests using BaseHandlerContext.
+    """
+
+    def get_mock_base_handler_context(self, data=None, errors=None, warnings=None, _status_code=None):
+        """
+        Creates a mock BaseHandlerContext for testing unauthenticated scenarios.
+
+        Args:
+            data (dict): Data to store in the context
+            errors (list): List of errors
+            warnings (list): List of warnings
+            _status_code (int): HTTP status code
+
+        Returns:
+            MagicMock: BaseHandlerContext instance
+        """
+        mock_context = BaseHandlerContext(request=MagicMock())
+        mock_context.data = data or {}
+        mock_context._errors = errors or []
+        mock_context._warnings = warnings or []
+        mock_context._status_code = _status_code or status.HTTP_200_OK
+
+        return mock_context
+
+    @mock.patch('enterprise_access.apps.bffs.context.BaseHandlerContext')
+    def test_unauthenticated_build_empty_response(self, mock_base_handler_context):
+        """
+        Test UnauthenticatedBaseResponseBuilder builds an empty response by default.
+        Since build() does nothing, the response should only contain errors and warnings.
+        """
+        mock_base_handler_context.return_value = self.get_mock_base_handler_context()
+        mock_context_instance = mock_base_handler_context.return_value
+
+        response_builder = MockUnauthenticatedBaseResponseBuilder(mock_context_instance)
+        response_builder.build()
+        response_builder.add_errors_warnings_to_response()
+        response_data, status_code = response_builder.serialize()
+
+        # Since build() does nothing, we expect a minimal response with just errors/warnings
+        expected_response_data = {
+            'errors': [],
+            'warnings': [],
+        }
+
+        self.assertEqual(status_code, status.HTTP_200_OK)
+        assert check_objects(response_data, expected_response_data)
+
+    @mock.patch('enterprise_access.apps.bffs.context.BaseHandlerContext')
+    def test_unauthenticated_build_with_context_data_ignored(self, mock_base_handler_context):
+        """
+        Test that UnauthenticatedBaseResponseBuilder ignores any data in the context.
+        Even if context has data, build() does nothing so it won't be included in response.
+        """
+        # Add some data to context that would normally be used
+        mock_context_data = {
+            'some_public_data': {'key': 'value'},
+            'enterprise_features': {'public_feature': True},
+        }
+
+        mock_base_handler_context.return_value = self.get_mock_base_handler_context(
+            data=mock_context_data,
+        )
+        mock_context_instance = mock_base_handler_context.return_value
+
+        response_builder = MockUnauthenticatedBaseResponseBuilder(mock_context_instance)
+        response_builder.build()
+        response_builder.add_errors_warnings_to_response()
+        response_data, status_code = response_builder.serialize()
+
+        # Data in context should be ignored since build() does nothing
+        expected_response_data = {
+            'errors': [],
+            'warnings': [],
+        }
+
+        self.assertEqual(status_code, status.HTTP_200_OK)
+        assert check_objects(response_data, expected_response_data)
+
+    @ddt.data(
+        {
+            'errors': [{'user_message': 'Rate limit exceeded', 'developer_message': 'Too many requests'}],
+            'warnings': [],
+            'status_code': status.HTTP_429_TOO_MANY_REQUESTS
+        },
+        {
+            'errors': [],
+            'warnings': [{'user_message': 'Service degraded', 'developer_message': 'Using fallback data'}],
+            'status_code': status.HTTP_200_OK
+        },
+        {
+            'errors': [{'user_message': 'Service unavailable', 'developer_message': 'External API down'}],
+            'warnings': [{'user_message': 'Limited functionality', 'developer_message': 'Some features disabled'}],
+            'status_code': status.HTTP_503_SERVICE_UNAVAILABLE
+        }
+    )
+    @mock.patch('enterprise_access.apps.bffs.context.BaseHandlerContext')
+    @ddt.unpack
+    def test_unauthenticated_build_with_errors_warnings(self, mock_base_handler_context, errors, warnings, status_code):
+        """
+        Test UnauthenticatedBaseResponseBuilder properly includes errors and warnings.
+        Even though build() does nothing, errors and warnings should still be included.
+        """
+        mock_base_handler_context.return_value = self.get_mock_base_handler_context(
+            errors=errors,
+            warnings=warnings,
+            _status_code=status_code
+        )
+        mock_context_instance = mock_base_handler_context.return_value
+
+        response_builder = MockUnauthenticatedBaseResponseBuilder(mock_context_instance)
+        response_builder.build()
+        response_builder.add_errors_warnings_to_response()
+        response_data, response_status_code = response_builder.serialize()
+
+        expected_response_data = {
+            'errors': errors,
+            'warnings': warnings,
+        }
+
+        self.assertEqual(response_status_code, status_code)
+        assert check_objects(response_data, expected_response_data)
+
+    @mock.patch('enterprise_access.apps.bffs.context.BaseHandlerContext')
+    def test_unauthenticated_status_code_from_context(self, mock_base_handler_context):
+        """
+        Test that UnauthenticatedBaseResponseBuilder properly returns status code from context.
+        """
+        test_status_code = status.HTTP_202_ACCEPTED
+
+        mock_base_handler_context.return_value = self.get_mock_base_handler_context(
+            _status_code=test_status_code
+        )
+        mock_context_instance = mock_base_handler_context.return_value
+
+        response_builder = MockUnauthenticatedBaseResponseBuilder(mock_context_instance)
+
+        # Status code should come from context
+        self.assertEqual(response_builder.status_code, test_status_code)
+
+    @mock.patch('enterprise_access.apps.bffs.context.BaseHandlerContext')
+    def test_unauthenticated_multiple_builds_safe(self, mock_base_handler_context):
+        """
+        Test that calling build multiple times is safe and doesn't cause issues.
+        """
+        mock_base_handler_context.return_value = self.get_mock_base_handler_context()
+        mock_context_instance = mock_base_handler_context.return_value
+
+        response_builder = MockUnauthenticatedBaseResponseBuilder(mock_context_instance)
+
+        # Call build multiple times
+        response_builder.build()
+        response_builder.build()
+        response_builder.build()
+
+        # Should still work fine
+        response_builder.add_errors_warnings_to_response()
+        response_data, status_code = response_builder.serialize()
+
+        expected_response_data = {
+            'errors': [],
+            'warnings': [],
+        }
+
+        self.assertEqual(status_code, status.HTTP_200_OK)
+        assert check_objects(response_data, expected_response_data)

--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -175,6 +175,9 @@ REST_FRAMEWORK = {
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     'PAGE_SIZE': 100,
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
+    'DEFAULT_THROTTLE_RATES': {
+        'bff_unauthenticated': '100/hour',
+    },
 }
 
 # DRF Spectacular settings


### PR DESCRIPTION
ENT-10475

* Support unauthenticated BFF viewset with anon-throttling.
* Adds a `api/v1/bffs/health/ping` endpoint to test connectivity.
* Refactors base context class to support a version that has no customer or user in context.
* Defines a new response builder intended for use with Unauthenticated request flows.

You should be able to hit this without authenticating: http://localhost:18270/api/v1/bffs/health/ping/

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
