### PR TITLE
Aed/checkout bff success

### DIFF
--- a/enterprise_access/apps/api/serializers/customer_billing.py
+++ b/enterprise_access/apps/api/serializers/customer_billing.py
@@ -20,6 +20,10 @@ class CustomerBillingCreateCheckoutSessionRequestSerializer(serializers.Serializ
         required=True,
         help_text='The unique slug proposed for the Enterprise Customer.',
     )
+    company_name = serializers.CharField(
+        required=True,
+        help_text='The unique name proposed for the Enterprise Customer.',
+    )
     quantity = serializers.IntegerField(
         required=True,
         min_value=1,

--- a/enterprise_access/apps/api/v1/tests/test_checkout_bff_views.py
+++ b/enterprise_access/apps/api/v1/tests/test_checkout_bff_views.py
@@ -3,11 +3,15 @@ Tests for the Checkout BFF ViewSet.
 """
 import json
 import uuid
+from datetime import datetime, timedelta
+from decimal import Decimal
 from unittest import mock
 
 from django.conf import settings
 from django.test import RequestFactory
 from django.urls import reverse
+from django.utils import timezone
+from pytz import UTC
 from rest_framework import status
 
 from enterprise_access.apps.api.v1.views.bffs.checkout import CheckoutBFFViewSet
@@ -19,6 +23,8 @@ from enterprise_access.apps.bffs.checkout.serializers import (
     PriceSerializer
 )
 from enterprise_access.apps.core.constants import SYSTEM_ENTERPRISE_LEARNER_ROLE
+from enterprise_access.apps.customer_billing.constants import CheckoutIntentState
+from enterprise_access.apps.customer_billing.models import CheckoutIntent
 from test_utils import APITest
 
 
@@ -240,13 +246,11 @@ class CheckoutBFFViewSetTests(APITest):
             ]
         }
 
-        # Authenticate the user
         self.set_jwt_cookie([{
             'system_wide_role': SYSTEM_ENTERPRISE_LEARNER_ROLE,
             'context': str(uuid.uuid4()),
         }])
 
-        # Make the request
         response = self.client.post(self.url, {}, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -268,10 +272,8 @@ class CheckoutBFFViewSetTests(APITest):
         """
         Test that the API handles errors from enterprise customer APIs gracefully.
         """
-        # Make the API throw an exception
         mock_get_customers.side_effect = Exception("API Error")
 
-        # Authenticate the user
         self.set_jwt_cookie([{
             'system_wide_role': SYSTEM_ENTERPRISE_LEARNER_ROLE,
             'context': str(uuid.uuid4()),
@@ -290,7 +292,6 @@ class CheckoutBFFViewSetTests(APITest):
         """
         Test that the API handles errors from pricing APIs gracefully.
         """
-        # Make the API throw an exception
         mock_get_pricing.side_effect = Exception("API Error")
 
         # Make the request - should not fail
@@ -307,7 +308,6 @@ class CheckoutBFFViewSetTests(APITest):
         """
         Test that pricing data is correctly formatted in the response.
         """
-        # Setup mock to return pricing data
         mock_get_pricing.return_value = {
             'product1': {
                 'id': 'price_123',
@@ -322,11 +322,9 @@ class CheckoutBFFViewSetTests(APITest):
             }
         }
 
-        # Make the request
         response = self.client.post(self.url, {}, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        # Verify the pricing data
         pricing = response.data['pricing']
         self.assertIn('prices', pricing)
         self.assertEqual(len(pricing['prices']), 1)
@@ -478,3 +476,232 @@ class TestCheckoutValidationBFF(APITest):
             validation_decisions = content['validation_decisions']
             self.assertEqual(validation_decisions['company_name']['error_code'], 'existing_enterprise_customer')
             self.assertEqual(validation_decisions['quantity']['error_code'], 'range_exceeded')
+
+
+class CheckoutBFFSuccessViewSetTests(APITest):
+    """Tests for the CheckoutBFFViewSet success action."""
+
+    url = reverse('api:v1:checkout-bff-success')
+
+    def setUp(self):
+        """Set up test data before each test."""
+        super().setUp()
+
+        # Sample checkout intent data
+        self.checkout_intent_data = {
+            'uuid': str(uuid.uuid4()),
+            'state': 'created',
+            'enterprise_name': 'Test Enterprise',
+            'enterprise_slug': 'test-enterprise',
+            'stripe_checkout_session_id': 'cs_test_123',
+            'last_checkout_error': '',
+            'last_provisioning_error': '',
+            'workflow_id': str(uuid.uuid4()),
+            'expires_at': datetime.now(tz=UTC).isoformat(),
+            'admin_portal_url': 'https://portal.edx.org/test-enterprise',
+            'first_billable_invoice': {
+                'start_time': datetime.now(tz=UTC).isoformat(),
+                'end_time': datetime.now(tz=UTC).isoformat(),
+                'last4': 4242,
+                'quantity': 35,
+                'unit_amount_decimal': 396.00,
+                'customer_phone': '+15551234567',
+                'customer_name': 'Test Customer',
+                'billing_address': {
+                    'city': 'New York',
+                    'country': 'US',
+                    'line1': '123 Main St',
+                    'line2': 'Apt 4B',
+                    'postal_code': '10001',
+                    'state': 'NY',
+                },
+            },
+        }
+
+        self.set_jwt_cookie([{
+            'system_wide_role': SYSTEM_ENTERPRISE_LEARNER_ROLE,
+            'context': str(uuid.uuid4()),
+        }])
+
+    def test_success_unauthenticated(self):
+        """Test that unauthenticated users get a 401."""
+        # Clear authentication
+        self.client.cookies.clear()
+
+        response = self.client.post(self.url, {})
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    @mock.patch('enterprise_access.apps.bffs.checkout.handlers.get_ssp_product_pricing')
+    @mock.patch('enterprise_access.apps.bffs.checkout.handlers.get_and_cache_enterprise_customer_users')
+    @mock.patch('enterprise_access.apps.bffs.checkout.handlers.CheckoutSuccessHandler')
+    @mock.patch('enterprise_access.apps.bffs.checkout.context.CheckoutSuccessContext')
+    def test_success_endpoint_empty_response(  # pylint: disable=unused-argument
+        self, mock_context_class, mock_handler_class, mock_get_customers, mock_get_pricing,
+    ):
+        """Test success endpoint when no checkout intent is found."""
+        mock_context = mock.MagicMock()
+        mock_context_class.return_value = mock_context
+        mock_handler = mock.MagicMock()
+        mock_handler_class.return_value = mock_handler
+        mock_handler.load_and_process.return_value = None
+
+        mock_context.checkout_intent = {}
+
+        response = self.client.post(self.url, {})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.json()['checkout_intent'])
+
+    @mock.patch('enterprise_access.apps.bffs.checkout.handlers.get_ssp_product_pricing')
+    @mock.patch('enterprise_access.apps.bffs.checkout.handlers.get_and_cache_enterprise_customer_users')
+    @mock.patch('enterprise_access.apps.bffs.checkout.handlers.CheckoutSuccessHandler._get_checkout_intent')
+    @mock.patch('enterprise_access.apps.bffs.checkout.handlers.CheckoutSuccessHandler.enhance_with_stripe_data')
+    def test_success_endpoint_handler_exception(  # pylint: disable=unused-argument
+        self, mock_enhance, mock_get_checkout_intent, mock_get_customers, mock_get_pricing,
+    ):
+        """Test success endpoint when handler raises an exception."""
+        mock_enhance.side_effect = Exception("Special Handler error")
+        mock_get_checkout_intent.return_value = self.checkout_intent_data
+
+        response = self.client.post(self.url, {})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("Special Handler error", str(response.json()['errors']))
+
+    @mock.patch('enterprise_access.apps.bffs.checkout.handlers.CheckoutIntent.for_user')
+    def test_success_endpoint_no_checkout_session(self, mock_for_user):
+        """Test the success endpoint when no checkout session id is present."""
+        mock_checkout_intent = CheckoutIntent.objects.create(
+            user_id=self.user.id,
+            state=CheckoutIntentState.CREATED,
+            quantity=10,
+            enterprise_name='Test Enterprise',
+            enterprise_slug='test-enterprise',
+            stripe_checkout_session_id=None,
+            last_checkout_error='',
+            last_provisioning_error='',
+            expires_at=timezone.now() + timedelta(hours=4),
+        )
+        mock_for_user.return_value = mock_checkout_intent
+
+        response = self.client.post(self.url, {})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Response should include basic fields from the checkout intent
+        response_data = response.json()['checkout_intent']
+        self.assertEqual(response_data['id'], mock_checkout_intent.id)
+        self.assertEqual(response_data['state'], mock_checkout_intent.state)
+        self.assertEqual(response_data['enterprise_name'], mock_checkout_intent.enterprise_name)
+
+        # first_billable_invoice key should be present but valued with null
+        self.assertIsNone(response_data['first_billable_invoice'])
+
+    @mock.patch('enterprise_access.apps.bffs.checkout.handlers.get_ssp_product_pricing')
+    @mock.patch('enterprise_access.apps.bffs.checkout.handlers.get_and_cache_enterprise_customer_users')
+    @mock.patch('enterprise_access.apps.bffs.checkout.handlers.get_stripe_checkout_session')
+    @mock.patch('enterprise_access.apps.bffs.checkout.handlers.get_stripe_payment_intent')
+    @mock.patch('enterprise_access.apps.bffs.checkout.handlers.get_stripe_payment_method')
+    @mock.patch('enterprise_access.apps.bffs.checkout.handlers.get_stripe_subscription')
+    @mock.patch('enterprise_access.apps.bffs.checkout.handlers.get_stripe_invoice')
+    @mock.patch('enterprise_access.apps.bffs.checkout.handlers.get_stripe_customer')
+    @mock.patch('enterprise_access.apps.bffs.checkout.handlers.CheckoutIntent.for_user')
+    def test_success_endpoint_full_stripe_data(  # pylint: disable=unused-argument
+        self, mock_for_user, mock_customer, mock_invoice,
+        mock_subscription, mock_payment_method,
+        mock_payment_intent, mock_session,
+        mock_get_customer, mock_get_pricing,
+    ):
+        """Test the success endpoint with full Stripe data integration."""
+        mock_checkout_intent = CheckoutIntent.objects.create(
+            user_id=self.user.id,
+            state=CheckoutIntentState.CREATED,
+            quantity=10,
+            enterprise_name='Test Enterprise',
+            enterprise_slug='test-enterprise',
+            stripe_checkout_session_id='cs_test_123',
+            last_checkout_error='',
+            last_provisioning_error='',
+            expires_at=timezone.now() + timedelta(hours=4),
+        )
+        mock_for_user.return_value = mock_checkout_intent
+
+        # Setup mock Stripe API responses
+        mock_session.return_value = {
+            'id': 'cs_test_123',
+            'payment_intent': 'pi_test_123',
+            'subscription': 'sub_test_123',
+        }
+
+        mock_payment_intent.return_value = {
+            'id': 'pi_test_123',
+            'payment_method': 'pm_test_123',
+        }
+
+        mock_payment_method.return_value = {
+            'id': 'pm_test_123',
+            'card': {
+                'last4': '4242',
+            },
+            'billing_details': {
+                'address': {
+                    'city': 'New York',
+                    'country': 'US',
+                    'line1': '123 Main St',
+                    'line2': 'Apt 4B',
+                    'postal_code': '10001',
+                    'state': 'NY',
+                }
+            }
+        }
+
+        mock_subscription.return_value = {
+            'id': 'sub_test_123',
+            'latest_invoice': 'in_test_123',
+        }
+
+        mock_invoice.return_value = {
+            'id': 'in_test_123',
+            'customer': 'cus_test_123',
+            'lines': {
+                'data': [
+                    {
+                        'quantity': 35,
+                        'price': {
+                            'unit_amount_decimal': '39600',
+                        },
+                        'period': {
+                            'start': int(datetime.now().timestamp()),
+                            'end': int(datetime.now().timestamp()) + 31536000,  # +1 year
+                        }
+                    }
+                ]
+            }
+        }
+
+        mock_customer.return_value = {
+            'id': 'cus_test_123',
+            'name': 'Test Customer',
+            'phone': '+15551234567',
+        }
+
+        response = self.client.post(self.url, {})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response_data = response.json()['checkout_intent']
+        self.assertEqual(response_data['id'], mock_checkout_intent.id)
+        self.assertEqual(response_data['state'], mock_checkout_intent.state)
+
+        invoice = response_data['first_billable_invoice']
+        self.assertEqual(invoice['last4'], 4242)
+        self.assertEqual(invoice['quantity'], 35)
+        self.assertEqual(Decimal(invoice['unit_amount_decimal']), 396.00)
+        self.assertEqual(invoice['customer_name'], 'Test Customer')
+        self.assertEqual(invoice['customer_phone'], '+15551234567')
+
+        address = invoice['billing_address']
+        self.assertEqual(address['city'], 'New York')
+        self.assertEqual(address['country'], 'US')
+        self.assertEqual(address['line1'], '123 Main St')

--- a/enterprise_access/apps/api/v1/views/customer_billing.py
+++ b/enterprise_access/apps/api/v1/views/customer_billing.py
@@ -170,7 +170,7 @@ class CustomerBillingViewSet(viewsets.ViewSet):
         )
         try:
             session = create_free_trial_checkout_session(
-                request.user,
+                user=request.user,
                 **serializer.validated_data,
             )
         except CreateCheckoutSessionValidationError as exc:

--- a/enterprise_access/apps/bffs/checkout/context.py
+++ b/enterprise_access/apps/bffs/checkout/context.py
@@ -77,3 +77,12 @@ class CheckoutValidationContext(BaseHandlerContext):
     @user_authn.setter
     def user_authn(self, value):
         self.data['user_authn'] = value
+
+
+class CheckoutSuccessContext(CheckoutContext):
+    """
+    Context class for checkout success BFF endpoint.
+    This is the same structure as ``CheckoutContext``, only the contained
+    checkout intent record will be expanded with additional data
+    via the Stripe API.
+    """

--- a/enterprise_access/apps/bffs/checkout/response_builder.py
+++ b/enterprise_access/apps/bffs/checkout/response_builder.py
@@ -3,6 +3,7 @@ Response builders for the Checkout BFF endpoints.
 """
 from enterprise_access.apps.bffs.checkout.serializers import (
     CheckoutContextResponseSerializer,
+    CheckoutSuccessResponseSerializer,
     CheckoutValidationResponseSerializer
 )
 from enterprise_access.apps.bffs.response_builder import BaseResponseBuilder
@@ -62,3 +63,8 @@ class CheckoutValidationResponseBuilder(BaseResponseBuilder):
             'validation_decisions': validation_decisions,
             'user_authn': user_authn,
         }
