### PR TITLE
feat: add SubsidyAccessPolicy model validation to prevent inactive/retired budgets

### DIFF
--- a/enterprise_access/apps/subsidy_access_policy/constants.py
+++ b/enterprise_access/apps/subsidy_access_policy/constants.py
@@ -129,6 +129,21 @@ SORT_BY_ENROLLMENT_COUNT = 'enrollment_count'
 GROUP_MEMBERS_WITH_AGGREGATES_DEFAULT_PAGE_SIZE = 10
 
 # Exceeding the spend_limit validation error
-VALIDATION_ERROR_SPEND_LIMIT_EXCEEDS_STARTING_BALANCE = "You cannot make this change, as the sum of all budget \
-spend_limits for a given subsidy would exceed the sum of all deposits into that subsidy.  If you are trying to \
-re-balance policies, FIRST reduce the spend_limit of one, THEN increase the spend_limit of another."
+VALIDATION_ERROR_SPEND_LIMIT_EXCEEDS_STARTING_BALANCE = (
+    "You cannot make this change, as the sum of all budget spend_limits for a given subsidy would exceed "
+    "the sum of all deposits into that subsidy. If you are trying to re-balance policies, FIRST reduce the "
+    "spend_limit of one, THEN increase the spend_limit of another."
+)
+
+ERROR_MSG_ACTIVE_WITH_SPEND = (
+    "Cannot deactivate this policy while it is retired and has existing spend."
+)
+ERROR_MSG_ACTIVE_UNKNOWN_SPEND = (
+    "Cannot deactivate this policy while it is retired because spend could not be determined."
+)
+ERROR_MSG_RETIRED_WITH_SPEND = (
+    "Cannot retire this policy while it is inactive and has existing spend."
+)
+ERROR_MSG_RETIRED_UNKNOWN_SPEND = (
+    "Cannot retire this policy while it is inactive because spend could not be determined."
+)

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -75,7 +75,8 @@ from .utils import (
     ProxyAwareHistoricalRecords,
     cents_to_usd_string,
     create_idempotency_key_for_transaction,
-    get_versioned_subsidy_client
+    get_versioned_subsidy_client,
+    validate_retired_budget_deactivation
 )
 
 # Magic key that is used transaction metadata hint to the subsidy service and all downstream services that the
@@ -431,6 +432,10 @@ class SubsidyAccessPolicy(TimeStampedModel):
             self.clean_spend_limit()
         except ValidationError as exc:
             validation_errors['spend_limit'] = str(exc)
+
+        # Validate that retired budgets with spend cannot be deactivated
+        if not self._state.adding:
+            validate_retired_budget_deactivation(self)
 
         # Perform basic field constraint checks.
         for field_name, (constraint_function, error_message) in self.FIELD_CONSTRAINTS.items():


### PR DESCRIPTION
**Description:**
Adds model validation to `SubsidyAccessPolicy` to prevent inactive/retired budgets from saving via Django Admin.

<img width="944" alt="image" src="https://github.com/user-attachments/assets/96e8d3b7-31ae-44b8-9808-b11019f6096f" />

**Jira:**
[ENT-9126](https://2u-internal.atlassian.net/browse/ENT-9126)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
