### PR TITLE
fix: map product id strings to catalog query ids, b/c yaml

### DIFF
--- a/enterprise_access/apps/provisioning/models.py
+++ b/enterprise_access/apps/provisioning/models.py
@@ -253,7 +253,7 @@ class GetCreateCatalogStep(AbstractWorkflowStep):
             return catalog_query_id_input
 
         # Need to get product_id from subscription plan input to infer catalog_query_id
-        product_id = workflow_input.create_subscription_plan_input.product_id
+        product_id = str(workflow_input.create_subscription_plan_input.product_id)
 
         if product_id and product_id in settings.PRODUCT_ID_TO_CATALOG_QUERY_ID_MAPPING:
             return settings.PRODUCT_ID_TO_CATALOG_QUERY_ID_MAPPING[product_id]

--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -577,9 +577,13 @@ PROVISIONING_DEFAULTS = {
 }
 
 # Add a mapping from product_id to catalog_query_id
+# we type the keys as strings instead of ints and have related
+# code look up by str(the_value) to avoid any complications
+# with loading environment settings from yaml, where the keys
+# may *always* be safely-loaded as strings.
 PRODUCT_ID_TO_CATALOG_QUERY_ID_MAPPING = {
-    1: 1,  # Product 1 maps to catalog query 1
-    2: 2,
+    '1': 1,  # Product 1 maps to catalog query 1
+    '2': 2,
     # Add more mappings as needed
 }
 

--- a/enterprise_access/settings/test.py
+++ b/enterprise_access/settings/test.py
@@ -77,5 +77,5 @@ KAFKA_TOPICS = [
 ################### End Kafka Related Settings ##############################
 
 PRODUCT_ID_TO_CATALOG_QUERY_ID_MAPPING = {
-    1: 42,
+    '1': 42,
 }


### PR DESCRIPTION
Change the mapping from product_id to catalog_query_id as follows:
type the keys as strings instead of ints and have related
code look up by str(the_value) to avoid any complications
with loading environment settings from yaml, where the keys
may *always* be safely-loaded as strings.

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