+
+
+class CheckoutSuccessResponseBuilder(CheckoutContextResponseBuilder):
+    """Builder for checkout success responses."""
+    serializer_class = CheckoutSuccessResponseSerializer

--- a/enterprise_access/apps/bffs/response_builder.py
+++ b/enterprise_access/apps/bffs/response_builder.py
@@ -84,18 +84,21 @@ class BaseResponseBuilder:
         if not hasattr(self, 'serializer_class') or self.serializer_class is None:
             raise NotImplementedError("Subclasses must define a serializer_class.")
 
+        self.add_errors_warnings_to_response()
+        self.response_data['enterprise_features'] = getattr(self.context, 'enterprise_features', {})
+        serializer = self.serializer_class(data=self.response_data)
+
         try:
-            serializer = self.serializer_class(data=self.response_data)
             serializer.is_valid(raise_exception=True)
-            return serializer.data, self.status_code
         except Exception as exc:  # pylint: disable=broad-except
             logger.exception('Could not serialize the response data.')
             self.context.add_warning(
                 user_message='An error occurred while processing the response data.',
                 developer_message=f'Could not serialize the response data. Error: {exc}',
             )
-            self.add_errors_warnings_to_response()
-            return self.serializer_class(self.response_data).data, self.status_code
+            serializer.data['warnings'] = self.context.warnings
+
+        return serializer.data, self.status_code
 
 
 class UnauthenticatedBaseResponseBuilder(BaseResponseBuilder):

