### PR TITLE
fix: permissions to view learner profile in admin portal

### DIFF
--- a/enterprise_access/apps/api/v1/views/admin_portal_learner_profile.py
+++ b/enterprise_access/apps/api/v1/views/admin_portal_learner_profile.py
@@ -4,6 +4,7 @@ REST API views for the admin_portal_learner_profile app.
 import logging
 
 from drf_spectacular.utils import extend_schema
+from edx_rbac.decorators import permission_required
 from rest_framework import permissions, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -11,6 +12,7 @@ from rest_framework.viewsets import ViewSet
 
 from enterprise_access.apps.admin_portal_learner_profile import api as admin_portal_learner_profile_api
 from enterprise_access.apps.admin_portal_learner_profile import serializers
+from enterprise_access.apps.core.constants import ADMIN_LEARNER_PROFILE_READ_PERMISSION
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +30,7 @@ class AdminLearnerProfileViewSet(ViewSet):
     - enterprise_customer_uuid (string): The UUID of an enterprise customer.
     """
 
-    permission_classes = [permissions.IsAdminUser]
+    permission_classes = [permissions.IsAuthenticated]
 
     @extend_schema(
         tags=['Admin Portal Learner Profile'],
@@ -39,6 +41,9 @@ class AdminLearnerProfileViewSet(ViewSet):
         }
     )
     @action(detail=False, methods=['get'])
+    @permission_required(
+        ADMIN_LEARNER_PROFILE_READ_PERMISSION,
+        fn=lambda request, *args, **kwargs: request.query_params.get('enterprise_customer_uuid'))
     def learner_profile(self, request):
         """
         Retrieves all licenses, subscriptions, and enrollments associated with

--- a/enterprise_access/apps/core/constants.py
+++ b/enterprise_access/apps/core/constants.py
@@ -38,6 +38,9 @@ CUSTOMER_BILLING_OPERATOR_ROLE = 'enterprise_access_customer_billing_operator'
 CUSTOMER_BILLING_ADMIN_ROLE = 'enterprise_access_customer_billing_admin'
 CUSTOMER_BILLING_CREATE_PORTAL_SESSION_PERMISSION = 'customer_billing.create_portal_session'
 
+ADMIN_LEARNER_PROFILE_ADMIN_ROLE = 'enterprise_access_admin_learner_profile_admin'
+ADMIN_LEARNER_PROFILE_READ_PERMISSION = 'admin_learner_profile.has_read_access'
+
 PROVISIONING_ADMIN_ROLE = 'provisioning_admin'
 PROVISIONING_CREATE_PERMISSION = 'provisioning.can_create'
 

--- a/enterprise_access/apps/core/rules.py
+++ b/enterprise_access/apps/core/rules.py
@@ -342,6 +342,29 @@ def has_explicit_access_to_customer_billing_admin(user, enterprise_customer_uuid
     return _has_explicit_access_to_role(user, enterprise_customer_uuid, constants.CUSTOMER_BILLING_ADMIN_ROLE)
 
 
+@rules.predicate
+def has_implicit_access_to_admin_learner_profile_admin(_, enterprise_customer_uuid):
+    """
+    Check that if request user has implicit access to the given enterprise UUID for the
+    `ADMIN_LEARNER_PROFILE_ADMIN_ROLE` feature role.
+
+    Returns:
+        boolean: whether the request user has access.
+    """
+    return _has_implicit_access_to_role(_, enterprise_customer_uuid, constants.ADMIN_LEARNER_PROFILE_ADMIN_ROLE)
+
+
+@rules.predicate
+def has_explicit_access_to_admin_learner_profile_admin(user, enterprise_customer_uuid):
+    """
+    Check that if request user has explicit access to `ADMIN_LEARNER_PROFILE_ADMIN_ROLE` feature role.
+
+    Returns:
+        boolean: whether the request user has access.
+    """
+    return _has_explicit_access_to_role(user, enterprise_customer_uuid, constants.ADMIN_LEARNER_PROFILE_ADMIN_ROLE)
+
+
 ######################################################
 # Consolidate implicit and explicit rule predicates. #
 ######################################################
@@ -401,6 +424,11 @@ has_customer_billing_operator_access = (
 
 has_customer_billing_admin_access = (
     has_implicit_access_to_customer_billing_admin | has_explicit_access_to_customer_billing_admin
+)
+
+
+has_admin_learner_profile_admin_access = (
+    has_implicit_access_to_admin_learner_profile_admin | has_explicit_access_to_admin_learner_profile_admin
 )
 
 
@@ -519,4 +547,10 @@ rules.add_perm(
 rules.add_perm(
     constants.CUSTOMER_BILLING_CREATE_PORTAL_SESSION_PERMISSION,
     has_customer_billing_operator_access | has_customer_billing_admin_access,
+)
+
+# Grants admin learner profile read permission to admin learner profile admins.
+rules.add_perm(
+    constants.ADMIN_LEARNER_PROFILE_READ_PERMISSION,
+    has_admin_learner_profile_admin_access,
 )

--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -4,6 +4,7 @@ from os.path import abspath, dirname, join
 from corsheaders.defaults import default_headers as corsheaders_default_headers
 
 from enterprise_access.apps.core.constants import (
+    ADMIN_LEARNER_PROFILE_ADMIN_ROLE,
     BFF_ADMIN_ROLE,
     BFF_LEARNER_ROLE,
     BFF_OPERATOR_ROLE,
@@ -351,6 +352,7 @@ SYSTEM_TO_FEATURE_ROLE_MAPPING = {
         REQUESTS_ADMIN_ROLE,
         BFF_ADMIN_ROLE,
         CUSTOMER_BILLING_ADMIN_ROLE,
+        ADMIN_LEARNER_PROFILE_ADMIN_ROLE,
     ],
     SYSTEM_ENTERPRISE_LEARNER_ROLE: [
         SUBSIDY_ACCESS_POLICY_LEARNER_ROLE,


### PR DESCRIPTION
**Description:**
Update the permissions to allow enterprise admins to view a learner's profile in the admin portal. Previously, only staff was able to access the endpoint because the code was checking for `isAdminUser`.

```
IsAdminUser is a built-in permission class in Django REST Framework (DRF) designed to restrict access to API views to only users with administrative privileges.
Key characteristics of IsAdminUser:
Grants access based on is_staff:
This permission class allows permission only if the user.is_staff attribute of the authenticated user is set to True. This attribute is typically used to designate administrative users in Django's authentication system.
```

**Jira:**
[ENT-10786
](https://2u-internal.atlassian.net/browse/ENT-10786)

<img width="1507" height="843" alt="Screenshot 2025-08-10 at 1 41 00 PM" src="https://github.com/user-attachments/assets/7b33a6a8-3e44-4e46-aaae-33ddeb698f15" />

<img width="1146" height="832" alt="Screenshot 2025-08-10 at 1 40 36 PM" src="https://github.com/user-attachments/assets/ef7bb824-842b-4000-a086-9225b8ffff67" />

### Test
1. Create an admin user without the `is_staff` status and assign it to an enterprise.
2. Spin up the admin profile locally with `npm run start` and ensure you can view the profile.

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
