### PR TITLE
feat: Minimal CheckoutIntent serializer

### DIFF
--- a/enterprise_access/apps/bffs/checkout/context.py
+++ b/enterprise_access/apps/bffs/checkout/context.py
@@ -1,6 +1,8 @@
 """
 Context classes for the Checkout BFF endpoints.
 """
+from django.conf import settings
+
 from enterprise_access.apps.bffs.context import BaseHandlerContext
 
 
@@ -12,17 +14,47 @@ class CheckoutContext(BaseHandlerContext):
     enterprise customer data, and field constraints.
     """
 
-    def __init__(self, request):
-        """
-        Initialize the checkout context with a request.
+    @property
+    def existing_customers_for_authenticated_user(self):
+        return self.data.get('existing_customers_for_authenticated_user', [])
 
-        Args:
-            request: The HTTP request
-        """
-        super().__init__(request)
-        self.existing_customers_for_authenticated_user = []
-        self.pricing = {}
-        self.field_constraints = {}
+    @existing_customers_for_authenticated_user.setter
+    def existing_customers_for_authenticated_user(self, value):
+        self.data['existing_customers_for_authenticated_user'] = value
+
+    @property
+    def pricing(self):
+        return self.data.get('pricing', {
+            'default_by_lookup_key': settings.DEFAULT_SSP_PRICE_LOOKUP_KEY,
+            'prices': []
+        })
+
+    @pricing.setter
+    def pricing(self, value):
+        self.data['pricing'] = value
+
+    @property
+    def field_constraints(self):
+        return self.data.get('field_constraints', {
+            'quantity': {'min': 5, 'max': 30},
+            'enterprise_slug': {
+                'min_length': 3,
+                'max_length': 30,
+                'pattern': '^[a-z0-9-]+$'
+            }
+        })
+
+    @field_constraints.setter
+    def field_constraints(self, value):
+        self.data['field_constraints'] = value
+
+    @property
+    def checkout_intent(self):
+        return self.data.get('checkout_intent', None)
+
+    @checkout_intent.setter
+    def checkout_intent(self, value):
+        self.data['checkout_intent'] = value
 
 
 class CheckoutValidationContext(BaseHandlerContext):

--- a/enterprise_access/apps/bffs/checkout/context.py
+++ b/enterprise_access/apps/bffs/checkout/context.py
@@ -62,13 +62,18 @@ class CheckoutValidationContext(BaseHandlerContext):
     Context class for checkout validation BFF endpoint.
     """
 
-    def __init__(self, request):
-        """
-        Initialize the checkout validaiton context with a request.
+    @property
+    def validation_decisions(self):
+        return self.data.get('validation_decisions', {})
 
-        Args:
-            request: The HTTP request
-        """
-        super().__init__(request)
-        self.validation_decisions = {}
-        self.user_authn = {}
+    @validation_decisions.setter
+    def validation_decisions(self, value):
+        self.data['validation_decisions'] = value
+
+    @property
+    def user_authn(self):
+        return self.data.get('user_authn', {})
+
+    @user_authn.setter
+    def user_authn(self, value):
+        self.data['user_authn'] = value

--- a/enterprise_access/apps/bffs/checkout/handlers.py
+++ b/enterprise_access/apps/bffs/checkout/handlers.py
@@ -2,16 +2,17 @@
 Handlers for the Checkout BFF endpoints.
 """
 import logging
-from typing import Dict, List, Optional
+from typing import Dict
 
 from django.conf import settings
-from django.urls import reverse
 
-from enterprise_access.apps.api_client.lms_client import LmsApiClient, LmsUserApiClient
+from enterprise_access.apps.api_client.lms_client import LmsApiClient
 from enterprise_access.apps.bffs.api import (
     get_and_cache_enterprise_customer_users,
     transform_enterprise_customer_users_data
 )
+from enterprise_access.apps.bffs.checkout.context import CheckoutContext, CheckoutValidationContext
+from enterprise_access.apps.bffs.checkout.serializers import CheckoutIntentModelSerializer
 from enterprise_access.apps.bffs.handlers import BaseHandler
 from enterprise_access.apps.customer_billing.api import validate_free_trial_checkout_session
 from enterprise_access.apps.customer_billing.models import CheckoutIntent
@@ -29,15 +30,16 @@ class CheckoutContextHandler(BaseHandler):
     - Pricing options for self-service subscriptions
     - Field constraints for the checkout form
     """
+    context: CheckoutContext
 
-    def __init__(self, context):
+    def __init__(self, context: CheckoutContext):
         """
         Initialize with the request context.
 
         Args:
             context: The handler context object containing request information
         """
-        self.context = context
+        super().__init__(context)
         self.lms_client = LmsApiClient()
 
     def load_and_process(self):
