### PR TITLE
feat: more transparent spend_limit validation error message

### DIFF
--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -195,6 +195,8 @@ class SubsidyAccessPolicyResponseSerializer(serializers.ModelSerializer):
             'is_late_redemption_allowed',
             'created',
             'bnr_enabled',
+            'total_spend_limits_for_subsidy',
+            'total_deposits_for_subsidy',
         ]
         read_only_fields = fields
 

--- a/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_subsidy_access_policy_views.py
@@ -326,6 +326,8 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
             'is_late_redemption_allowed': False,
             'created': self.redeemable_policy.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
             'bnr_enabled': False,
+            'total_deposits_for_subsidy': 4,
+            'total_spend_limits_for_subsidy': 3,
         }, response.json())
 
     @ddt.data(
@@ -423,6 +425,8 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
                 'is_late_redemption_allowed': False,
                 'created': self.non_redeemable_policy.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
                 'bnr_enabled': False,
+                'total_deposits_for_subsidy': 4,
+                'total_spend_limits_for_subsidy': 0,
             },
             {
                 'access_method': 'direct',
@@ -456,6 +460,8 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
                 'is_late_redemption_allowed': False,
                 'created': self.redeemable_policy.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
                 'bnr_enabled': False,
+                'total_deposits_for_subsidy': 4,
+                'total_spend_limits_for_subsidy': 3,
             },
         ]
 
@@ -559,6 +565,8 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
             'is_late_redemption_allowed': False,
             'created': self.redeemable_policy.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
             'bnr_enabled': False,
+            'total_deposits_for_subsidy': 4,
+            'total_spend_limits_for_subsidy': 0,
         }
         self.assertEqual(expected_response, response.json())
 
@@ -676,6 +684,8 @@ class TestAuthenticatedPolicyCRUDViews(CRUDViewTestMixin, APITestWithMocks):
             'is_late_redemption_allowed': False,
             'created': policy_for_edit.created.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
             'bnr_enabled': False,
+            'total_deposits_for_subsidy': 4,
+            'total_spend_limits_for_subsidy': 0 if 'spend_limit' in request_payload else policy_for_edit.spend_limit,
         }
 
         if 'retired' in request_payload:

--- a/enterprise_access/apps/subsidy_access_policy/admin/__init__.py
+++ b/enterprise_access/apps/subsidy_access_policy/admin/__init__.py
@@ -25,6 +25,7 @@ from enterprise_access.apps.subsidy_access_policy.admin.views import (
     SubsidyAccessPolicyDepositFundsView,
     SubsidyAccessPolicySetLateRedemptionView
 )
+from enterprise_access.apps.subsidy_access_policy.utils import cents_to_usd_string
 
 from .forms import ForcedPolicyRedemptionForm, SubsidyAccessPolicyForm
 
@@ -47,16 +48,6 @@ GEAG_DATETIME_FMT = '%Y-%m-%dT%H:%M:%SZ'
 
 def super_admin_enabled():
     return getattr(settings, 'DJANGO_ADMIN_POLICY_SUPER_ADMIN', False)
-
-
-def cents_to_usd_string(cents):
-    """
-    Helper to convert cents as an int to dollars as a
-    nicely formatted string.
-    """
-    if cents is None:
-        return None
-    return "${:,.2f}".format(float(cents) / constants.CENTS_PER_DOLLAR)
 
 
 class BaseSubsidyAccessPolicyMixin(DjangoObjectActions, SimpleHistoryAdmin):
@@ -96,6 +87,14 @@ class BaseSubsidyAccessPolicyMixin(DjangoObjectActions, SimpleHistoryAdmin):
         'set_late_redemption',
         'deposit_funds',
     )
