### PR TITLE
feat: [ForcedPolicyRedemption] Provide external reference ID fallback

### DIFF
--- a/enterprise_access/apps/subsidy_access_policy/admin/__init__.py
+++ b/enterprise_access/apps/subsidy_access_policy/admin/__init__.py
@@ -1,6 +1,7 @@
 """ Admin configuration for subsidy_access_policy models. """
 import json
 import logging
+from typing import Any, Dict
 
 from django.conf import settings
 from django.contrib import admin, messages
@@ -39,7 +40,12 @@ EVERY_SPEND_LIMIT_FIELD = [
     'per_learner_enrollment_limit',
 ]
 
-FORCED_REDEMPTION_GEAG_KEYS = ('geag_first_name', 'geag_last_name', 'geag_date_of_birth')
+FORCED_REDEMPTION_GEAG_KEYS = (
+    'geag_first_name',
+    'geag_last_name',
+    'geag_date_of_birth',
+    constants.FALLBACK_EXTERNAL_REFERENCE_ID_KEY,
+)
 FORCED_REDEMPTION_CURRENT_TIME_KEY = 'geag_terms_accepted_at'
 FORCED_REDEMPTION_DATA_SHARE_CONSENT_KEY = 'geag_data_share_consent'
 FORCED_REDEMPTION_EMAIL_KEY = 'geag_email'
@@ -451,7 +457,7 @@ class ForcedPolicyRedemptionAdmin(DjangoQLSearchMixin, SimpleHistoryAdmin):
         'traceback',
     ]
 
-    def save_model(self, request, obj, form, change):
+    def save_model(self, request, obj, form, change) -> None:
         """
         If this record has not been successfully redeemed yet,
         and if ``wait_to_redeem`` is false, then call ``force_redeem()`` on
@@ -475,7 +481,7 @@ class ForcedPolicyRedemptionAdmin(DjangoQLSearchMixin, SimpleHistoryAdmin):
 
         form.full_clean()  # populates cleaned_data below
         try:
-            extra_metadata = {
+            extra_metadata: Dict[str, Any] = {
                 key: str(form.cleaned_data.get(key))
                 for key in FORCED_REDEMPTION_GEAG_KEYS
                 if form.cleaned_data.get(key)

--- a/enterprise_access/apps/subsidy_access_policy/admin/forms.py
+++ b/enterprise_access/apps/subsidy_access_policy/admin/forms.py
@@ -92,6 +92,15 @@ class ForcedPolicyRedemptionForm(forms.ModelForm):
         help_text=_("Learner date of birth, only used for Exec Ed Redemptions"),
         required=False,
     )
+    fallback_external_fulfillment_reference_id = forms.UUIDField(
+        label=_("Order UUID of existing GEAG allocation (EE-only)"),
+        help_text=_(
+            "Link new transaction to a specific Order UUID. This is rarely needed, "
+            "as a GEAG allocation will typically not yet exist and neither will an "
+            "Order UUID. Only used for Exec Ed Redemptions."
+        ),
+        required=False,
+    )
 
     class Meta:
         model = ForcedPolicyRedemption

--- a/enterprise_access/apps/subsidy_access_policy/constants.py
+++ b/enterprise_access/apps/subsidy_access_policy/constants.py
@@ -129,6 +129,9 @@ REASON_LEARNER_ASSIGNMENT_REVERSED = "reason_learner_assignment_reversed"
 # forces enrollment to take place, regardless of course state.
 FORCE_ENROLLMENT_KEYWORD = 'allow_late_enrollment'
 
+# Transaction metadata key used by the forced redemption tool to provide a fallback external fulfillment reference ID.
+FALLBACK_EXTERNAL_REFERENCE_ID_KEY = 'fallback_external_fulfillment_reference_id'
+
 SORT_BY_ENROLLMENT_COUNT = 'enrollment_count'
 
 GROUP_MEMBERS_WITH_AGGREGATES_DEFAULT_PAGE_SIZE = 10

--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -1063,6 +1063,9 @@ class SubsidyAccessPolicy(TimeStampedModel):
                 requested_price_cents = kwargs.get('requested_price_cents')
                 if requested_price_cents is not None:
                     creation_payload['requested_price_cents'] = requested_price_cents
+                external_fulfillment_reference_id = kwargs.get('external_fulfillment_reference_id')
+                if external_fulfillment_reference_id is not None:
+                    creation_payload['external_fulfillment_reference_id'] = external_fulfillment_reference_id
                 return self.subsidy_client.create_subsidy_transaction(**creation_payload)
             except requests.exceptions.HTTPError as exc:
                 raise SubsidyAPIHTTPError('HTTPError occurred in Subsidy API request.') from exc


### PR DESCRIPTION
In cases where the external fulfillment already exists (Order UUID already exists for an existing GEAG allocation), allow the ID to be specified in the ForcePolicyRedemption form and annotate the transaction to give enterprise-subsidy redemption logic a fallback value to use.

ENT-10879

Related PR: https://github.com/openedx/enterprise-subsidy/pull/389

UI Screenshot
---

<img width="748" height="714" alt="Screenshot 2025-09-04 at 9 17 27 PM" src="https://github.com/user-attachments/assets/88c87014-779b-4ae1-8626-bde4498a7359" />

