### PR TITLE
fix: add learner_request_state filter to learner credit requests

### DIFF
--- a/enterprise_access/apps/api/filters/subsidy_request.py
+++ b/enterprise_access/apps/api/filters/subsidy_request.py
@@ -19,6 +19,11 @@ LATEST_ACTION_STATUS_HELP_TEXT = (
     ', '.join([choice for choice, _ in LearnerCreditRequestActionChoices])
 )
 
+LEARNER_REQUEST_STATE_HELP_TEXT = (
+    'Choose from the following valid learner request states: '
+    'requested, pending, approved, declined, accepted, cancelled, expired, reversed, reminded, waiting, failed'
+)
+
 
 class SubsidyRequestFilterBackend(filters.BaseFilterBackend):
     """
@@ -104,7 +109,7 @@ class SubsidyRequestCustomerConfigurationFilterBackend(filters.BaseFilterBackend
 
 class LearnerCreditRequestFilterSet(drf_filters.FilterSet):
     """
-    Custom FilterSet for LearnerCreditRequest to allow filtering by policy_uuid and latest_action_status.
+    Custom FilterSet for LearnerCreditRequest to allow filtering by policy_uuid and latest_action_status
     """
 
     policy_uuid = drf_filters.UUIDFilter(field_name='learner_credit_request_config__learner_credit_config__uuid')
@@ -119,6 +124,19 @@ class LearnerCreditRequestFilterSet(drf_filters.FilterSet):
         field_name='latest_action_status',
         lookup_expr='in',
         help_text=LATEST_ACTION_STATUS_HELP_TEXT,
+    )
+
+    # Add filtering support for learner_request_state annotated field
+    learner_request_state = CharFilter(
+        field_name='learner_request_state',
+        lookup_expr='exact',
+        help_text=LEARNER_REQUEST_STATE_HELP_TEXT,
+    )
+
+    learner_request_state__in = CharInFilter(
+        field_name='learner_request_state',
+        lookup_expr='in',
+        help_text=LEARNER_REQUEST_STATE_HELP_TEXT,
     )
 
     class Meta:

--- a/enterprise_access/apps/api/tests/test_serializers.py
+++ b/enterprise_access/apps/api/tests/test_serializers.py
@@ -495,7 +495,7 @@ class TestLearnerCreditRequestSerializer(TestCase):
 
     def test_learner_request_state_field_default_state(self):
         """
-        Test that the learner_request_state field defaults to actual status for other cases.
+        Test that the learner_request_state field shows the request state for non-special cases.
         """
         learner_credit_request = LearnerCreditRequestFactory()
 
@@ -515,7 +515,7 @@ class TestLearnerCreditRequestSerializer(TestCase):
         serializer = LearnerCreditRequestSerializer(annotated_request)
         data = serializer.data
 
-        # Verify that learner_request_state field shows the actual status
+        # Verify that learner_request_state field shows the actual state
         self.assertIn('learner_request_state', data)
-        expected_status = get_user_message_choice(SubsidyRequestStates.REQUESTED)
-        self.assertEqual(data['learner_request_state'], expected_status)
+        expected_state = SubsidyRequestStates.REQUESTED
+        self.assertEqual(data['learner_request_state'], expected_state)

--- a/enterprise_access/apps/api/v1/views/browse_and_request.py
+++ b/enterprise_access/apps/api/v1/views/browse_and_request.py
@@ -770,6 +770,7 @@ class LearnerCreditRequestViewSet(SubsidyRequestViewSet):
         'latest_action_time',
         'latest_action_type',
         'latest_action_status',
+        'learner_request_state',
 
         # State-based sorting field
         'state_sort_order',


### PR DESCRIPTION
- Add learner_request_state and learner_request_state__in filters
- Support filtering by computed states like 'waiting' and 'failed'
- Include help text with all available state values

**Description:**
Add a description of your changes here. 

**Jira:**
ENT-XXXX

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