@@ -54,7 +56,7 @@ class CheckoutContextHandler(BaseHandler):
         try:
             self.context.pricing = self._get_pricing_data()
             self.context.field_constraints = self._get_field_constraints()
-            self.context.checkout_intent = CheckoutIntent.for_user(self.context.user)
+            self.context.checkout_intent = self._get_checkout_intent()
             if self.context.user:
                 self._load_enterprise_customers()
         except Exception as exc:  # pylint: disable=broad-exception-caught
@@ -66,6 +68,16 @@ class CheckoutContextHandler(BaseHandler):
                 user_message="Could not load and/or process checkout context data",
                 developer_message=f"Unable to load and/or process checkout context data: {exc}",
             )
+
+    def _get_checkout_intent(self) -> Dict | None:
+        """
+        Load checkout intent data (from database) for the given user.
+        """
+        checkout_intent_instance = CheckoutIntent.for_user(self.context.user)
+        checkout_intent_data = None
+        if checkout_intent_instance:
+            checkout_intent_data = CheckoutIntentModelSerializer(checkout_intent_instance).data
+        return checkout_intent_data
 
     def _load_enterprise_customers(self):
         """
@@ -109,7 +121,7 @@ class CheckoutContextHandler(BaseHandler):
                     })
 
             self.context.existing_customers_for_authenticated_user = formatted_customers
-        except Exception as exc:
+        except Exception as exc:  # pylint: disable=broad-exception-caught
             logger.exception(
                 "Error loading enterprise customers for user: %s",
                 exc
@@ -133,7 +145,7 @@ class CheckoutContextHandler(BaseHandler):
 
             # Format the pricing data according to our API response schema
             prices = []
-            for product_key, price_data in pricing_data.items():
+            for _, price_data in pricing_data.items():
                 prices.append({
                     'id': price_data.get('id'),
                     'product': price_data.get('product', {}).get('id'),
@@ -188,10 +200,12 @@ class CheckoutValidationHandler(BaseHandler):
     """
     Handler for validating checkout form fields.
     """
-    def __init__(self, context):
-        self.context = context
+    context: CheckoutValidationContext
+
+    def __init__(self, context: CheckoutValidationContext):
+        super().__init__(context)
         self.user = getattr(context.request, 'user', None)
-        self.authenticated_user = self.user if self.user.is_authenticated else None
+        self.authenticated_user = self.user if self.user and self.user.is_authenticated else None
 
     def load_and_process(self):
         """
@@ -206,7 +220,8 @@ class CheckoutValidationHandler(BaseHandler):
         if (admin_email := request_data.get('admin_email')):
             user_exists_for_email = self._check_user_existence(admin_email)
 
-        validation_data = {k: v for k, v in request_data.items()}
+        # Create a mutable copy of the request data.
+        validation_data = dict(request_data.items())
         validation_decisions = {}
 
         # Only validate enterprise_slug if authenticated

--- a/enterprise_access/apps/bffs/checkout/response_builder.py
+++ b/enterprise_access/apps/bffs/checkout/response_builder.py
@@ -6,6 +6,7 @@ from rest_framework import status
 
 from enterprise_access.apps.bffs.checkout.serializers import (
     CheckoutContextResponseSerializer,
+    CheckoutIntentModelSerializer,
     CheckoutValidationResponseSerializer
 )
 from enterprise_access.apps.bffs.response_builder import BaseResponseBuilder
@@ -22,22 +23,15 @@ class CheckoutContextResponseBuilder(BaseResponseBuilder):
         Build the response data from the context. This specifically does *not*
         call super().build().
         """
-        # Create the response structure
+        checkout_intent_data = None
+        if self.context.checkout_intent:
+            checkout_intent_data = CheckoutIntentModelSerializer(self.context.checkout_intent).data
+
         response_data = {
-            'existing_customers_for_authenticated_user':
-                getattr(self.context, 'existing_customers_for_authenticated_user', []),
-            'pricing': getattr(self.context, 'pricing', {
-                'default_by_lookup_key': settings.DEFAULT_SSP_PRICE_LOOKUP_KEY,
-                'prices': []
-            }),
-            'field_constraints': getattr(self.context, 'field_constraints', {
-                'quantity': {'min': 5, 'max': 30},
-                'enterprise_slug': {
-                    'min_length': 3,
-                    'max_length': 30,
-                    'pattern': '^[a-z0-9-]+$'
-                }
-            })
+            'existing_customers_for_authenticated_user': self.context.existing_customers_for_authenticated_user,
+            'pricing': self.context.pricing,
+            'field_constraints': self.context.field_constraints,
+            'checkout_intent': checkout_intent_data,
         }
 
         # Update the data with the serialized data

--- a/enterprise_access/apps/bffs/checkout/response_builder.py
+++ b/enterprise_access/apps/bffs/checkout/response_builder.py
@@ -1,12 +1,8 @@
 """
 Response builders for the Checkout BFF endpoints.
 """
-from django.conf import settings
-from rest_framework import status
-
 from enterprise_access.apps.bffs.checkout.serializers import (
     CheckoutContextResponseSerializer,
-    CheckoutIntentModelSerializer,
     CheckoutValidationResponseSerializer
 )
 from enterprise_access.apps.bffs.response_builder import BaseResponseBuilder
@@ -23,15 +19,11 @@ class CheckoutContextResponseBuilder(BaseResponseBuilder):
         Build the response data from the context. This specifically does *not*
         call super().build().
         """
