### PR TITLE
feat: added cancel api endpoint for learner credit request

### DIFF
--- a/enterprise_access/apps/api/serializers/__init__.py
+++ b/enterprise_access/apps/api/serializers/__init__.py
@@ -46,6 +46,7 @@ from .subsidy_access_policy import (
 from .subsidy_requests import (
     CouponCodeRequestSerializer,
     LearnerCreditRequestApproveRequestSerializer,
+    LearnerCreditRequestCancelSerializer,
     LearnerCreditRequestDeclineSerializer,
     LearnerCreditRequestSerializer,
     LicenseRequestSerializer,

--- a/enterprise_access/apps/api/serializers/subsidy_requests.py
+++ b/enterprise_access/apps/api/serializers/subsidy_requests.py
@@ -334,3 +334,34 @@ class LearnerCreditRequestApproveRequestSerializer(serializers.Serializer):
         Not implemented - this serializer is for validation only
         """
         raise NotImplementedError("This serializer is for validation only")
+
+
+# pylint: disable=abstract-method
+class LearnerCreditRequestCancelSerializer(serializers.Serializer):
+    """
+    Request serializer to validate cancel endpoint query params.
+
+    For view: LearnerCreditRequestViewSet.cancel
+    """
+    request_uuid = serializers.UUIDField()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._learner_credit_request = None
+
+    def validate_request_uuid(self, value):
+        """
+        Validate that the learner credit request exists and store it for later use.
+        """
+        try:
+            learner_credit_request = LearnerCreditRequest.objects.get(uuid=value)
+            self._learner_credit_request = learner_credit_request
+            return value
+        except LearnerCreditRequest.DoesNotExist as exc:
+            raise serializers.ValidationError(f"Learner credit request with uuid {value} not found.") from exc
+
+    def get_learner_credit_request(self):
+        """
+        Return the already-fetched learner credit request object.
+        """
+        return getattr(self, '_learner_credit_request', None)

--- a/enterprise_access/apps/api/v1/tests/test_browse_and_request_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_browse_and_request_views.py
@@ -33,7 +33,12 @@ from enterprise_access.apps.subsidy_access_policy.models import SubsidyAccessPol
 from enterprise_access.apps.subsidy_access_policy.tests.factories import (
     PerLearnerSpendCapLearnerCreditAccessPolicyFactory
 )
-from enterprise_access.apps.subsidy_request.constants import SegmentEvents, SubsidyRequestStates, SubsidyTypeChoices
+from enterprise_access.apps.subsidy_request.constants import (
+    LearnerCreditRequestActionErrorReasons,
+    SegmentEvents,
+    SubsidyRequestStates,
+    SubsidyTypeChoices
+)
 from enterprise_access.apps.subsidy_request.models import (
     CouponCodeRequest,
     LearnerCreditRequest,
@@ -48,7 +53,11 @@ from enterprise_access.apps.subsidy_request.tests.factories import (
     LicenseRequestFactory,
     SubsidyRequestCustomerConfigurationFactory
 )
-from enterprise_access.apps.subsidy_request.utils import get_action_choice, get_user_message_choice
+from enterprise_access.apps.subsidy_request.utils import (
+    get_action_choice,
+    get_error_reason_choice,
+    get_user_message_choice
+)
 from test_utils import APITestWithMocks
 
 from .utils import BaseEnterpriseAccessTestCase
@@ -2489,3 +2498,153 @@ class TestLearnerCreditRequestViewSet(BaseEnterpriseAccessTestCase):
         self.user_request_1.refresh_from_db()
         assert self.user_request_1.state == SubsidyRequestStates.REQUESTED
         assert self.user_request_1.assignment is None
+
+    def test_cancel_invalid_request_uuid(self):
+        """
+        Test cancel with invalid UUID format returns 400.
+        """
+        self.set_jwt_cookie([{
+            'system_wide_role': SYSTEM_ENTERPRISE_ADMIN_ROLE,
+            'context': str(self.enterprise_customer_uuid_1)
+        }])
+
+        url = reverse('api:v1:learner-credit-requests-cancel')
+        data = {
+            'enterprise_customer_uuid': str(self.enterprise_customer_uuid_1),
+            'request_uuid': 'invalid-uuid-format'
+        }
+        response = self.client.post(url, data)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_cancel_nonexistent_request(self):
+        """
+        Test cancel with non-existent request UUID returns 400.
+        """
+        self.set_jwt_cookie([{
+            'system_wide_role': SYSTEM_ENTERPRISE_ADMIN_ROLE,
+            'context': str(self.enterprise_customer_uuid_1)
+        }])
+
+        url = reverse('api:v1:learner-credit-requests-cancel')
+        data = {
+            'enterprise_customer_uuid': str(self.enterprise_customer_uuid_1),
+            'request_uuid': str(uuid4())
+        }
+        response = self.client.post(url, data)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @mock.patch('enterprise_access.apps.content_assignments.api.cancel_assignments')
+    def test_cancel_success(self, mock_cancel_assignments):
+        """
+        Test successful cancellation of an approved learner credit request.
+        """
+        # Set up approved request with assignment
+        assignment = LearnerContentAssignmentFactory(
+            assignment_configuration=self.assignment_config,
+            content_quantity=-1000,
+            state='allocated'
+        )
+        approved_request = LearnerCreditRequestFactory(
+            enterprise_customer_uuid=self.enterprise_customer_uuid_1,
+            user=self.user,
+            learner_credit_request_config=self.learner_credit_config,
+            course_price=1000,
+            state=SubsidyRequestStates.APPROVED,
+            assignment=assignment
+        )
+
+        # Mock successful assignment cancellation
+        mock_cancel_assignments.return_value = {'non_cancelable': []}
+
+        self.set_jwt_cookie([{
+            'system_wide_role': SYSTEM_ENTERPRISE_ADMIN_ROLE,
+            'context': str(self.enterprise_customer_uuid_1)
+        }])
+
+        url = reverse('api:v1:learner-credit-requests-cancel')
+        data = {
+            'enterprise_customer_uuid': str(self.enterprise_customer_uuid_1),
+            'request_uuid': str(approved_request.uuid)
+        }
+        response = self.client.post(url, data)
+
+        assert response.status_code == status.HTTP_200_OK
+
+        # Verify request was cancelled
+        approved_request.refresh_from_db()
+        assert approved_request.state == SubsidyRequestStates.CANCELLED
+        assert approved_request.reviewer == self.user
+
+        # Verify assignment cancellation was called
+        mock_cancel_assignments.assert_called_once_with([assignment], False)
+
+        # Verify successful action record was created
+        success_action = LearnerCreditRequestActions.objects.filter(
+            learner_credit_request=approved_request,
+            recent_action=get_action_choice(SubsidyRequestStates.CANCELLED),
+            status=get_user_message_choice(SubsidyRequestStates.CANCELLED),
+            error_reason=None,
+            traceback=None
+        ).first()
+        assert success_action is not None
+
+    @mock.patch('enterprise_access.apps.content_assignments.api.cancel_assignments')
+    def test_cancel_failed_assignment_cancellation(self, mock_cancel_assignments):
+        """
+        Test cancel failure when assignment cannot be cancelled.
+        """
+        # Set up approved request with assignment
+        assignment = LearnerContentAssignmentFactory(
+            assignment_configuration=self.assignment_config,
+            content_quantity=-1000,
+            state='allocated'
+        )
+        approved_request = LearnerCreditRequestFactory(
+            enterprise_customer_uuid=self.enterprise_customer_uuid_1,
+            user=self.user,
+            learner_credit_request_config=self.learner_credit_config,
+            course_price=1000,
+            state=SubsidyRequestStates.APPROVED,
+            assignment=assignment
+        )
+
+        # Mock failed assignment cancellation
+        mock_cancel_assignments.return_value = {'non_cancelable': [assignment.uuid]}
+
+        self.set_jwt_cookie([{
+            'system_wide_role': SYSTEM_ENTERPRISE_ADMIN_ROLE,
+            'context': str(self.enterprise_customer_uuid_1)
+        }])
+
+        url = reverse('api:v1:learner-credit-requests-cancel')
+        data = {
+            'enterprise_customer_uuid': str(self.enterprise_customer_uuid_1),
+            'request_uuid': str(approved_request.uuid)
+        }
+        response = self.client.post(url, data)
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        expected_error = (
+            f"Failed to cancel associated assignment with uuid: {assignment.uuid}"
+            f" for request: {approved_request.uuid}."
+        )
+        assert response.data == expected_error
+
+        # Verify request was NOT cancelled
+        approved_request.refresh_from_db()
+        assert approved_request.state == SubsidyRequestStates.APPROVED
+
+        # Verify assignment cancellation was called
+        mock_cancel_assignments.assert_called_once_with([assignment], False)
+
+        # Verify error action record was created
+        error_action = LearnerCreditRequestActions.objects.filter(
+            learner_credit_request=approved_request,
+            recent_action=get_action_choice(SubsidyRequestStates.CANCELLED),
+            status=get_user_message_choice(SubsidyRequestStates.APPROVED),
+            error_reason=get_error_reason_choice(LearnerCreditRequestActionErrorReasons.FAILED_CANCELLATION)
+        ).first()
+        assert error_action is not None
+        assert error_action.traceback == expected_error

--- a/enterprise_access/apps/content_assignments/api.py
+++ b/enterprise_access/apps/content_assignments/api.py
@@ -749,7 +749,7 @@ def _create_new_assignments(
     )
 
 
-def cancel_assignments(assignments: Iterable[LearnerContentAssignment]) -> dict:
+def cancel_assignments(assignments: Iterable[LearnerContentAssignment], send_cancel_email_to_learner=True) -> dict:
     """
     Bulk cancel assignments.
 
@@ -788,7 +788,8 @@ def cancel_assignments(assignments: Iterable[LearnerContentAssignment]) -> dict:
 
     cancelled_assignments = _update_and_refresh_assignments(cancelable_assignments, ['state'])
     for cancelled_assignment in cancelled_assignments:
-        send_cancel_email_for_pending_assignment.delay(cancelled_assignment.uuid)
+        if send_cancel_email_to_learner:
+            send_cancel_email_for_pending_assignment.delay(cancelled_assignment.uuid)
 
     return {
         'cancelled': list(set(cancelled_assignments) | already_cancelled_assignments),

--- a/enterprise_access/apps/subsidy_request/models.py
+++ b/enterprise_access/apps/subsidy_request/models.py
@@ -386,6 +386,12 @@ class LearnerCreditRequest(SubsidyRequest):
         self.reviewed_at = localized_utcnow()
         self.save()
 
+    def cancel(self, reviewer):
+        self.state = SubsidyRequestStates.CANCELLED
+        self.reviewer = reviewer
+        self.reviewed_at = localized_utcnow()
+        self.save()
+
 
 class LearnerCreditRequestActions(TimeStampedModel):
     """

--- a/enterprise_access/apps/subsidy_request/tests/test_models.py
+++ b/enterprise_access/apps/subsidy_request/tests/test_models.py
@@ -184,6 +184,16 @@ class LearnerCreditRequestTests(TestCase):
         self.assertEqual(self.learner_credit_request.decline_reason, decline_reason)
         self.assertIsNotNone(self.learner_credit_request.reviewed_at)
 
+    def test_cancel_success(self):
+        """
+        Verify that canceling a request updates the state and sets the reviewed timestamp.
+        """
+        reviewer = UserFactory()
+        self.learner_credit_request.cancel(reviewer)
+        self.assertEqual(self.learner_credit_request.state, SubsidyRequestStates.CANCELLED)
+        self.assertEqual(self.learner_credit_request.reviewer, reviewer)
+        self.assertIsNotNone(self.learner_credit_request.reviewed_at)
+
     def test_clean_invalid_without_review_data(self):
         """
         Ensure validation fails if a reviewed request lacks a reviewer and timestamp.


### PR DESCRIPTION
**Description:**
Created the cancel api for learner credit request. It uses the existing `cancel_assignments` function to cancel the associated assignment and then updates the request state.

**Jira:**
[ENT-10357](https://2u-internal.atlassian.net/browse/ENT-10357)

**Merge checklist:**
- [x] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