--- a/enterprise_access/apps/bffs/serializers.py
+++ b/enterprise_access/apps/bffs/serializers.py
@@ -176,6 +176,7 @@ class MinimalBffResponseSerializer(BaseBffSerializer):
     """
     errors = ErrorSerializer(many=True, required=False, default=list)
     warnings = WarningSerializer(many=True, required=False, default=list)
+    enterprise_features = serializers.DictField(required=False, default=dict)
 
 
 class BaseResponseSerializer(MinimalBffResponseSerializer):
@@ -193,7 +194,6 @@ class BaseResponseSerializer(MinimalBffResponseSerializer):
         help_text='Mapping of catalog UUIDs to catalog query UUIDs.',
     )
     algolia = SecuredAlgoliaMetadataSerializer(required=False, allow_null=True)
-    enterprise_features = serializers.DictField(required=False, default=dict)
 
 
 class CustomerAgreementSerializer(BaseBffSerializer):

--- a/enterprise_access/apps/customer_billing/models.py
+++ b/enterprise_access/apps/customer_billing/models.py
@@ -344,7 +344,8 @@ class CheckoutIntent(TimeStampedModel):
             if existing_intent.state in cls.FAILURE_STATES:
                 raise ValueError("Failed checkout record already exists")
 
-            # Update the existing CREATED intent
+            # Update the existing CREATED or EXPIRED intent
+            existing_intent.state = CheckoutIntentState.CREATED
             existing_intent.enterprise_slug = slug
             existing_intent.enterprise_name = name
             existing_intent.quantity = quantity

--- a/enterprise_access/apps/customer_billing/tests/test_stripe_api.py
+++ b/enterprise_access/apps/customer_billing/tests/test_stripe_api.py
@@ -1,0 +1,367 @@
+"""
+Unit tests for interacting with stripe via ``stripe_api.api``.
+"""
+from unittest import mock
+
+import stripe
+from django.test import TestCase
+from edx_django_utils.cache import TieredCache
+
+from enterprise_access.apps.customer_billing.stripe_api import (
+    get_stripe_checkout_session,
+    get_stripe_invoice,
+    get_stripe_payment_intent,
+    get_stripe_payment_method,
+    stripe_cache
+)
+
+
+class StripeApiFunctionsTests(TestCase):
+    """Tests for Stripe API functions with caching."""
+
+    def setUp(self):
+        """Set up test case."""
+        # Clear cache before each test
+        TieredCache.dangerous_clear_all_tiers()
+
+        # Sample test data
+        self.session_id = "cs_test_123456789"
+        self.payment_intent_id = "pi_test_123456789"
+        self.invoice_id = "in_test_123456789"
+        self.payment_method_id = "pm_test_123456789"
+
+        # Sample response objects
+        self.session_response = {"id": self.session_id, "object": "checkout.session"}
+        self.payment_intent_response = {"id": self.payment_intent_id, "object": "payment_intent"}
+        self.invoice_response = {"id": self.invoice_id, "object": "invoice"}
+        self.payment_method_response = {"id": self.payment_method_id, "object": "payment_method"}
+
+
+class TestStripeCheckoutSession(StripeApiFunctionsTests):
+    """Tests for get_stripe_checkout_session function."""
+
+    @mock.patch('enterprise_access.apps.customer_billing.stripe_api.stripe.checkout.Session.retrieve')
+    def test_get_stripe_checkout_session_success(self, mock_retrieve):
+        """Test successful retrieval of checkout session."""
+        mock_retrieve.return_value = self.session_response
+
+        # First call should hit the API
+        result = get_stripe_checkout_session(self.session_id)
+
+        mock_retrieve.assert_called_once_with(self.session_id)
+        self.assertEqual(result, self.session_response)
+
+    @mock.patch('enterprise_access.apps.customer_billing.stripe_api.stripe.checkout.Session.retrieve')
+    @mock.patch('edx_django_utils.cache.TieredCache.get_cached_response')
+    @mock.patch('edx_django_utils.cache.TieredCache.set_all_tiers')
+    def test_get_stripe_checkout_session_cache_hit(self, mock_set, mock_get, mock_retrieve):
+        """Test cache hit for checkout session."""
+        # Setup cache hit
+        mock_cached_response = mock.MagicMock()
+        mock_cached_response.is_found = True
+        mock_cached_response.value = self.session_response
+        mock_get.return_value = mock_cached_response
+
+        # Call function
+        result = get_stripe_checkout_session(self.session_id)
+
+        # Verify behavior
+        mock_get.assert_called_once()
+        mock_retrieve.assert_not_called()
+        mock_set.assert_not_called()
+        self.assertEqual(result, self.session_response)
+
+    @mock.patch('enterprise_access.apps.customer_billing.stripe_api.stripe.checkout.Session.retrieve')
+    @mock.patch('edx_django_utils.cache.TieredCache.get_cached_response')
+    @mock.patch('edx_django_utils.cache.TieredCache.set_all_tiers')
+    def test_get_stripe_checkout_session_cache_miss(self, mock_set, mock_get, mock_retrieve):
+        """Test cache miss for checkout session."""
+        # Setup cache miss
+        mock_cached_response = mock.MagicMock()
+        mock_cached_response.is_found = False
+        mock_get.return_value = mock_cached_response
+
+        # Setup API response
+        mock_retrieve.return_value = self.session_response
+
+        # Call function
+        result = get_stripe_checkout_session(self.session_id)
+
+        # Verify behavior
+        mock_get.assert_called_once()
+        mock_retrieve.assert_called_once_with(self.session_id)
+        mock_set.assert_called_once()
+        self.assertEqual(result, self.session_response)
+
+    @mock.patch('enterprise_access.apps.customer_billing.stripe_api.stripe.checkout.Session.retrieve')
+    def test_get_stripe_checkout_session_api_error(self, mock_retrieve):
+        """Test API error handling for checkout session."""
+        # Setup API error
+        mock_retrieve.side_effect = stripe.error.StripeError("API Error")
+
+        # Call function and verify exception is raised
+        with self.assertRaises(stripe.error.StripeError):
+            get_stripe_checkout_session(self.session_id)
+
+
+class TestStripePaymentIntent(StripeApiFunctionsTests):
+    """Tests for get_stripe_payment_intent function."""
+
+    @mock.patch('enterprise_access.apps.customer_billing.stripe_api.stripe.PaymentIntent.retrieve')
+    def test_get_stripe_payment_intent_success(self, mock_retrieve):
+        """Test successful retrieval of payment intent."""
+        mock_retrieve.return_value = self.payment_intent_response
+
+        # First call should hit the API
+        result = get_stripe_payment_intent(self.payment_intent_id)
+
+        mock_retrieve.assert_called_once_with(self.payment_intent_id)
+        self.assertEqual(result, self.payment_intent_response)
+
+    @mock.patch('enterprise_access.apps.customer_billing.stripe_api.stripe.PaymentIntent.retrieve')
+    @mock.patch('edx_django_utils.cache.TieredCache.get_cached_response')
+    @mock.patch('edx_django_utils.cache.TieredCache.set_all_tiers')
+    def test_get_stripe_payment_intent_cache_hit(self, mock_set, mock_get, mock_retrieve):
+        """Test cache hit for payment intent."""
+        # Setup cache hit
+        mock_cached_response = mock.MagicMock()
+        mock_cached_response.is_found = True
+        mock_cached_response.value = self.payment_intent_response
+        mock_get.return_value = mock_cached_response
+
+        # Call function
+        result = get_stripe_payment_intent(self.payment_intent_id)
+
+        # Verify behavior
+        mock_get.assert_called_once()
+        mock_retrieve.assert_not_called()
+        mock_set.assert_not_called()
+        self.assertEqual(result, self.payment_intent_response)
+
+    @mock.patch('enterprise_access.apps.customer_billing.stripe_api.stripe.PaymentIntent.retrieve')
+    @mock.patch('edx_django_utils.cache.TieredCache.get_cached_response')
+    @mock.patch('edx_django_utils.cache.TieredCache.set_all_tiers')
+    def test_get_stripe_payment_intent_cache_miss(self, mock_set, mock_get, mock_retrieve):
+        """Test cache miss for payment intent."""
+        # Setup cache miss
+        mock_cached_response = mock.MagicMock()
+        mock_cached_response.is_found = False
+        mock_get.return_value = mock_cached_response
+
+        # Setup API response
+        mock_retrieve.return_value = self.payment_intent_response
+
+        # Call function
+        result = get_stripe_payment_intent(self.payment_intent_id)
+
+        # Verify behavior
+        mock_get.assert_called_once()
+        mock_retrieve.assert_called_once_with(self.payment_intent_id)
+        mock_set.assert_called_once()
+        self.assertEqual(result, self.payment_intent_response)
+
+    @mock.patch('enterprise_access.apps.customer_billing.stripe_api.stripe.PaymentIntent.retrieve')
+    def test_get_stripe_payment_intent_api_error(self, mock_retrieve):
+        """Test API error handling for payment intent."""
+        # Setup API error
+        mock_retrieve.side_effect = stripe.error.StripeError("API Error")
+
+        # Call function and verify exception is raised
+        with self.assertRaises(stripe.error.StripeError):
+            get_stripe_payment_intent(self.payment_intent_id)
+
+
+class TestStripeInvoice(StripeApiFunctionsTests):
+    """Tests for get_stripe_invoice function."""
+
+    @mock.patch('enterprise_access.apps.customer_billing.stripe_api.stripe.Invoice.retrieve')
+    def test_get_stripe_invoice_success(self, mock_retrieve):
+        """Test successful retrieval of invoice."""
+        mock_retrieve.return_value = self.invoice_response
+
+        # First call should hit the API
+        result = get_stripe_invoice(self.invoice_id)
+
+        mock_retrieve.assert_called_once_with(self.invoice_id)
+        self.assertEqual(result, self.invoice_response)
+
+    @mock.patch('enterprise_access.apps.customer_billing.stripe_api.stripe.Invoice.retrieve')
+    @mock.patch('edx_django_utils.cache.TieredCache.get_cached_response')
+    @mock.patch('edx_django_utils.cache.TieredCache.set_all_tiers')
+    def test_get_stripe_invoice_cache_hit(self, mock_set, mock_get, mock_retrieve):
+        """Test cache hit for invoice."""
+        # Setup cache hit
+        mock_cached_response = mock.MagicMock()
+        mock_cached_response.is_found = True
+        mock_cached_response.value = self.invoice_response
+        mock_get.return_value = mock_cached_response
+
+        # Call function
+        result = get_stripe_invoice(self.invoice_id)
+
+        # Verify behavior
+        mock_get.assert_called_once()
+        mock_retrieve.assert_not_called()
+        mock_set.assert_not_called()
+        self.assertEqual(result, self.invoice_response)
+
+    @mock.patch('enterprise_access.apps.customer_billing.stripe_api.stripe.Invoice.retrieve')
+    @mock.patch('edx_django_utils.cache.TieredCache.get_cached_response')
+    @mock.patch('edx_django_utils.cache.TieredCache.set_all_tiers')
+    def test_get_stripe_invoice_cache_miss(self, mock_set, mock_get, mock_retrieve):
+        """Test cache miss for invoice."""
+        # Setup cache miss
+        mock_cached_response = mock.MagicMock()
+        mock_cached_response.is_found = False
+        mock_get.return_value = mock_cached_response
+
+        # Setup API response
+        mock_retrieve.return_value = self.invoice_response
+
+        # Call function
+        result = get_stripe_invoice(self.invoice_id)
+
+        # Verify behavior
+        mock_get.assert_called_once()
+        mock_retrieve.assert_called_once_with(self.invoice_id)
+        mock_set.assert_called_once()
+        self.assertEqual(result, self.invoice_response)
+
+    @mock.patch('enterprise_access.apps.customer_billing.stripe_api.stripe.Invoice.retrieve')
+    def test_get_stripe_invoice_api_error(self, mock_retrieve):
+        """Test API error handling for invoice."""
+        # Setup API error
+        mock_retrieve.side_effect = stripe.error.StripeError("API Error")
+
+        # Call function and verify exception is raised
+        with self.assertRaises(stripe.error.StripeError):
+            get_stripe_invoice(self.invoice_id)
+
+
+class TestStripePaymentMethod(StripeApiFunctionsTests):
+    """Tests for get_stripe_payment_method function."""
+
+    @mock.patch('enterprise_access.apps.customer_billing.stripe_api.stripe.PaymentMethod.retrieve')
+    def test_get_stripe_payment_method_success(self, mock_retrieve):
+        """Test successful retrieval of payment method."""
+        mock_retrieve.return_value = self.payment_method_response
+
+        # First call should hit the API
+        result = get_stripe_payment_method(self.payment_method_id)
+
+        mock_retrieve.assert_called_once_with(self.payment_method_id)
+        self.assertEqual(result, self.payment_method_response)
+
+    @mock.patch('enterprise_access.apps.customer_billing.stripe_api.stripe.PaymentMethod.retrieve')
+    @mock.patch('edx_django_utils.cache.TieredCache.get_cached_response')
+    @mock.patch('edx_django_utils.cache.TieredCache.set_all_tiers')
+    def test_get_stripe_payment_method_cache_hit(self, mock_set, mock_get, mock_retrieve):
+        """Test cache hit for payment method."""
+        # Setup cache hit
+        mock_cached_response = mock.MagicMock()
+        mock_cached_response.is_found = True
+        mock_cached_response.value = self.payment_method_response
+        mock_get.return_value = mock_cached_response
+
+        # Call function
+        result = get_stripe_payment_method(self.payment_method_id)
+
+        # Verify behavior
+        mock_get.assert_called_once()
+        mock_retrieve.assert_not_called()
+        mock_set.assert_not_called()
+        self.assertEqual(result, self.payment_method_response)
+
+    @mock.patch('enterprise_access.apps.customer_billing.stripe_api.stripe.PaymentMethod.retrieve')
+    @mock.patch('edx_django_utils.cache.TieredCache.get_cached_response')
+    @mock.patch('edx_django_utils.cache.TieredCache.set_all_tiers')
+    def test_get_stripe_payment_method_cache_miss(self, mock_set, mock_get, mock_retrieve):
+        """Test cache miss for payment method."""
+        # Setup cache miss
+        mock_cached_response = mock.MagicMock()
+        mock_cached_response.is_found = False
+        mock_get.return_value = mock_cached_response
+
+        # Setup API response
+        mock_retrieve.return_value = self.payment_method_response
+
+        # Call function
+        result = get_stripe_payment_method(self.payment_method_id)
+
+        # Verify behavior
+        mock_get.assert_called_once()
+        mock_retrieve.assert_called_once_with(self.payment_method_id)
+        mock_set.assert_called_once()
+        self.assertEqual(result, self.payment_method_response)
+
+    @mock.patch('enterprise_access.apps.customer_billing.stripe_api.stripe.PaymentMethod.retrieve')
+    def test_get_stripe_payment_method_api_error(self, mock_retrieve):
+        """Test API error handling for payment method."""
+        # Setup API error
+        mock_retrieve.side_effect = stripe.error.StripeError("API Error")
+
+        # Call function and verify exception is raised
+        with self.assertRaises(stripe.error.StripeError):
+            get_stripe_payment_method(self.payment_method_id)
+
+
+class TestStripeCacheDecorator(TestCase):
+    """Tests for the stripe_cache decorator itself."""
+
+    def setUp(self):
+        """Set up test case."""
+        TieredCache.dangerous_clear_all_tiers()
+
+    @mock.patch('edx_django_utils.cache.TieredCache.get_cached_response', autospec=True)
+    @mock.patch('edx_django_utils.cache.TieredCache.set_all_tiers', autospec=True)
+    def test_stripe_cache_decorator_different_keys(self, mock_set, mock_get):
+        """Test that different resource IDs create different cache keys."""
+        # Setup cache miss for all calls
+        mock_cached_response = mock.MagicMock()
+        mock_cached_response.is_found = False
+        mock_get.return_value = mock_cached_response
+
+        # Mock the stripe API call
+        with mock.patch('stripe.checkout.Session.retrieve') as mock_retrieve:
+            mock_retrieve.return_value = {"id": "test1"}
+
+            # Call with first ID
+            get_stripe_checkout_session("test1")
+
+            # Call with second ID
+            get_stripe_checkout_session("test2")
+
+        # Check that we got two different cache keys
+        self.assertEqual(mock_get.call_count, 2)
+        self.assertNotEqual(
+            mock_get.call_args_list[0][0][0],  # First call's cache key
+            mock_get.call_args_list[1][0][0],  # Second call's cache key
+        )
+        mock_set.assert_has_calls([
+            mock.call('stripe_get_stripe_checkout_session_test1', {'id': 'test1'}, django_cache_timeout=60),
+            mock.call('stripe_get_stripe_checkout_session_test2', {'id': 'test1'}, django_cache_timeout=60),
+        ])
+
+    @mock.patch('edx_django_utils.cache.TieredCache.get_cached_response')
+    @mock.patch('edx_django_utils.cache.TieredCache.set_all_tiers')
+    def test_stripe_cache_decorator_custom_timeout(self, mock_set, mock_get):
+        """Test that the timeout parameter is passed correctly."""
+        # Setup cache miss
+        mock_cached_response = mock.MagicMock()
+        mock_cached_response.is_found = False
+        mock_get.return_value = mock_cached_response
+
+        # Define a test function with custom timeout
+        @stripe_cache(timeout=120)
+        def test_function(resource_id):
+            return {"id": resource_id}
+
+        # Call the function
+        test_function("test_id")
+
+        # Check that set_all_tiers was called with the correct timeout
+        mock_set.assert_called_once()
+
+        # Third argument to set_all_tiers should be the timeout
+        call_kwargs = mock_set.call_args[1]
+        self.assertEqual(call_kwargs, {'django_cache_timeout': 120})

--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -632,6 +632,8 @@ ENABLE_CUSTOMER_BILLING_API = False
 
 DEFAULT_SSP_PRICE_LOOKUP_KEY = 'subscription_licenses_yearly'
 
+DEFAULT_STRIPE_CACHE_TIMEOUT = 60
+
 # How long we consider Stripe prices valid for
 STRIPE_PRICE_DATA_CACHE_TIMEOUT = 300
 

--- a/enterprise_access/utils.py
+++ b/enterprise_access/utils.py
@@ -4,6 +4,7 @@ Utils for any app in the enterprise-access project.
 import logging
 import traceback
 from datetime import datetime, timedelta
+from decimal import Decimal
 
 from django.apps import apps
 from pytz import UTC
@@ -287,3 +288,14 @@ def get_course_run_metadata_for_assignment(assignment, content_metadata):
 
     # For course-based assignments, return metadata for the advertised course run
     return get_advertised_course_run_metadata(content_metadata)
+
+
+def cents_to_dollars(value_in_cents):
+    """
+    Converts some value of cents (could be an int or a string)
+    into dollars.
+
+    Returns:
+      A Decimal representation of cents converted to dollars.
+    """
+    return Decimal(value_in_cents) / Decimal(100)


### PR DESCRIPTION
**Description:**
Adds a success checkout BFF endpoint that populates the checkout intent dict with more detailed data about the successful checkout session from Stripe.

Also fixes a bug with base BFF response-building/serialization layer, where errors that occurred outside of the `serialize()` function were not propagated into the response payload.

**Jira:**
ENT-10714

To test: make an authenticated request like so:
```
curl --location --request POST 'http://localhost:18270/api/v1/bffs/checkout/success/' \
--header 'Authorization: JWT [your jwt] \
--data ''
```

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