-        checkout_intent_data = None
-        if self.context.checkout_intent:
-            checkout_intent_data = CheckoutIntentModelSerializer(self.context.checkout_intent).data
-
         response_data = {
             'existing_customers_for_authenticated_user': self.context.existing_customers_for_authenticated_user,
             'pricing': self.context.pricing,
             'field_constraints': self.context.field_constraints,
-            'checkout_intent': checkout_intent_data,
+            'checkout_intent': self.context.checkout_intent,
         }
 
         # Update the data with the serialized data

--- a/enterprise_access/apps/bffs/handlers.py
+++ b/enterprise_access/apps/bffs/handlers.py
@@ -14,7 +14,7 @@ from enterprise_access.apps.bffs.api import (
     invalidate_enterprise_course_enrollments_cache,
     invalidate_subscription_licenses_cache
 )
-from enterprise_access.apps.bffs.context import HandlerContext
+from enterprise_access.apps.bffs.context import BaseHandlerContext, HandlerContext
 from enterprise_access.apps.bffs.mixins import BaseLearnerDataMixin, LearnerDashboardDataMixin
 from enterprise_access.apps.bffs.serializers import EnterpriseCustomerUserSubsidiesSerializer
 
@@ -27,7 +27,7 @@ class BaseHandler:
     The `BaseHandler` includes core methods for loading data and adding errors to the context.
     """
 
-    def __init__(self, context: HandlerContext):
+    def __init__(self, context: BaseHandlerContext):
         """
         Initializes the BaseHandler with a HandlerContext.
         Args:
@@ -71,13 +71,14 @@ class BaseLearnerPortalHandler(BaseHandler, BaseLearnerDataMixin):
     The `BaseLearnerHandler` extends `BaseHandler` and provides shared core functionality
     across all learner-focused page routes, such as the learner dashboard, search, and course routes.
     """
+    context: HandlerContext
 
-    def __init__(self, context):
+    def __init__(self, context: HandlerContext):
         """
-         Initializes the BaseLearnerPortalHandler with a HandlerContext and API clients.
-         Args:
-             context (HandlerContext): The context object containing request information and data.
-         """
+        Initializes the BaseLearnerPortalHandler with a HandlerContext and API clients.
+        Args:
+            context (HandlerContext): The context object containing request information and data.
+        """
         super().__init__(context)
 
         # API Clients

--- a/enterprise_access/apps/bffs/tests/test_checkout_handlers.py
+++ b/enterprise_access/apps/bffs/tests/test_checkout_handlers.py
@@ -226,11 +226,13 @@ class TestCheckoutContextHandler(APITest):
         """
         # Setup
         mock_get_pricing.return_value = {}
-        mock_intent = mock.MagicMock()
-        mock_intent.state = 'created'
-        mock_intent.enterprise_name = 'Test Enterprise'
-        mock_intent.enterprise_slug = 'test-slug'
-        mock_intent.admin_portal_url = 'https://portal.edx.org/test-slug'
+        mock_intent_data = {
+            'state': 'created',
+            'enterprise_name': 'Test Enterprise',
+            'enterprise_slug': 'test-slug',
+            'admin_portal_url': 'https://portal.edx.org/test-slug',
+        }
+        mock_intent = mock.MagicMock(**mock_intent_data)  # type: ignore
         mock_filter.return_value.first.return_value = mock_intent
 
         context = self._create_context()
@@ -240,7 +242,7 @@ class TestCheckoutContextHandler(APITest):
         handler.load_and_process()
 
         # Assert
-        self.assertEqual(context.checkout_intent, mock_intent)
+        self.assertEqual(context.checkout_intent, context.checkout_intent or {} | mock_intent_data)
         mock_filter.assert_called_once_with(user=self.user)
 
     @mock.patch('enterprise_access.apps.bffs.checkout.handlers.get_ssp_product_pricing')

--- a/enterprise_access/apps/bffs/tests/test_checkout_response_builder.py
+++ b/enterprise_access/apps/bffs/tests/test_checkout_response_builder.py
@@ -3,7 +3,6 @@ Tests for Checkout BFF response builders.
 """
 from datetime import timedelta
 from decimal import Decimal
