### PR TITLE
feat: add utilization detail methods for PerLearnerSpentCreditAccessPolicy

### DIFF
--- a/enterprise_access/apps/api/serializers/subsidy_access_policy.py
+++ b/enterprise_access/apps/api/serializers/subsidy_access_policy.py
@@ -74,13 +74,14 @@ class SubsidyAccessPolicyAggregatesSerializer(serializers.Serializer):
     )
     amount_allocated_usd_cents = serializers.SerializerMethodField(
         help_text=(
-            f"Total amount allocated for policies of type {PolicyTypes.ASSIGNED_LEARNER_CREDIT} (0 otherwise), in "
-            "positive USD cents."
+            f"Total amount allocated for policies of type {PolicyTypes.ASSIGNED_LEARNER_CREDIT} or "
+            "{PolicyTypes.PER_LEARNER_SPEND_CREDIT} (0 otherwise), in positive USD cents."
         ),
     )
     amount_allocated_usd = serializers.SerializerMethodField(
         help_text=(
-            f"Total amount allocated for policies of type {PolicyTypes.ASSIGNED_LEARNER_CREDIT} (0 otherwise), in USD.",
+            f"Total amount allocated for policies of type {PolicyTypes.ASSIGNED_LEARNER_CREDIT} or ",
+            "{PolicyTypes.PER_LEARNER_SPEND_CREDIT} (0 otherwise), in USD."
         ),
     )
     spend_available_usd_cents = serializers.SerializerMethodField(


### PR DESCRIPTION
**Description:**
Added two methods `total_allocated` and `spend_available` for PerLearnerCreditAccessPolicy to return utilization details.

**Jira:**
[ENT-10338](https://2u-internal.atlassian.net/browse/ENT-10338)

**Merge checklist:**
- [x] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