+
+    def get_form(self, *args, **kwargs):
+        """
+        Expand width of certain fields so that large integers (e.g. $100k in cents) are fully visible.
+        """
+        form = super().get_form(*args, **kwargs)
+        form.base_fields['spend_limit'].widget.attrs['style'] = 'width: 10em;'  # Wide enough for billions of dollars.
+        return form
 
     @action(
         label='Set Late Redemption',

--- a/enterprise_access/apps/subsidy_access_policy/constants.py
+++ b/enterprise_access/apps/subsidy_access_policy/constants.py
@@ -129,7 +129,6 @@ SORT_BY_ENROLLMENT_COUNT = 'enrollment_count'
 GROUP_MEMBERS_WITH_AGGREGATES_DEFAULT_PAGE_SIZE = 10
 
 # Exceeding the spend_limit validation error
-VALIDATION_ERROR_SPEND_LIMIT_EXCEEDS_STARTING_BALANCE = "You cannot make this change, as the value of all budget \
-limits would exceed the funds available on the subsidy. Please double-check the subsidy’s initial value and any \
-adjustments, then ensure the budgets sum to an equal or lower amount. If you are trying to re-balance policies, \
-please reduce the value of one first, then proceed to increase the value of another"
+VALIDATION_ERROR_SPEND_LIMIT_EXCEEDS_STARTING_BALANCE = "You cannot make this change, as the sum of all budget \
+spend_limits for a given subsidy would exceed the sum of all deposits into that subsidy.  If you are trying to \
+re-balance policies, FIRST reduce the spend_limit of one, THEN increase the spend_limit of another."

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -71,7 +71,12 @@ from .subsidy_api import (
     get_tiered_cache_subsidy_record,
     set_tiered_cache_subsidy_record
 )
-from .utils import ProxyAwareHistoricalRecords, create_idempotency_key_for_transaction, get_versioned_subsidy_client
+from .utils import (
+    ProxyAwareHistoricalRecords,
+    cents_to_usd_string,
+    create_idempotency_key_for_transaction,
+    get_versioned_subsidy_client
+)
 
 # Magic key that is used transaction metadata hint to the subsidy service and all downstream services that the
 # enrollment should be allowed even if the enrollment deadline has passed.
@@ -328,17 +333,26 @@ class SubsidyAccessPolicy(TimeStampedModel):
         return None
 
     @property
-    def total_spend_limit_for_all_policies_associated_to_subsidy(self):
+    def total_spend_limits_for_subsidy(self):
         """
-        Sums the policies spend_limit excluding the db's instance of this policy
+        Sum of spend_limit for all policies associated with this policy's subsidy.
+
+        Calculation is based on what the sum would be if this instance was saved to the DB.
         """
-        spend_limit = self.spend_limit if self.active and self.spend_limit else 0
         sibling_policies_sum = SubsidyAccessPolicy.objects.filter(
             enterprise_customer_uuid=self.enterprise_customer_uuid,
             subsidy_uuid=self.subsidy_uuid,
-            active=True
-        ).exclude(uuid=self.uuid).aggregate(models.Sum("spend_limit", default=0))["spend_limit__sum"]
-        return spend_limit + sibling_policies_sum
+            active=True,
+        ).exclude(
+            # Exclude self from the DB query because that value might be outdated.
+            uuid=self.uuid,
+        ).aggregate(
+            models.Sum("spend_limit", default=0),
+        )["spend_limit__sum"]
+
+        # Re-add self.spend_limit which likely is more up-to-date compared to the DB value.
+        self_spend_limit = self.spend_limit if self.active and self.spend_limit else 0
+        return self_spend_limit + sibling_policies_sum
 
     @property
     def is_spend_limit_updated(self):
@@ -394,17 +408,38 @@ class SubsidyAccessPolicy(TimeStampedModel):
             learner_credit_request_config__active=True
         ).exists()
 
