### PR TITLE
feat: add organization name in celery tasks

### DIFF
--- a/enterprise_access/apps/api/tasks.py
+++ b/enterprise_access/apps/api/tasks.py
@@ -107,6 +107,8 @@ def send_notification_email_for_request(
     recipient = braze_client_instance.create_recipient(user_email=user.email, lms_user_id=user.lms_user_id)
     enterprise_customer_data = lms_client.get_enterprise_customer_data(subsidy_request.enterprise_customer_uuid)
 
+    organization = enterprise_customer_data.get('name')
+
     admin_emails = [user['email'] for user in enterprise_customer_data['admin_users']]
     braze_trigger_properties['contact_admin_link'] = braze_client_instance.generate_mailto_link(admin_emails)
 
@@ -123,6 +125,7 @@ def send_notification_email_for_request(
     braze_trigger_properties['course_about_page_url'] = course_about_page_url
     braze_trigger_properties['course_title'] = subsidy_request.course_title
     braze_trigger_properties['enterprise_dashboard_url'] = enterprise_dashboard_url
+    braze_trigger_properties['organization'] = organization
 
     logger.info(f'Sending braze campaign message for subsidy request {subsidy_request}')
     braze_client_instance.send_campaign_message(

--- a/enterprise_access/apps/api/tests/test_tasks.py
+++ b/enterprise_access/apps/api/tests/test_tasks.py
@@ -136,13 +136,15 @@ class TestTasks(APITestWithMocks):
 
         slug = 'sluggy'
         admin_email = 'edx@example.org'
+        organization = 'Test Organization'
 
         mock_lms_client().get_enterprise_customer_data.return_value = {
             'slug': slug,
             'admin_users': [{
                 'email': admin_email,
                 'lms_user_id': 1
-            }]
+            }],
+            'name': organization
         }
 
         mock_recipient = {
@@ -176,7 +178,8 @@ class TestTasks(APITestWithMocks):
                 'contact_admin_link': mock_admin_mailto,
                 'course_title': self.license_requests[0].course_title,
                 'course_about_page_url': expected_course_about_page_url,
-                'enterprise_dashboard_url': expected_enterprise_dashboard_url
+                'enterprise_dashboard_url': expected_enterprise_dashboard_url,
+                'organization': organization,
             },
         )
         assert mock_braze_client().send_campaign_message.call_count == 1

--- a/enterprise_access/apps/subsidy_request/tasks.py
+++ b/enterprise_access/apps/subsidy_request/tasks.py
@@ -184,6 +184,7 @@ def send_learner_credit_bnr_admins_email_with_new_requests_task(
     lms_client = LmsApiClient()
     enterprise_customer_data = lms_client.get_enterprise_customer_data(enterprise_customer_uuid)
     enterprise_slug = enterprise_customer_data.get('slug')
+    organization = enterprise_customer_data.get('name')
 
     manage_requests_url = (f'{settings.ENTERPRISE_ADMIN_PORTAL_URL}/{enterprise_slug}'
                            f'/admin/learner-credit/{policy_uuid}/requests')
@@ -208,6 +209,7 @@ def send_learner_credit_bnr_admins_email_with_new_requests_task(
         'manage_requests_url': manage_requests_url,
         'requests': [],
         'total_requests': len(subsidy_requests),
+        'organization': organization,
     }
 
     for subsidy_request in latest_subsidy_requests:


### PR DESCRIPTION
**Description:**
Added organization name in braze trigger properties for celery tasks.

**Jira:**
[ENT-10769](https://2u-internal.atlassian.net/browse/ENT-10769)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
