### PR TITLE
fix: subsidy request user field now in admin autocomplete_fields

### DIFF
--- a/enterprise_access/apps/subsidy_request/admin.py
+++ b/enterprise_access/apps/subsidy_request/admin.py
@@ -50,6 +50,10 @@ class BaseSubsidyRequestAdmin(DjangoQLSearchMixin):
         'state',
     )
 
+    autocomplete_fields = [
+        'user',
+    ]
+
     @admin.display(
         description='Course partners'
     )


### PR DESCRIPTION
We don't want to load every possible user into a select list.

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
