### PR TITLE
feat: API to Approve Learner Credit Request

### DIFF
--- a/enterprise_access/apps/api/serializers/__init__.py
+++ b/enterprise_access/apps/api/serializers/__init__.py
@@ -45,6 +45,7 @@ from .subsidy_access_policy import (
 )
 from .subsidy_requests import (
     CouponCodeRequestSerializer,
+    LearnerCreditRequestApproveRequestSerializer,
     LearnerCreditRequestDeclineSerializer,
     LearnerCreditRequestSerializer,
     LicenseRequestSerializer,

--- a/enterprise_access/apps/api/serializers/subsidy_requests.py
+++ b/enterprise_access/apps/api/serializers/subsidy_requests.py
@@ -302,3 +302,35 @@ class LearnerCreditRequestDeclineSerializer(serializers.Serializer):
         Not implemented - this serializer is for validation only
         """
         raise NotImplementedError("This serializer is for validation only")
+
+
+class LearnerCreditRequestApproveRequestSerializer(serializers.Serializer):
+    """
+    Request Serializer to validate subsidy-request ``approve`` endpoint POST data.
+
+    For view: LearnerCreditRequestViewSet.approve
+    """
+    policy_uuid = serializers.UUIDField(
+        required=True,
+        help_text='The UUID of the policy to which the request belongs.',
+    )
+    enterprise_customer_uuid = serializers.UUIDField(
+        required=True,
+        help_text='The UUID of the Enterprise Customer.',
+    )
+    learner_credit_request_uuid = serializers.UUIDField(
+        required=True,
+        help_text='The UUID of the LearnerCreditRequest to be approved.',
+    )
+
+    def create(self, validated_data):
+        """
+        Not implemented - this serializer is for validation only
+        """
+        raise NotImplementedError("This serializer is for validation only")
+
+    def update(self, instance, validated_data):
+        """
+        Not implemented - this serializer is for validation only
+        """
+        raise NotImplementedError("This serializer is for validation only")

--- a/enterprise_access/apps/api/v1/views/browse_and_request.py
+++ b/enterprise_access/apps/api/v1/views/browse_and_request.py
@@ -44,6 +44,8 @@ from enterprise_access.apps.api.utils import (
 from enterprise_access.apps.api_client.ecommerce_client import EcommerceApiClient
 from enterprise_access.apps.api_client.license_manager_client import LicenseManagerApiClient
 from enterprise_access.apps.core import constants
+from enterprise_access.apps.subsidy_access_policy.api import approve_learner_credit_request_via_policy
+from enterprise_access.apps.subsidy_access_policy.exceptions import SubisidyAccessPolicyRequestApprovalError
 from enterprise_access.apps.subsidy_access_policy.models import SubsidyAccessPolicy
 from enterprise_access.apps.subsidy_request.constants import (
     LearnerCreditRequestActionErrorReasons,
@@ -64,7 +66,7 @@ from enterprise_access.apps.subsidy_request.utils import (
     get_user_message_choice
 )
 from enterprise_access.apps.track.segment import track_event
-from enterprise_access.utils import get_subsidy_model
+from enterprise_access.utils import format_traceback, get_subsidy_model
 
 from .utils import PaginationWithPageCount
 
@@ -716,6 +718,11 @@ class CouponCodeRequestViewSet(SubsidyRequestViewSet):
         tags=['Learner Credit Requests'],
         summary='Create a learner credit request.',
     ),
+    approve=extend_schema(
+        tags=['Learner Credit Requests'],
+        summary='Approve a learner credit request.',
+        request=serializers.LearnerCreditRequestApproveRequestSerializer,
+    ),
     overview=extend_schema(
         tags=['Learner Credit Requests'],
         summary='Learner credit request overview.',
@@ -828,6 +835,72 @@ class LearnerCreditRequestViewSet(SubsidyRequestViewSet):
                     logger.warning(f"LearnerCreditRequest {lcr_uuid} not found for action creation.")
 
         return response
+
+    @permission_required(
+        constants.REQUESTS_ADMIN_ACCESS_PERMISSION,
+        fn=get_enterprise_uuid_from_request_data,
+    )
+    @action(detail=False, url_path='approve', methods=['post'])
+    def approve(self, request, *args, **kwargs):
+        """
+        Approve a learner credit request.
+        """
+        # Validate the request data
+        serializer = serializers.LearnerCreditRequestApproveRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        learner_credit_request_uuid = serializer.data['learner_credit_request_uuid']
+        policy_uuid = serializer.data['policy_uuid']
+
+        lc_request = LearnerCreditRequest.objects.select_related('user').get(
+            uuid=learner_credit_request_uuid,
+        )
+
+        learner_email = lc_request.user.email
+        content_key = lc_request.course_id
+        content_price_cents = lc_request.course_price
+
+        # Log "approve" as recent action in the Request Action model.
+        lc_request_action = LearnerCreditRequestActions.create_action(
+            learner_credit_request=lc_request,
+            recent_action=get_action_choice(SubsidyRequestStates.APPROVED),
+            status=get_user_message_choice(SubsidyRequestStates.APPROVED),
+        )
+
+        try:
+            with transaction.atomic():
+                # Validate the policy, once validated, approve the request by creating a content assignment.
+                learner_credit_request_assignment = approve_learner_credit_request_via_policy(
+                    policy_uuid,
+                    content_key,
+                    content_price_cents,
+                    learner_email,
+                    lc_request.user.lms_user_id
+                )
+                # link allocated assignment to the request
+                lc_request.assignment = learner_credit_request_assignment
+                lc_request.save()
+                lc_request.approve(request.user)
+            # todo: Add logic to send approval email to the learner.
+            response_data = serializers.LearnerCreditRequestSerializer(lc_request).data
+            return Response(
+                response_data,
+                status=status.HTTP_200_OK,
+            )
+        except SubisidyAccessPolicyRequestApprovalError as exc:
+            error_msg = (
+                f"[LC REQUEST APPROVAL] Failed to approve learner credit request "
+                f"with UUID {learner_credit_request_uuid}. Reason: {exc.message}."
+            )
+            logger.exception(error_msg)
+
+            # Update approve action with error reason.
+            lc_request_action.status = get_user_message_choice(SubsidyRequestStates.REQUESTED)
+            lc_request_action.error_reason = get_error_reason_choice(
+                LearnerCreditRequestActionErrorReasons.FAILED_APPROVAL
+            )
+            lc_request_action.traceback = format_traceback(exc)
+            lc_request_action.save()
+            return Response({"detail": error_msg}, exc.status_code)
 
     @permission_required(
         constants.REQUESTS_ADMIN_ACCESS_PERMISSION,

--- a/enterprise_access/apps/subsidy_access_policy/api.py
+++ b/enterprise_access/apps/subsidy_access_policy/api.py
@@ -1,7 +1,23 @@
 """
 Python API for interacting with SubsidyAccessPolicy records.
 """
+import logging
+
+from django.core.exceptions import ValidationError
+from django.db import DatabaseError
+from requests.exceptions import HTTPError
+from rest_framework import status
+
+from enterprise_access.apps.content_assignments.api import AllocationException
+
+from .exceptions import (
+    PriceValidationError,
+    SubisidyAccessPolicyRequestApprovalError,
+    SubsidyAccessPolicyLockAttemptFailed
+)
 from .models import SubsidyAccessPolicy
+
+logger = logging.getLogger(__name__)
 
 
 def get_subsidy_access_policy(uuid):
@@ -13,3 +29,87 @@ def get_subsidy_access_policy(uuid):
         return SubsidyAccessPolicy.objects.get(uuid=uuid)
     except SubsidyAccessPolicy.DoesNotExist:
         return None
+
+
+def approve_learner_credit_request_via_policy(
+    policy_uuid,
+    content_key,
+    content_price_cents,
+    learner_email,
+    lms_user_id,
+):
+    """
+    Approves a Learner Credit Request via the specified SubsidyAccessPolicy.
+    If the policy does not exist, raises a `SubisidyAccessPolicyRequestApprovalError`.
+    If the content key, learner email, or content price is not provided,
+    raises a `SubisidyAccessPolicyRequestApprovalError`.
+    If the request cannot be approved via policy, raises a `SubisidyAccessPolicyRequestApprovalError`
+    If the policy is successfully approved, returns a `LearnerCreditRequestAssignment`
+    object.
+    """
+    policy = get_subsidy_access_policy(policy_uuid)
+    if not policy:
+        error_msg = f"Policy with UUID {policy_uuid} does not exist."
+        logger.error(error_msg)
+        raise SubisidyAccessPolicyRequestApprovalError(message=error_msg, status_code=status.HTTP_404_NOT_FOUND)
+
+    if not content_key or not learner_email or content_price_cents is None:
+        error_msg = (
+            "Content key, learner email, and content price must be provided."
+        )
+        logger.error(error_msg)
+        raise SubisidyAccessPolicyRequestApprovalError(
+            message=error_msg,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
+        )
+    try:
+        with policy.lock():
+            can_approve, reason = policy.can_approve(
+                content_key,
+                content_price_cents,
+            )
+            if can_approve:
+                learner_credit_request_assignment = policy.approve(
+                    learner_email,
+                    content_key,
+                    content_price_cents,
+                    lms_user_id,
+                )
+                if not learner_credit_request_assignment:
+                    error_msg = (
+                        f"Failed to create an assignment while approving request for learner: "
+                        f"{learner_email} with content key: {content_key} and price: {content_price_cents}"
+                    )
+                    logger.error(error_msg)
+                    raise SubisidyAccessPolicyRequestApprovalError(
+                        message=error_msg,
+                        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
+                    )
+                return learner_credit_request_assignment
+            if reason:
+                raise SubisidyAccessPolicyRequestApprovalError(
+                    message=reason,
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
+                )
+            # If we reach here, can_approve is False but no reason was provided
+            raise SubisidyAccessPolicyRequestApprovalError(
+                message="Request cannot be approved by this policy",
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
+            )
+    except SubsidyAccessPolicyLockAttemptFailed as exc:
+        logger.exception(exc)
+        error_msg = (
+            f"Failed to acquire lock for policy UUID {policy_uuid}. "
+            "Please try again later."
+        )
+        raise SubisidyAccessPolicyRequestApprovalError(
+            message=error_msg,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
+        ) from exc
+    except (AllocationException, PriceValidationError, ValidationError, DatabaseError,
+            HTTPError, ConnectionError) as exc:
+        logger.exception(exc)
+        raise SubisidyAccessPolicyRequestApprovalError(
+            message=str(exc),
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
+        ) from exc

--- a/enterprise_access/apps/subsidy_access_policy/constants.py
+++ b/enterprise_access/apps/subsidy_access_policy/constants.py
@@ -132,3 +132,5 @@ GROUP_MEMBERS_WITH_AGGREGATES_DEFAULT_PAGE_SIZE = 10
 VALIDATION_ERROR_SPEND_LIMIT_EXCEEDS_STARTING_BALANCE = "You cannot make this change, as the sum of all budget \
 spend_limits for a given subsidy would exceed the sum of all deposits into that subsidy.  If you are trying to \
 re-balance policies, FIRST reduce the spend_limit of one, THEN increase the spend_limit of another."
+
+REASON_BNR_NOT_ENABLED = "This policy does not support BNR."

--- a/enterprise_access/apps/subsidy_access_policy/exceptions.py
+++ b/enterprise_access/apps/subsidy_access_policy/exceptions.py
@@ -11,6 +11,16 @@ class SubsidyAccessPolicyException(Exception):
     """
 
 
+class SubisidyAccessPolicyRequestApprovalError(Exception):
+    """
+    Raised when an error occurs while approving a Learner Credit Request.
+    """
+    def __init__(self, message, status_code=None):
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
 class UnredeemableContentException(SubsidyAccessPolicyException):
     """
     Raised from any exceptional state that causes content to not be redeemable.

--- a/enterprise_access/apps/subsidy_access_policy/tests/test_api.py
+++ b/enterprise_access/apps/subsidy_access_policy/tests/test_api.py
@@ -1,0 +1,234 @@
+"""
+Tests for the ``api.py`` module of the content_assignments app.
+"""
+from unittest import mock
+from uuid import uuid4
+
+import ddt
+from django.core.exceptions import ValidationError
+from django.db import DatabaseError
+from django.test import TestCase
+from requests.exceptions import HTTPError
+from rest_framework import status
+
+from enterprise_access.apps.content_assignments.api import AllocationException
+from enterprise_access.apps.content_assignments.models import LearnerContentAssignment
+from enterprise_access.apps.content_assignments.tests.factories import LearnerContentAssignmentFactory
+from enterprise_access.apps.core.tests.factories import UserFactory
+from enterprise_access.apps.subsidy_access_policy.api import approve_learner_credit_request_via_policy
+from enterprise_access.apps.subsidy_access_policy.constants import REASON_CONTENT_NOT_IN_CATALOG
+from enterprise_access.apps.subsidy_access_policy.exceptions import (
+    PriceValidationError,
+    SubisidyAccessPolicyRequestApprovalError,
+    SubsidyAccessPolicyLockAttemptFailed
+)
+from enterprise_access.apps.subsidy_access_policy.tests.factories import (
+    PerLearnerSpendCapLearnerCreditAccessPolicyFactory
+)
+
+
+@ddt.ddt
+class SubsidyAccessPolicyApiTests(TestCase):
+    """
+    Tests for the APIs in the subsidy_access_policy app.
+    """
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+        self.enterprise_customer_uuid_1 = "12345678-1234-5678-1234-567812345678"
+        self.policy = PerLearnerSpendCapLearnerCreditAccessPolicyFactory(
+            enterprise_customer_uuid=self.enterprise_customer_uuid_1,
+            active=True,
+            retired=False,
+            per_learner_spend_limit=0,  # For B&R budget, limit should be set to 0.
+            spend_limit=4000,
+        )
+
+    @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.approve')
+    @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.can_approve')
+    def test_approve_learner_credit_request_via_policy_success(self, mock_can_approve, mock_approve):
+        """
+        Test that if a learner credit request is approved, the correct
+        assignment is returned.
+        """
+        content_key = "test_content_key"
+        content_price_cents = 1000
+        learner_email = "test_learner@example.com"
+        lms_user_id = "12345678"
+
+        mock_can_approve.return_value = True, None
+        mock_approve.return_value = LearnerContentAssignmentFactory(
+            content_quantity=content_price_cents * -1,
+            state='allocated',
+            learner_email=learner_email,
+            lms_user_id=lms_user_id,
+            content_key=content_key,
+        )
+
+        result = approve_learner_credit_request_via_policy(
+            policy_uuid=self.policy.uuid,
+            content_key=content_key,
+            content_price_cents=content_price_cents,
+            learner_email=learner_email,
+            lms_user_id=lms_user_id,
+        )
+
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, LearnerContentAssignment)
+        self.assertEqual(result.content_key, content_key)
+        self.assertEqual(result.content_quantity, content_price_cents * -1)
+        self.assertEqual(result.state, 'allocated')
+        self.assertEqual(result.learner_email, learner_email)
+        self.assertEqual(result.lms_user_id, lms_user_id)
+
+    def test_approve_learner_credit_request_via_policy_nonexistent_policy(self):
+        """
+        Test that if a policy does not exist, the correct exception is raised.
+        """
+        nonexistent_policy_uuid = str(uuid4())
+
+        with self.assertRaises(SubisidyAccessPolicyRequestApprovalError) as context:
+            approve_learner_credit_request_via_policy(
+                policy_uuid=nonexistent_policy_uuid,
+                content_key="test_content_key",
+                content_price_cents=1000,
+                learner_email="test@example.com",
+                lms_user_id="12345678",
+            )
+
+        self.assertEqual(context.exception.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertIn(f"Policy with UUID {nonexistent_policy_uuid} does not exist", str(context.exception))
+
+    @ddt.data(
+        (None, "test@example.com", 1000),  # Missing content_key
+        ("", "test@example.com", 1000),    # Empty content_key
+        ("test_content_key", None, 1000),  # Missing learner_email
+        ("test_content_key", "", 1000),    # Empty learner_email
+        ("test_content_key", "test@example.com", None),  # Missing content_price_cents
+    )
+    @ddt.unpack
+    def test_approve_learner_credit_request_via_policy_missing_required_params(
+        self, content_key, learner_email, content_price_cents
+    ):
+        """
+        Test that if required parameters are missing or empty, the correct exception is raised.
+        """
+        with self.assertRaises(SubisidyAccessPolicyRequestApprovalError) as context:
+            approve_learner_credit_request_via_policy(
+                policy_uuid=self.policy.uuid,
+                content_key=content_key,
+                content_price_cents=content_price_cents,
+                learner_email=learner_email,
+                lms_user_id="12345678",
+            )
+
+        self.assertEqual(context.exception.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertIn("Content key, learner email, and content price must be provided", str(context.exception))
+
+    @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.can_approve')
+    def test_approve_learner_credit_request_via_policy_cannot_approve_with_reason(self, mock_can_approve):
+        """
+        Test that if can_approve returns False with a reason, the correct exception is raised.
+        """
+        reason = REASON_CONTENT_NOT_IN_CATALOG
+        mock_can_approve.return_value = False, reason
+
+        with self.assertRaises(SubisidyAccessPolicyRequestApprovalError) as context:
+            approve_learner_credit_request_via_policy(
+                policy_uuid=self.policy.uuid,
+                content_key="test_content_key",
+                content_price_cents=1000,
+                learner_email="test@example.com",
+                lms_user_id="12345678",
+            )
+
+        self.assertEqual(context.exception.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(str(context.exception), reason)
+
+    @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.approve')
+    @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.can_approve')
+    def test_approve_learner_credit_request_via_policy_approve_returns_none(self, mock_can_approve, mock_approve):
+        """
+        Test that if policy.approve() returns None, the correct exception is raised.
+        """
+        mock_can_approve.return_value = True, None
+        mock_approve.return_value = None
+
+        with self.assertRaises(SubisidyAccessPolicyRequestApprovalError) as context:
+            approve_learner_credit_request_via_policy(
+                policy_uuid=self.policy.uuid,
+                content_key="test_content_key",
+                content_price_cents=1000,
+                learner_email="test@example.com",
+                lms_user_id="12345678",
+            )
+
+        self.assertEqual(context.exception.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertIn("Failed to create an assignment while approving request", str(context.exception))
+
+    @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.lock')
+    def test_approve_learner_credit_request_via_policy_lock_failed(self, mock_lock):
+        """
+        Test that if acquiring the policy lock fails, the correct exception is raised.
+        """
+        mock_lock.side_effect = SubsidyAccessPolicyLockAttemptFailed("Lock acquisition failed")
+
+        with self.assertRaises(SubisidyAccessPolicyRequestApprovalError) as context:
+            approve_learner_credit_request_via_policy(
+                policy_uuid=self.policy.uuid,
+                content_key="test_content_key",
+                content_price_cents=1000,
+                learner_email="test@example.com",
+                lms_user_id="12345678",
+            )
+
+        self.assertEqual(context.exception.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertIn(f"Failed to acquire lock for policy UUID {self.policy.uuid}", str(context.exception))
+
+    @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.can_approve')
+    @ddt.data(
+        AllocationException("Allocation failed"),
+        PriceValidationError("Price validation failed"),
+        ValidationError("Validation error"),
+        DatabaseError("Database error"),
+        HTTPError("HTTP error"),
+        ConnectionError("Connection error"),
+    )
+    def test_approve_learner_credit_request_via_policy_exceptions(self, exception, mock_can_approve):
+        """
+        Test that various exceptions are properly caught and re-raised as SubsidyAccessPolicyRequestApprovalError.
+        """
+        mock_can_approve.side_effect = exception
+
+        with self.assertRaises(SubisidyAccessPolicyRequestApprovalError) as context:
+            approve_learner_credit_request_via_policy(
+                policy_uuid=self.policy.uuid,
+                content_key="test_content_key",
+                content_price_cents=1000,
+                learner_email="test@example.com",
+                lms_user_id="12345678",
+            )
+
+        self.assertEqual(context.exception.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(str(context.exception), str(exception))
+
+    @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.approve')
+    @mock.patch('enterprise_access.apps.subsidy_access_policy.models.SubsidyAccessPolicy.can_approve')
+    def test_approve_learner_credit_request_via_policy_approve_exception(self, mock_can_approve, mock_approve):
+        """
+        Test that exceptions raised during policy.approve() are properly handled.
+        """
+        mock_can_approve.return_value = True, None
+        mock_approve.side_effect = AllocationException("Allocation failed during approval")
+
+        with self.assertRaises(SubisidyAccessPolicyRequestApprovalError) as context:
+            approve_learner_credit_request_via_policy(
+                policy_uuid=self.policy.uuid,
+                content_key="test_content_key",
+                content_price_cents=1000,
+                learner_email="test@example.com",
+                lms_user_id="12345678",
+            )
+
+        self.assertEqual(context.exception.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(str(context.exception), "Allocation failed during approval")

--- a/enterprise_access/apps/subsidy_request/tests/factories.py
+++ b/enterprise_access/apps/subsidy_request/tests/factories.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 import factory
 from faker import Faker
 
+from enterprise_access.apps.content_assignments.tests.factories import LearnerContentAssignmentFactory
 from enterprise_access.apps.core.tests.factories import UserFactory
 from enterprise_access.apps.subsidy_request.constants import SubsidyRequestStates, SubsidyTypeChoices
 from enterprise_access.apps.subsidy_request.models import (
@@ -93,6 +94,7 @@ class LearnerCreditRequestFactory(SubsidyRequestFactory):
     Test factory for the `LearnerCreditRequest` model.
     """
     learner_credit_request_config = factory.SubFactory(LearnerCreditRequestConfigurationFactory)
+    assignment = factory.SubFactory(LearnerContentAssignmentFactory)
 
     class Meta:
         model = LearnerCreditRequest


### PR DESCRIPTION
**Description:**
This PR introduces an API endpoint to approve a Learner Credit Request, which will be invoked from the Admin Portal when an admin approves a request.

**Implementation details:**

- Validates whether a request can be approved using the existing "can_allocate" functionality.
- Allocates a content assignment to the learner using existing logic.
- Associates the assignment with the learner credit request.
- Updates the request’s status to APPROVED.
- Logs the action in the LearnerCreditRequestActions model for auditing purposes.

**Jira:**
https://2u-internal.atlassian.net/browse/ENT-10347 

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance