### PR TITLE
feat: stripe pricing API integration

### DIFF
--- a/enterprise_access/apps/customer_billing/pricing_api.py
+++ b/enterprise_access/apps/customer_billing/pricing_api.py
@@ -1,0 +1,392 @@
+"""
+Python API for fetching and serializing Stripe pricing data.
+
+This module provides a centralized way to fetch pricing information from Stripe
+and serialize it in a consistent format for use across enterprise-access applications.
+
+Basic Format Structure:
+    {
+        "usd": 100.00,           # Price in dollars (decimal)
+        "usd_cents": 10000,      # Price in cents (integer)
+        "currency": "usd",       # Currency code
+        "recurring": {           # Present for subscription prices
+            "interval": "year",
+            "interval_count": 1
+        },
+        "product": {             # Product metadata when available
+            "id": "prod_123",
+            "name": "Product Name",
+            "description": "...",
+            "metadata": {}
+        }
+    }
+"""
+import logging
+from decimal import Decimal
+from typing import Dict, List, Optional, TypedDict
+
+import stripe
+from django.conf import settings
+from edx_django_utils.cache import TieredCache
+
+from enterprise_access.cache_utils import versioned_cache_key
+
+logger = logging.getLogger(__name__)
+
+# Initialize Stripe with API key from settings
+stripe.api_key = settings.STRIPE_API_KEY
+
+
+class StripePricingError(Exception):
+    """Exception raised when there's an error fetching Stripe pricing data."""
+
+
+class SerializedRecurringData(TypedDict, total=False):
+    """TypedDict for serialized recurring billing data."""
+    interval: str
+    interval_count: int
+    usage_type: str
+
+
+class SerializedProductData(TypedDict, total=False):
+    """TypedDict for serialized product data."""
+    id: str
+    name: str
+    description: str
+    metadata: Dict[str, str]
+
+
+class SerializedPriceData(TypedDict, total=False):
+    """
+    TypedDict for our serialized price data in basic format.
+
+    Example:
+        {
+            "unit_amount_decimal": 100.00,
+            "unit_amount": 10000,
+            "currency": "usd",
+            "recurring": {
+                "interval": "year",
+                "interval_count": 1
+            },
+            "product": {
+                "id": "prod_123",
+                "name": "Product Name",
+                "description": "...",
+                "metadata": {}
+            }
+        }
+    """
+    currency: str
+    unit_amount: int
+    unit_amount_decimal: Decimal
+    recurring: SerializedRecurringData
+    product: SerializedProductData
+    lookup_key: Optional[str]
+
+
+def get_stripe_price_data(
+    price_id: str,
+    timeout: int = settings.STRIPE_PRICE_DATA_CACHE_TIMEOUT,
+) -> Optional[Dict]:
+    """
+    Fetch and cache Stripe price data for a given Price ID.
+
+    Args:
+        price_id: Stripe Price ID to fetch
+        timeout: Cache timeout in seconds
+
+    Returns:
+        Dict containing serialized price data in basic format, or None if not found
+
+    Raises:
+        StripePricingError: If there's an error fetching from Stripe
+    """
+    cache_key = versioned_cache_key(
+        'stripe_price_data',
+        price_id,
+    )
+
+    cached_response = TieredCache.get_cached_response(cache_key)
+    if cached_response.is_found:
+        logger.info(f'Cache hit for Stripe price {price_id}')
+        return cached_response.value
+
+    try:
+        # Fetch price and associated product from Stripe
+        stripe_price = stripe.Price.retrieve(price_id, expand=['product'])
+
+        # Validate the response against our expected schema
+        _validate_stripe_price_schema(stripe_price)
+
+        # Serialize the price data in basic format
+        serialized_data = _serialize_basic_format(stripe_price)
+
+        if serialized_data:
+            TieredCache.set_all_tiers(
+                cache_key,
+                serialized_data,
+                django_cache_timeout=timeout,
+            )
+            logger.info(f'Cached Stripe price data for {price_id}')
+
+        return serialized_data
+
+    except stripe.error.StripeError as exc:
+        logger.error(f'Stripe API error fetching price {price_id}: {exc}')
+        raise StripePricingError(f'Failed to fetch price {price_id}: {exc}') from exc
+    except Exception as exc:
+        logger.error(f'Unexpected error fetching price {price_id}: {exc}')
+        raise StripePricingError(f'Unexpected error fetching price {price_id}: {exc}') from exc
+
+
+def _validate_stripe_price_schema(stripe_price: stripe.Price) -> None:
+    """
+    Validate that the Stripe price response matches our expected schema.
+
+    Args:
+        stripe_price: Stripe Price object to validate
+
+    Raises:
+        StripePricingError: If the schema doesn't match expectations
+    """
+    required_fields = ['id', 'currency', 'unit_amount', 'type']
+
+    for field in required_fields:
+        if not hasattr(stripe_price, field) or getattr(stripe_price, field) is None:
+            raise StripePricingError(f'Missing required field in Stripe price response: {field}')
+
+    if not isinstance(stripe_price.currency, str):
+        raise StripePricingError(f'Invalid currency type: expected str, got {type(stripe_price.currency)}')
+
+    if not isinstance(stripe_price.unit_amount, int):
+        raise StripePricingError(f'Invalid unit_amount type: expected int, got {type(stripe_price.unit_amount)}')
+
+    if not stripe_price.active:
+        raise StripePricingError('Stripe price must be active')
+
+    if stripe_price.billing_scheme != 'per_unit':
+        raise StripePricingError(f'Only per_unit billing_scheme is supported, got {stripe_price.billing_scheme}')
+
+    if stripe_price.type != 'recurring':
+        raise StripePricingError(f'Only recurring price type is supported, got {stripe_price.type}')
+
+    # TODO: do we want to validate on livemode? Might it be useful for some testing scenarios?
+
+    if stripe_price.recurring:
+        if not hasattr(stripe_price.recurring, 'interval') or not stripe_price.recurring.interval:
+            raise StripePricingError('Recurring price missing interval')
+        if not hasattr(stripe_price.recurring, 'interval_count') or stripe_price.recurring.interval_count is None:
+            raise StripePricingError('Recurring price missing interval_count')
+        if stripe_price.recurring.usage_type != 'licensed':
+            raise StripePricingError(
+                'Only licensed recurring prices are supported, '
+                f'got {stripe_price.recurring.usage_type}'
+            )
+
+    logger.debug(f'Stripe price {stripe_price.id} schema validation passed')
+
+
+def get_multiple_stripe_prices(
+    price_ids: List[str],
+    timeout: int = settings.CONTENT_METADATA_CACHE_TIMEOUT,
+) -> Dict[str, Dict]:
+    """
+    Fetch multiple Stripe prices efficiently with caching.
+
+    Args:
+        price_ids: List of Stripe Price IDs to fetch
+        timeout: Cache timeout in seconds
+
+    Returns:
+        Dict mapping price_id to serialized price data
+    """
+    results = {}
+
+    # Check cache for each price ID individually
+    for price_id in price_ids:
+        cache_key = versioned_cache_key(
+            'stripe_price_data',
+            price_id,
+        )
+
+        cached_response = TieredCache.get_cached_response(cache_key)
+        if cached_response.is_found:
+            logger.info(f'Cache hit for Stripe price {price_id}')
+            results[price_id] = cached_response.value
+        else:
+            # Fetch uncached price from Stripe
+            try:
+                price_data = get_stripe_price_data(price_id, timeout)
+                if price_data:
+                    results[price_id] = price_data
+            except StripePricingError:
+                logger.warning(f'Failed to fetch price data for {price_id}')
+                continue
+
+    return results
+
+
+def get_ssp_product_pricing() -> Dict[str, Dict]:
+    """
+    Get pricing data for all configured SSP products.
+
+    Returns:
+        Dict mapping SSP product keys to price data
+    """
+    ssp_pricing = {}
+    for product_key, product_config in settings.SSP_PRODUCTS.items():
+        price_id = product_config.get('stripe_price_id')
+        if price_id:
+            try:
+                price_data = get_stripe_price_data(price_id)
+                if price_data:
+                    # Add SSP-specific metadata
+                    price_data['ssp_product_key'] = product_key
+                    price_data['quantity_range'] = product_config.get('quantity_range')
+                    ssp_pricing[product_key] = price_data
+            except Exception as exc:
+                logger.error(f'Failed to fetch pricing for SSP product {product_key}: {exc}')
+                raise
+
+    return ssp_pricing
+
+
+def calculate_subtotal(
+    price_data: Dict,
+    quantity: int,
+) -> Optional[Dict]:
+    """
+    Calculate subtotal for a given price and quantity.
+
+    Args:
+        price_data: Serialized price data from pricing API
+        quantity: Number of units
+
+    Returns:
+        Dict with subtotal information or None if calculation fails
+    """
+    try:
+        # Get recurring info if available
+        if 'recurring' in price_data:
+            interval = price_data['recurring']['interval']
+            interval_count = price_data['recurring']['interval_count']
+        else:
+            interval = None
+            interval_count = None
+
+        unit_amount_cents = price_data['unit_amount']
+        unit_amount_decimal = price_data['unit_amount_decimal']
+
+        subtotal_cents = unit_amount_cents * quantity
+        subtotal_decimal = unit_amount_decimal * quantity
+
+        result = {
+            'subtotal_cents': subtotal_cents,
+            'subtotal_decimal': round(subtotal_decimal, 2),
+            'currency': price_data['currency'],
+            'quantity': quantity,
+            'unit_amount_cents': unit_amount_cents,
+            'unit_amount_decimal': unit_amount_decimal,
+        }
+
+        if interval:
+            result['billing_period'] = {
+                'interval': interval,
+                'interval_count': interval_count,
+            }
+
+        return result
+
+    except (KeyError, TypeError, ValueError) as e:
+        logger.error(f'Error calculating subtotal: {e}')
+        return None
+
+
+def format_price_display(
+    price_data: Dict,
+    currency: str = 'usd',
+    include_currency_symbol: bool = True
+) -> str:
+    """
+    Format price data for display to users.
+
+    Args:
+        price_data: Serialized price data
+        currency: Currency code
+        include_currency_symbol: Whether to include currency symbol
+
+    Returns:
+        Formatted price string (e.g., "$100.00/year")
+    """
+    if currency != price_data['currency']:
+        logger.error(
+            f"Cannot provide {currency} format for price data with currency {price_data['currency']}"
+        )
+        return 'Price unavailable'
+
+    try:
+        amount = price_data['unit_amount_decimal']
+
+        # Format currency
+        if include_currency_symbol and currency.lower() == 'usd':
+            formatted_amount = f'${amount:.2f}'
+        else:
+            formatted_amount = f'{amount:.2f} {currency.upper()}'
+
+        # Add billing period if recurring
+        if 'recurring' in price_data:
+            interval = price_data['recurring']['interval']
+            interval_count = price_data['recurring']['interval_count']
+
+            if interval_count == 1:
+                period = f'/{interval}'
+            else:
+                period = f'/every {interval_count} {interval}s'
+
+            formatted_amount += period
+
+        return formatted_amount
+
+    except (KeyError, TypeError, ValueError):
+        return 'Price unavailable'
+
+
+def _serialize_basic_format(stripe_price: stripe.Price) -> SerializedPriceData:
+    """
+    Serialize Stripe price in basic format matching Learner Credit APIs.
+
+    Returns:
+        SerializedPriceData with format: {"currency": "usd", "unit_amount_decimal": 100.00, "unit_amount": 10000, ...}
+    """
+    currency = stripe_price.currency.lower()
+    unit_amount = stripe_price.unit_amount or 0
+    unit_amount_decimal = Decimal(unit_amount) / 100
+
+    # Start with the typed base structure
+    base_data: SerializedPriceData = {
+        'currency': currency,
+        'unit_amount': unit_amount,
+        'unit_amount_decimal': unit_amount_decimal,
+        'lookup_key': getattr(stripe_price, 'lookup_key', None)
+    }
+
+    # Add recurring information if available
+    if stripe_price.recurring:
+        base_data['recurring'] = {
+            'interval': stripe_price.recurring.interval,
+            'interval_count': stripe_price.recurring.interval_count,
+            'usage_type': stripe_price.recurring.usage_type,
+        }
+
+    # Add product information if available
+    if stripe_price.product:
+        product = stripe_price.product
+        base_data['product'] = {
+            'id': product.id,
+            'name': product.name,
+            'description': product.description,
+            'metadata': product.metadata,
+        }
+
+    return base_data

