### PR TITLE
feat: set LCR status to reversed when related content assignment is reversed

### DIFF
--- a/enterprise_access/apps/content_assignments/signals.py
+++ b/enterprise_access/apps/content_assignments/signals.py
@@ -3,7 +3,8 @@ Signal handlers for content_assignments app.
 """
 import logging
 
-from django.db import transaction
+from django.core.exceptions import ValidationError
+from django.db import DatabaseError, IntegrityError
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils import timezone
@@ -12,8 +13,17 @@ from openedx_events.enterprise.signals import LEDGER_TRANSACTION_REVERSED
 from enterprise_access.apps.content_assignments.constants import LearnerContentAssignmentStateChoices
 from enterprise_access.apps.content_assignments.models import LearnerContentAssignment
 from enterprise_access.apps.core.models import User
-from enterprise_access.apps.subsidy_request.models import LearnerCreditRequestActions, SubsidyRequestStates
-from enterprise_access.apps.subsidy_request.utils import get_action_choice, get_user_message_choice
+from enterprise_access.apps.subsidy_request.models import (
+    LearnerCreditRequestActionErrorReasons,
+    LearnerCreditRequestActions,
+    SubsidyRequestStates
+)
+from enterprise_access.apps.subsidy_request.utils import (
+    get_action_choice,
+    get_error_reason_choice,
+    get_user_message_choice
+)
+from enterprise_access.utils import format_traceback
 
 logger = logging.getLogger(__name__)
 
@@ -55,36 +65,50 @@ def update_assignment_status_for_reversed_transaction(**kwargs):
     except LearnerContentAssignment.DoesNotExist:
         logger.info(f'No LearnerContentAssignment exists with transaction uuid: {transaction_uuid}')
         return
-
-    if assignment_to_update.state in LearnerContentAssignmentStateChoices.REVERSIBLE_STATES:
-        with transaction.atomic():
-            assignment_to_update.state = LearnerContentAssignmentStateChoices.REVERSED
-            assignment_to_update.reversed_at = timezone.now()
-            assignment_to_update.save()
-            assignment_to_update.add_successful_reversal_action()
-            logger.info(
-                f"LearnerContentAssignment {assignment_to_update.uuid} reversed."
-            )
-
-            # --- Update linked LearnerCreditRequest if present ---
-            learner_credit_request = getattr(
-                assignment_to_update, "credit_request", None
-            )
-            if learner_credit_request:
-                learner_credit_request.state = SubsidyRequestStates.REVERSED
-                learner_credit_request.save(update_fields=["state"])
-                logger.info(
-                    f"LearnerCreditRequest {learner_credit_request.uuid} reversed due to assignment reversal."
-                )
-                # Add reversal action
-                LearnerCreditRequestActions.create_action(
-                    learner_credit_request=learner_credit_request,
-                    recent_action=get_action_choice(SubsidyRequestStates.REVERSED),
-                    status=get_user_message_choice(SubsidyRequestStates.REVERSED),
-                )
-
-    else:
+    if assignment_to_update.state not in LearnerContentAssignmentStateChoices.REVERSIBLE_STATES:
         logger.warning(
             f'Cannot reverse LearnerContentAssignment {assignment_to_update.uuid} '
             f'because its state is {assignment_to_update.state}'
         )
+        return
+
+    learner_credit_request = getattr(assignment_to_update, "credit_request", None)
+    action_instance = None
+
+    if learner_credit_request:
+        action_instance = LearnerCreditRequestActions.create_action(
+            learner_credit_request=learner_credit_request,
+            recent_action=get_action_choice(SubsidyRequestStates.REVERSED),
+            status=get_user_message_choice(SubsidyRequestStates.REVERSED),
+        )
+
+    try:
+        assignment_to_update.state = LearnerContentAssignmentStateChoices.REVERSED
+        assignment_to_update.reversed_at = timezone.now()
+        assignment_to_update.save()
+        assignment_to_update.add_successful_reversal_action()
+        logger.info(
+            f"LearnerContentAssignment {assignment_to_update.uuid} reversed."
+        )
+
+        if learner_credit_request:
+            learner_credit_request.state = SubsidyRequestStates.REVERSED
+            learner_credit_request.save(update_fields=["state"])
+            logger.info(
+                f"LearnerCreditRequest {learner_credit_request.uuid} reversed due to assignment reversal."
+            )
+
+    except (ValidationError, IntegrityError, DatabaseError) as exc:
+        error_msg = f"Failed to reverse LearnerContentAssignment {assignment_to_update.uuid}"
+        if learner_credit_request:
+            error_msg += f" and its associated LearnerCreditRequest {learner_credit_request.uuid}"
+        error_msg += f". The entire transaction was rolled back. Error: {exc}"
+        logger.error(error_msg)
+
+        if action_instance:
+            action_instance.status = get_user_message_choice(SubsidyRequestStates.ACCEPTED)
+            action_instance.error_reason = get_error_reason_choice(
+                LearnerCreditRequestActionErrorReasons.FAILED_REVERSAL
+            )
+            action_instance.traceback = format_traceback(exc)
+            action_instance.save()

--- a/enterprise_access/apps/content_assignments/tests/test_signals.py
+++ b/enterprise_access/apps/content_assignments/tests/test_signals.py
@@ -1,11 +1,24 @@
 """
 Signals and handlers tests.
 """
+from unittest import mock
+from uuid import uuid4
+
+from django.db import DatabaseError
 from django.test import TestCase
 from django.utils import timezone
 
+from enterprise_access.apps.content_assignments.constants import LearnerContentAssignmentStateChoices
+from enterprise_access.apps.content_assignments.models import LearnerContentAssignment
+from enterprise_access.apps.content_assignments.signals import update_assignment_status_for_reversed_transaction
 from enterprise_access.apps.content_assignments.tests.factories import LearnerContentAssignmentFactory
 from enterprise_access.apps.core.tests.factories import UserFactory
+from enterprise_access.apps.subsidy_request.models import (
+    LearnerCreditRequestActionErrorReasons,
+    LearnerCreditRequestActions,
+    SubsidyRequestStates
+)
+from enterprise_access.apps.subsidy_request.tests.factories import LearnerCreditRequestFactory
 
 TEST_EMAIL = 'test@example.com'
 
@@ -71,3 +84,64 @@ class SignalsTests(TestCase):
         for assignment in assignments_other_learner:
             assignment.refresh_from_db()
             assert assignment.lms_user_id is None
+
+
+class TestReversalSignal(TestCase):
+    """
+    Tests for reversal signals.
+    """
+
+    def setUp(self):
+        self.user = UserFactory()
+        self.assignment = LearnerContentAssignmentFactory(
+            state=LearnerContentAssignmentStateChoices.ACCEPTED,
+            lms_user_id=self.user.lms_user_id,
+            transaction_uuid=uuid4()
+        )
+        self.lcr = LearnerCreditRequestFactory(
+            user=self.user,
+            assignment=self.assignment,
+            state=SubsidyRequestStates.ACCEPTED,
+        )
+        self.assignment.refresh_from_db()
+
+    def test_assignment_and_lcr_reversal_happy_path(self):
+        update_assignment_status_for_reversed_transaction(
+            ledger_transaction=mock.Mock(uuid=self.assignment.transaction_uuid)
+        )
+        self.assignment.refresh_from_db()
+        self.lcr.refresh_from_db()
+        actions = LearnerCreditRequestActions.objects.filter(learner_credit_request=self.lcr)
+        assert actions.exists(), "No LearnerCreditRequestActions created"
+        action = actions.latest('created')
+
+        assert self.assignment.state == LearnerContentAssignmentStateChoices.REVERSED
+        assert self.lcr.state == SubsidyRequestStates.REVERSED
+        assert action.recent_action == SubsidyRequestStates.REVERSED
+        assert action.status == SubsidyRequestStates.REVERSED
+        assert not action.error_reason
+
+    def test_assignment_reversal_no_lcr(self):
+        assignment = LearnerContentAssignmentFactory(
+            state=LearnerContentAssignmentStateChoices.ACCEPTED,
+            lms_user_id=self.user.lms_user_id,
+            transaction_uuid=uuid4()
+        )
+        update_assignment_status_for_reversed_transaction(
+            ledger_transaction=mock.Mock(uuid=assignment.transaction_uuid)
+        )
+        assignment.refresh_from_db()
+        assert assignment.state == LearnerContentAssignmentStateChoices.REVERSED
+        assert not LearnerCreditRequestActions.objects.filter(learner_credit_request__assignment=assignment).exists()
+
+    def test_reversal_error_updates_action(self):
+        with mock.patch.object(LearnerContentAssignment, "save", side_effect=DatabaseError("Simulated DB error")):
+            update_assignment_status_for_reversed_transaction(
+                ledger_transaction=mock.Mock(uuid=self.assignment.transaction_uuid)
+            )
+        actions = LearnerCreditRequestActions.objects.filter(learner_credit_request=self.lcr)
+        assert actions.exists(), "No LearnerCreditRequestActions created"
+        action = actions.latest('created')
+        assert action.error_reason == LearnerCreditRequestActionErrorReasons.FAILED_REVERSAL
+        assert action.status == SubsidyRequestStates.ACCEPTED
+        assert "Simulated DB error" in action.traceback


### PR DESCRIPTION
**Description:**
We're not modifying the existing reversal mechanism for LearnerContentAssignment. We're simply updating the related LearnerCreditRequest to reversed whenever its associated assignment is reversed—ensuring the LCR reflects the correct state without altering the current flow.

**Jira:**
ENT-XXXX

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
