### PR TITLE
fix: add mapping to exception string for debugging

### DIFF
--- a/enterprise_access/apps/provisioning/models.py
+++ b/enterprise_access/apps/provisioning/models.py
@@ -259,7 +259,8 @@ class GetCreateCatalogStep(AbstractWorkflowStep):
             return settings.PRODUCT_ID_TO_CATALOG_QUERY_ID_MAPPING[product_id]
         else:
             raise CreateCatalogStepException(
-                f"Cannot infer catalog_query_id: product_id {product_id} not found in mapping"
+                f"Cannot infer catalog_query_id: product_id {product_id} "
+                f"not found in mapping: {settings.PRODUCT_ID_TO_CATALOG_QUERY_ID_MAPPING}"
             )
 
     def get_workflow_record(self):


### PR DESCRIPTION
Trying to determine the state of the mapping in stage/prod, getting this exception even though we deployed settings to set the mapping and product_id `1` is supposedly included in it.
```
enterprise_access.apps.provisioning.models.CreateCatalogStepException: Cannot infer catalog_query_id: product_id 1 not found in mapping
```

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