-from unittest import mock
 
 import ddt
 from django.test import RequestFactory
@@ -30,17 +29,18 @@ class TestCheckoutContextResponseBuilder(APITest):
         self.request = self.request_factory.post('/api/v1/bffs/checkout/context')
         self.request.user = self.user
 
-        self.mock_checkout_intent = mock.MagicMock()
-        self.mock_checkout_intent.id = 123
-        self.mock_checkout_intent.state = 'created'
-        self.mock_checkout_intent.enterprise_name = 'Test Enterprise'
-        self.mock_checkout_intent.enterprise_slug = 'test-enterprise'
-        self.mock_checkout_intent.expires_at = timezone.now() + timedelta(hours=24)
-        self.mock_checkout_intent.stripe_checkout_session_id = 'cs_test_123abc'
-        self.mock_checkout_intent.last_checkout_error = ''
-        self.mock_checkout_intent.last_provisioning_error = ''
-        self.mock_checkout_intent.workflow = None
-        self.mock_checkout_intent.admin_portal_url = 'https://portal.edx.org/test-enterprise'
+        self.mock_checkout_intent = {
+            'id': 123,
+            'state': 'created',
+            'enterprise_name': 'Test Enterprise',
+            'enterprise_slug': 'test-enterprise',
+            'expires_at': timezone.now() + timedelta(hours=24),
+            'stripe_checkout_session_id': 'cs_test_123abc',
+            'last_checkout_error': '',
+            'last_provisioning_error': '',
+            'workflow': None,
+            'admin_portal_url': 'https://portal.edx.org/test-enterprise',
+        }
 
     def _create_context(self):
         """
@@ -374,7 +374,7 @@ class TestCheckoutContextResponseBuilder(APITest):
         # Setup context with a PAID checkout intent
         context = self._create_minimal_valid_context()
         paid_intent = self.mock_checkout_intent
-        paid_intent.state = 'paid'
+        paid_intent['state'] = 'paid'
         context.checkout_intent = paid_intent
 
         # Create and build response
@@ -396,8 +396,8 @@ class TestCheckoutContextResponseBuilder(APITest):
         # Setup context with a checkout intent that has errors
         context = self._create_minimal_valid_context()
         error_intent = self.mock_checkout_intent
-        error_intent.state = 'errored_stripe_checkout'
-        error_intent.last_checkout_error = 'Payment processing failed'
+        error_intent['state'] = 'errored_stripe_checkout'
+        error_intent['last_checkout_error'] = 'Payment processing failed'
         context.checkout_intent = error_intent
 
         # Create and build response

--- a/enterprise_access/apps/customer_billing/constants.py
+++ b/enterprise_access/apps/customer_billing/constants.py
@@ -1,6 +1,7 @@
 """
 Constants for customer_billing app.
 """
+from enum import StrEnum
 
 CHECKOUT_SESSION_ERROR_CODES = {
     'common': {
@@ -61,7 +62,7 @@ SLUG_RESERVATION_DURATION_MINUTES = 24 * 60
 INTENT_RESERVATION_DURATION_MINUTES = 24 * 60
 
 
-class CheckoutIntentState:
+class CheckoutIntentState(StrEnum):
     """
     Namespace for CheckoutIntent state values
     """

--- a/enterprise_access/apps/customer_billing/models.py
+++ b/enterprise_access/apps/customer_billing/models.py
@@ -361,6 +361,18 @@ class CheckoutIntent(TimeStampedModel):
             expires_at=expires_at,
         )
 
+    @classmethod
+    def for_user(cls, user):
+        """
+        Fetch the CheckoutIntent for a user.
+
+        Returns:
+          CheckoutIntent: The user's checkout intent, or None if not found
+        """
+        if not user or not user.is_authenticated:
+            return None
+        return cls.objects.filter(user=user).first()
+
     def update_stripe_session_id(self, session_id):
         """Update the associated Stripe checkout session ID."""
         self.stripe_checkout_session_id = session_id


### PR DESCRIPTION
ENT-10700 | CheckoutIntent state needs to be surfaced to the frontend in order to give real-time feedback to the "go to dashboard" stateful button, conditionally perform a forced redirect from other pages to the success page, and support a hard refresh of the Success page.
This change adds a minimal CI serializer to the checkout context BFF response.

https://2u-internal.atlassian.net/browse/ENT-10700

API docs:
http://localhost:18270/api/schema/redoc/#tag/Checkout-BFF/operation/checkout_context

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
