### PR TITLE
fix: Add learner_request_state annotation for learner credit request

### DIFF
--- a/enterprise_access/apps/api/serializers/subsidy_requests.py
+++ b/enterprise_access/apps/api/serializers/subsidy_requests.py
@@ -160,6 +160,12 @@ class LearnerCreditRequestSerializer(SubsidyRequestSerializer):
         help_text="Cost of the content in USD Cents.",
     )
     latest_action = serializers.SerializerMethodField()
+    learner_request_state = serializers.CharField(
+        read_only=True,
+        help_text="Computed state based on action status and error conditions. "
+                  "Returns 'waiting' for approved/reminded actions without errors, "
+                  "'failed' for actions with error_reason, or the actual status otherwise"
+    )
 
     class Meta:
         model = LearnerCreditRequest
@@ -168,9 +174,11 @@ class LearnerCreditRequestSerializer(SubsidyRequestSerializer):
             "assignment",
             "course_price",
             "latest_action",
+            "learner_request_state",
         ]
         read_only_fields = SubsidyRequestSerializer.Meta.read_only_fields + [
             "latest_action",
+            "learner_request_state",
         ]
         extra_kwargs = SubsidyRequestSerializer.Meta.extra_kwargs
 

--- a/enterprise_access/apps/subsidy_request/admin.py
+++ b/enterprise_access/apps/subsidy_request/admin.py
@@ -197,6 +197,7 @@ class LearnerCreditRequestAdmin(BaseSubsidyRequestAdmin, admin.ModelAdmin):
         'enterprise_customer_uuid',
         'course_id',
         'state',
+        'get_learner_request_state',
         'assignment',
         'modified',
     )
@@ -239,6 +240,23 @@ class LearnerCreditRequestAdmin(BaseSubsidyRequestAdmin, admin.ModelAdmin):
 
     def get_fields(self, request, obj=None):
         return super().fields + self.fields
+
+    @admin.display(
+        description='Learner Request State',
+        ordering='learner_request_state'
+    )
+    def get_learner_request_state(self, obj):
+        """
+        Display the computed learner request state from the annotated field.
+        """
+        return getattr(obj, 'learner_request_state', 'N/A')
+
+    def get_queryset(self, request):
+        """
+        Override to ensure the annotated fields are available in the admin.
+        """
+        queryset = super().get_queryset(request)
+        return self.model.annotate_dynamic_fields_onto_queryset(queryset)
 
 
 @admin.register(models.LearnerCreditRequestConfiguration)


### PR DESCRIPTION
- Add annotated field `learner_request_state` to LearnerCreditRequest model
- Implement annotation logic to correctly handle "waiting" and "failed" states
- Update LearnerCreditRequestSerializer to expose learner_request_state field
- Enhance admin interface to display computed request state
- Add comprehensive test coverage for annotation scenarios

The learner_request_state field provides corrected status handling:
- "failed": when error_reason is present (cancellation/redemption failed)
- "waiting": for approved/reminded actions without errors
- Default: uses actual status from latest_action_status

Resolves issues with action statuses showing incorrect values like "cancelled" with error_reason instead of proper "error" status.

**Description:**
Add a description of your changes here. 

**Jira:**
ENT-XXXX

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
