### PR TITLE
fix: credits_available endpoint should return BnR policy if per learner spent limit is 0

### DIFF
--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -1535,6 +1535,10 @@ class PerLearnerSpendCreditAccessPolicy(CreditPolicyMixin, SubsidyAccessPolicy,
 
         # Validate whether learner has enough remaining balance (spend) for this policy.
         remaining_balance_per_user = self.remaining_balance_per_user(lms_user_id)
+
+        if self.bnr_enabled and remaining_balance_per_user == 0:
+            return True
+
         return (remaining_balance_per_user is not None) and remaining_balance_per_user > 0
 
     def remaining_balance_per_user(self, lms_user_id=None):


### PR DESCRIPTION
**Description:**
Modified the `credits_available` model method for `PerLearnerSpendCreditAccessPolicy` to return True is BnR is enabled and per learner spent limit is set to 0.

**Jira:**
[ENT-10641](https://2u-internal.atlassian.net/browse/ENT-10641?atlOrigin=eyJpIjoiOTIzM2E1M2VmNzk0NDhmZWE4ZDIwYWY4ZTEwNjRmNDEiLCJwIjoiaiJ9)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