--- a/enterprise_access/apps/customer_billing/tests/test_pricing_api.py
+++ b/enterprise_access/apps/customer_billing/tests/test_pricing_api.py
@@ -1,0 +1,419 @@
+"""
+Unit tests for the pricing_api module.
+"""
+from decimal import Decimal
+from unittest import mock
+
+import ddt
+from django.test import TestCase, override_settings
+from edx_django_utils.cache import TieredCache
+from stripe.error import InvalidRequestError
+
+from enterprise_access.apps.customer_billing import pricing_api
+
+
+@override_settings(
+    SSP_PRODUCTS={
+        'quarterly_license_plan': {
+            'stripe_price_id': 'price_ABC',
+            'stripe_product_id': 'prod_ABC',
+            'quantity_range': (5, 30),
+        },
+        'yearly_license_plan': {
+            'stripe_price_id': 'price_XYZ',
+            'stripe_product_id': 'prod_XYZ',
+            'quantity_range': (5, 30),
+        },
+    },
+)
+@ddt.ddt
+class TestStripePricingAPI(TestCase):
+    """
+    Tests for the Stripe pricing API functions.
+    """
+
+    def setUp(self):
+        # Clear cache before each test
+        TieredCache.dangerous_clear_all_tiers()
+
+    def tearDown(self):
+        # Clear cache after each test
+        TieredCache.dangerous_clear_all_tiers()
+
+    def _create_mock_stripe_price(
+        self,
+        price_id='price_123',
+        unit_amount=10000,
+        currency='usd',
+        product_id='prod_123',
+        product_name='Test Product',
+        recurring=None,
+    ):
+        """Helper to create mock Stripe price object."""
+        mock_product = mock.MagicMock()
+        mock_product.id = product_id
+        mock_product.name = product_name
+        mock_product.description = 'Test product description'
+        mock_product.metadata = {'test': 'value'}
+
+        mock_price = mock.MagicMock()
+        mock_price.id = price_id
+        mock_price.unit_amount = unit_amount
+        mock_price.currency = currency
+        mock_price.product = mock_product
+        mock_price.recurring = recurring
+        mock_price.lookup_key = 'foo-bar'
+        mock_price.billing_scheme = 'per_unit'
+        mock_price.type = 'recurring'
+
+        return mock_price
+
+    @mock.patch('enterprise_access.apps.customer_billing.pricing_api.stripe')
+    def test_get_stripe_price_data_basic_format(self, mock_stripe):
+        """Test fetching price data in basic format."""
+        mock_price = self._create_mock_stripe_price()
+        mock_stripe.Price.retrieve.return_value = mock_price
+
+        result = pricing_api.get_stripe_price_data('price_123')
+
+        expected = {
+            'unit_amount_decimal': Decimal(100.0),
+            'unit_amount': 10000,
+            'currency': 'usd',
+            'lookup_key': 'foo-bar',
+            'product': {
+                'id': 'prod_123',
+                'name': 'Test Product',
+                'description': 'Test product description',
+                'metadata': {'test': 'value'},
+            }
+        }
+
+        self.assertEqual(result, expected)
+        mock_stripe.Price.retrieve.assert_called_once_with('price_123', expand=['product'])
+
+    @mock.patch('enterprise_access.apps.customer_billing.pricing_api.stripe')
+    def test_get_stripe_price_data_with_recurring(self, mock_stripe):
+        """Test fetching price data with recurring billing info."""
+        mock_recurring = mock.MagicMock()
+        mock_recurring.interval = 'year'
+        mock_recurring.interval_count = 1
+        mock_recurring.usage_type = 'licensed'
+
+        mock_price = self._create_mock_stripe_price(recurring=mock_recurring)
+        mock_stripe.Price.retrieve.return_value = mock_price
+
+        result = pricing_api.get_stripe_price_data('price_123')
+
+        self.assertIn('recurring', result)
+        self.assertEqual(result['recurring']['interval'], 'year')
+        self.assertEqual(result['recurring']['interval_count'], 1)
+        self.assertEqual(result['recurring']['usage_type'], 'licensed')
+
+    @mock.patch('enterprise_access.apps.customer_billing.pricing_api.stripe')
+    def test_get_stripe_price_data_caching(self, mock_stripe):
+        """Test that price data is properly cached."""
+        mock_price = self._create_mock_stripe_price()
+        mock_stripe.Price.retrieve.return_value = mock_price
+
+        # First call should hit Stripe
+        result1 = pricing_api.get_stripe_price_data('price_123')
+
+        # Second call should hit cache
+        result2 = pricing_api.get_stripe_price_data('price_123')
+
+        self.assertEqual(result1, result2)
+        # Stripe should only be called once
+        mock_stripe.Price.retrieve.assert_called_once()
+
+    @mock.patch('enterprise_access.apps.customer_billing.pricing_api.stripe.Price')
+    def test_get_stripe_price_data_stripe_error(self, mock_stripe_price):
+        """Test handling of Stripe API errors."""
+        mock_stripe_price.retrieve.side_effect = InvalidRequestError(
+            'No such price', 'price_123'
+        )
+
+        with self.assertRaises(pricing_api.StripePricingError):
+            pricing_api.get_stripe_price_data('price_123')
+
+    @mock.patch('enterprise_access.apps.customer_billing.pricing_api.get_stripe_price_data')
+    def test_get_multiple_stripe_prices(self, mock_get_price):
+        """Test fetching multiple prices."""
+        mock_get_price.side_effect = [
+            {'currency': 'usd', 'unit_amount_decimal': Decimal(100.0), 'unit_amount': 10000},
+            {'currency': 'usd', 'unit_amount_decimal': Decimal(200.0), 'unit_amount': 20000},
+        ]
+
+        result = pricing_api.get_multiple_stripe_prices(['price_1', 'price_2'])
+
+        expected = {
+            'price_1': {'currency': 'usd', 'unit_amount_decimal': Decimal(100.0), 'unit_amount': 10000},
+            'price_2': {'currency': 'usd', 'unit_amount_decimal': Decimal(200.0), 'unit_amount': 20000},
+        }
+
+        self.assertEqual(result, expected)
+        self.assertEqual(mock_get_price.call_count, 2)
+
+    @mock.patch('enterprise_access.apps.customer_billing.pricing_api.stripe')
+    def test_get_ssp_product_pricing(self, mock_stripe):
+        """Test fetching SSP product pricing."""
+        mock_price = self._create_mock_stripe_price()
+        mock_stripe.Price.retrieve.return_value = mock_price
+
+        result = pricing_api.get_ssp_product_pricing()
+
+        # Should have entries for configured SSP products
+        self.assertIn('quarterly_license_plan', result)
+        self.assertIn('yearly_license_plan', result)
+
+        # Check that SSP-specific metadata is added
+        quarterly_data = result['quarterly_license_plan']
+        self.assertEqual(quarterly_data['ssp_product_key'], 'quarterly_license_plan')
+        self.assertEqual(quarterly_data['quantity_range'], (5, 30))
+
+    def test_calculate_subtotal_basic_format(self):
+        """Test subtotal calculation with basic format."""
+        price_data = {
+            'unit_amount_decimal': Decimal(100.0),
+            'unit_amount': 10000,
+            'currency': 'usd',
+            'recurring': {
+                'interval': 'year',
+                'interval_count': 1,
+            }
+        }
+
+        result = pricing_api.calculate_subtotal(price_data, 5)
+
+        expected = {
+            'subtotal_cents': 50000,
+            'subtotal_decimal': 500.0,
+            'currency': 'usd',
+            'quantity': 5,
+            'unit_amount_cents': 10000,
+            'unit_amount_decimal': 100.0,
+            'billing_period': {
+                'interval': 'year',
+                'interval_count': 1,
+            }
+        }
+
+        self.assertEqual(result, expected)
+
+    def test_calculate_subtotal_non_usd_currency_data(self):
+        """Test subtotal calculation with non-usd currency data."""
+        price_data = {
+            'unit_amount_decimal': Decimal(85.0),
+            'unit_amount': 8500,
+            'currency': 'eur',
+        }
+
+        result = pricing_api.calculate_subtotal(price_data, 3)
+
+        expected = {
+            'subtotal_cents': 8500 * 3,
+            'subtotal_decimal': Decimal('255.00'),
+            'currency': 'eur',
+            'quantity': 3,
+            'unit_amount_cents': 8500,
+            'unit_amount_decimal': Decimal(85.0),
+        }
+        self.assertEqual(expected, result)
+
+    def test_format_price_display_basic_format(self):
+        """Test price display formatting with basic format."""
+        price_data = {
+            'unit_amount_decimal': Decimal(100.0),
+            'unit_amount': 10000,
+            'currency': 'usd',
+            'recurring': {
+                'interval': 'year',
+                'interval_count': 1,
+            }
+        }
+
+        result = pricing_api.format_price_display(price_data)
+        self.assertEqual(result, '$100.00/year')
+
+    def test_format_price_display_without_currency_symbol(self):
+        """Test price display formatting without currency symbol."""
+        price_data = {
+            'unit_amount_decimal': Decimal(100.0),
+            'unit_amount': 10000,
+            'currency': 'usd',
+        }
+
+        result = pricing_api.format_price_display(price_data, include_currency_symbol=False)
+        self.assertEqual(result, '100.00 USD')
+
+    def test_format_price_display_multi_interval(self):
+        """Test price display with multi-interval recurring."""
+        price_data = {
+            'unit_amount_decimal': Decimal(100.0),
+            'unit_amount': 10000,
+            'currency': 'usd',
+            'recurring': {
+                'interval': 'month',
+                'interval_count': 3,
+            }
+        }
+
+        result = pricing_api.format_price_display(price_data)
+        self.assertEqual(result, '$100.00/every 3 months')
+
+    def test_format_price_display_non_usd_currency(self):
+        """Test price display with non-USD currency data."""
+        price_data = {
+            'unit_amount_decimal': Decimal(42.31),
+            'unit_amount': 4231,
+            'currency': 'eur',
+        }
+
+        result = pricing_api.format_price_display(price_data, currency='eur', include_currency_symbol=False)
+        self.assertEqual(result, '42.31 EUR')
+
+    def test_format_price_display_mismatched_currency(self):
+        """Test price display with mismatched currency data."""
+        price_data = {
+            'unit_amount_decimal': Decimal(42.31),
+            'unit_amount': 4231,
+            'currency': 'eur',
+        }
+
+        # Price data in EUR, but we request USD
+        result = pricing_api.format_price_display(price_data, currency='usd')
+        self.assertEqual(result, 'Price unavailable')
+
+    def test_serialize_basic_format_edge_cases(self):
+        """Test serialization edge cases for basic format."""
+        # Test with zero amount
+        mock_price = self._create_mock_stripe_price(unit_amount=0)
+        result = pricing_api._serialize_basic_format(mock_price)  # pylint: disable=protected-access
+
+        self.assertEqual(result['unit_amount_decimal'], Decimal(0.0))
+        self.assertEqual(result['unit_amount'], 0)
+
+    def test_serialize_basic_format_no_product(self):
+        """Test serialization when product is not expanded."""
+        mock_price = self._create_mock_stripe_price()
+        mock_price.product = None  # No expanded product data
+
+        result = pricing_api._serialize_basic_format(mock_price)  # pylint: disable=protected-access
+
+        self.assertNotIn('product', result)
+        self.assertEqual(result['unit_amount_decimal'], Decimal(100.0))
+        self.assertEqual(result['unit_amount'], 10000)
+
+    def test_validate_stripe_price_schema_missing_field(self):
+        """Test schema validation with missing required field."""
+        mock_price = self._create_mock_stripe_price()
+        # Remove required field
+        del mock_price.currency
+
+        with mock.patch('enterprise_access.apps.customer_billing.pricing_api.stripe.Price') as mock_stripe_price:
+            mock_stripe_price.retrieve.return_value = mock_price
+
+            with self.assertRaises(pricing_api.StripePricingError) as cm:
+                pricing_api.get_stripe_price_data('price_123')
+
+            self.assertIn('Missing required field', str(cm.exception))
+
+    def test_validate_stripe_price_schema_invalid_type(self):
+        """Test schema validation with invalid field type."""
+        mock_price = self._create_mock_stripe_price()
+        # Set invalid type for unit_amount
+        mock_price.unit_amount = "invalid"
+
+        with mock.patch('enterprise_access.apps.customer_billing.pricing_api.stripe.Price') as mock_stripe_price:
+            mock_stripe_price.retrieve.return_value = mock_price
+
+            with self.assertRaises(pricing_api.StripePricingError) as cm:
+                pricing_api.get_stripe_price_data('price_123')
+
+            self.assertIn('Invalid unit_amount type', str(cm.exception))
+
+    def test_validate_stripe_price_schema_invalid_recurring(self):
+        """Test schema validation with invalid recurring data."""
+        mock_recurring = mock.MagicMock()
+        mock_recurring.interval = None  # Invalid - should be a string
+        mock_recurring.interval_count = 1
+
+        mock_price = self._create_mock_stripe_price(recurring=mock_recurring)
+
+        with mock.patch('enterprise_access.apps.customer_billing.pricing_api.stripe.Price') as mock_stripe_price:
+            mock_stripe_price.retrieve.return_value = mock_price
+
+            with self.assertRaises(pricing_api.StripePricingError) as cm:
+                pricing_api.get_stripe_price_data('price_123')
+
+            self.assertIn('Recurring price missing interval', str(cm.exception))
+
+    @ddt.data(
+        # All valid
+        {
+            "active": True,
+            "billing_scheme": "per_unit",
+            "type_": "recurring",
+            "recurring_usage_type": "licensed",
+            "expect_error": None,
+        },
+        # inactive price
+        {
+            "active": False,
+            "billing_scheme": "per_unit",
+            "type_": "recurring",
+            "recurring_usage_type": "licensed",
+            "expect_error": "Stripe price must be active",
+        },
+        # wrong billing_scheme
+        {
+            "active": True,
+            "billing_scheme": "tiered",
+            "type_": "recurring",
+            "recurring_usage_type": "licensed",
+            "expect_error": "Only per_unit billing_scheme is supported, got tiered",
+        },
+        # wrong type
+        {
+            "active": True,
+            "billing_scheme": "per_unit",
+            "type_": "one_time",
+            "recurring_usage_type": "licensed",
+            "expect_error": "Only recurring price type is supported, got one_time",
+        },
+        # wrong recurring.usage_type
+        {
+            "active": True,
+            "billing_scheme": "per_unit",
+            "type_": "recurring",
+            "recurring_usage_type": "metered",
+            "expect_error": "Only licensed recurring prices are supported, got metered",
+        },
+    )
+    @ddt.unpack
+    def test_validate_stripe_price_schema_variants(
+        self,
+        active,
+        billing_scheme,
+        type_,
+        recurring_usage_type,
+        expect_error,
+    ):
+        mock_recurring = mock.MagicMock()
+        mock_recurring.interval = "month"
+        mock_recurring.interval_count = 1
+        mock_recurring.usage_type = recurring_usage_type
+
+        mock_price = self._create_mock_stripe_price()
+        mock_price.active = active
+        mock_price.billing_scheme = billing_scheme
+        mock_price.type = type_
+        mock_price.recurring = mock_recurring
+
+        # pylint: disable=protected-access
+        if expect_error is None:
+            pricing_api._validate_stripe_price_schema(mock_price)
+        else:
+            with self.assertRaises(pricing_api.StripePricingError) as cm:
+                pricing_api._validate_stripe_price_schema(mock_price)
+            self.assertIn(expect_error, str(cm.exception))