+    def clean_spend_limit(self):
+        if self.active and (self.is_active_updated or self.is_spend_limit_updated):
+            if self.total_spend_limits_for_subsidy > self.total_deposits_for_subsidy:
+                sum_of_spend_limits_str = cents_to_usd_string(
+                    self.total_spend_limits_for_subsidy
+                )
+                sum_of_deposits_str = cents_to_usd_string(self.total_deposits_for_subsidy)
+                raise ValidationError(
+                    f'{self} {VALIDATION_ERROR_SPEND_LIMIT_EXCEEDS_STARTING_BALANCE} '
+                    f'Error: {sum_of_spend_limits_str} is greater than {sum_of_deposits_str}'
+                )
+
     def clean(self):
         """
         Used to help validate field values before saving this model instance.
         """
-        if self.active and (self.is_active_updated or self.is_spend_limit_updated):
-            if self.total_spend_limit_for_all_policies_associated_to_subsidy > self.subsidy_total_deposits():
-                raise ValidationError(f'{self} {VALIDATION_ERROR_SPEND_LIMIT_EXCEEDS_STARTING_BALANCE}')
+        validation_errors = {}
+
+        # Validate the spend_limit field.
+        try:
+            self.clean_spend_limit()
+        except ValidationError as exc:
+            validation_errors['spend_limit'] = str(exc)
+
+        # Perform basic field constraint checks.
         for field_name, (constraint_function, error_message) in self.FIELD_CONSTRAINTS.items():
             field = getattr(self, field_name)
             if not constraint_function(field):
-                raise ValidationError(f'{self} {error_message}')
+                validation_errors[field_name] = f'{self} {error_message}'
+
+        if validation_errors:
+            raise ValidationError(validation_errors)
 
     def save(self, *args, **kwargs):
         """
@@ -500,9 +535,10 @@ class SubsidyAccessPolicy(TimeStampedModel):
         current_balance = self.subsidy_record().get('current_balance') or 0
         return int(current_balance)
 
-    def subsidy_total_deposits(self):
+    @property
+    def total_deposits_for_subsidy(self):
         """
-        Returns total remaining balance for the associated subsidy ledger.
+        Returns total amount deposited into the associated subsidy ledger.
         """
         total_deposits = self.subsidy_record().get('total_deposits') or 0
         return int(total_deposits)

--- a/enterprise_access/apps/subsidy_access_policy/utils.py
+++ b/enterprise_access/apps/subsidy_access_policy/utils.py
@@ -8,6 +8,8 @@ from django.conf import settings
 from edx_enterprise_subsidy_client import get_enterprise_subsidy_api_client
 from simple_history.models import HistoricalRecords, registered_models
 
+from enterprise_access.apps.subsidy_access_policy import constants
+
 LEDGERED_SUBSIDY_IDEMPOTENCY_KEY_PREFIX = 'ledger-for-subsidy'
 TRANSACTION_METADATA_KEYS = {
     'lms_user_id',
@@ -128,3 +130,13 @@ class ProxyAwareHistoricalRecords(HistoricalRecords):
         name = self.get_history_model_name(model)
         registered_models[opts.db_table] = model
         return type(str(name), (base_history,), attrs)
+
+
+def cents_to_usd_string(cents):
+    """
+    Helper to convert cents as an int to dollars as a
+    nicely formatted string.
+    """
+    if cents is None:
+        return None
+    return "${:,.2f}".format(float(cents) / constants.CENTS_PER_DOLLAR)


### PR DESCRIPTION
The main fix in the PR was adding the actual values being compared to the spend_limit field validation message (see first screenshot below).

Additionally, the following 3 QoL improvements were included:

Error message moved from top of page to next to field.
===
![457456458-f639fef1-bcb9-4bb8-8147-95b6667f42b1](https://github.com/user-attachments/assets/206899b2-c7ee-4425-9201-9c3ef34d3141)


Serializer fields added for better observability.
===
![Screenshot 2025-06-20 at 10 24 11 AM](https://github.com/user-attachments/assets/a126b3fa-c9e8-40c5-b308-291624097b6f)


Widen integer cents input
===
![Screenshot 2025-06-20 at 10 42 28 AM](https://github.com/user-attachments/assets/928d99c7-ab9e-47d7-a64e-b4fe87baaf22)
