### PR TITLE
fix: CI state errored provisioning -> fulfilled

### DIFF
--- a/enterprise_access/apps/customer_billing/constants.py
+++ b/enterprise_access/apps/customer_billing/constants.py
@@ -88,7 +88,7 @@ ALLOWED_CHECKOUT_INTENT_STATE_TRANSITIONS = {
         CheckoutIntentState.PAID,
     ],
     CheckoutIntentState.ERRORED_PROVISIONING: [
-        CheckoutIntentState.PAID,
+        CheckoutIntentState.FULFILLED,
     ],
     CheckoutIntentState.EXPIRED: [
         CheckoutIntentState.CREATED,


### PR DESCRIPTION
Small fix from a conversation earlier this week: CheckoutIntents in the `ERRORED_PROVISIONING` state should only be allowed to move into `FULFILLED` - moving into `PAID` is actually moving "backwards".

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