--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -622,4 +622,7 @@ SSP_PRODUCTS = {
 ENABLE_CUSTOMER_BILLING_API = False
 STRIPE_API_KEY = None
 
+# How long we consider Stripe prices valid for
+STRIPE_PRICE_DATA_CACHE_TIMEOUT = 300
+
 ################# End Self-Service Purchasing (SSP) settings #################

--- a/enterprise_access/settings/devstack.py
+++ b/enterprise_access/settings/devstack.py
@@ -108,6 +108,7 @@ SHELL_PLUS_IMPORTS = [
     'from enterprise_access.apps.content_assignments import api as assignments_api',
     'from pprint import pprint',
     'from enterprise_access.apps.content_assignments import tasks as assignments_tasks',
+    'from enterprise_access.apps.customer_billing import pricing_api',
     'from enterprise_access.apps.provisioning.models import *',
     'from enterprise_access.apps.provisioning import api as provisioning_api',
 ]


### PR DESCRIPTION
**Description:**
Implements a central Python API for fetching and serializing Stripe pricing data to support the self-service purchasing. The API provides functions to fetch individual or multiple price records with TieredCache caching, serialize them in a basic format matching existing Learner Credit APIs, and includes utility functions for subtotal calculations and price display formatting. Schema validation ensures Stripe responses match expected structure, and comprehensive TypedDict definitions provide type safety and documentation for the serialized data format.

**How to test** 
Settings in private.py:
```python
STRIPE_API_KEY = '[STORED IN PASSWORD MANAGER or Stripe dashboard]'
# Placeholder Stripe products, override in prod.
SSP_PRODUCTS = {
    'find a product with a price': {
        'stripe_price_id': 'price_1234',
        'quantity_range': (0, 1000),
    },
}
```

Then run `./manage.py shell_plus` and do `pricing_api.get_stripe_price_data()` - this should print out a serialized dictionary of pricing info.

**Jira:**
ENT-10478

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
