### PR TITLE
fix: remove dead code accidentally left after refactor

### DIFF
--- a/enterprise_access/apps/subsidy_access_policy/models.py
+++ b/enterprise_access/apps/subsidy_access_policy/models.py
@@ -1063,9 +1063,6 @@ class SubsidyAccessPolicy(TimeStampedModel):
                 requested_price_cents = kwargs.get('requested_price_cents')
                 if requested_price_cents is not None:
                     creation_payload['requested_price_cents'] = requested_price_cents
-                external_fulfillment_reference_id = kwargs.get('external_fulfillment_reference_id')
-                if external_fulfillment_reference_id is not None:
-                    creation_payload['external_fulfillment_reference_id'] = external_fulfillment_reference_id
                 return self.subsidy_client.create_subsidy_transaction(**creation_payload)
             except requests.exceptions.HTTPError as exc:
                 raise SubsidyAPIHTTPError('HTTPError occurred in Subsidy API request.') from exc


### PR DESCRIPTION
The approach actually used was to pass the UUID via transaction metadata, not as a net-new `create_subsidy_transaction()` kwarg. If you follow this kwarg into the [client function code](https://github.com/openedx/edx-enterprise-subsidy-client/blob/8a6579b96abf4e927181fc17b9b1fb8b1aa56005/edx_enterprise_subsidy_client/client.py#L231-L239), it actually doesn't have a matching kwarg, and would throw an "unexpected keyword argument" error if actually passed.

Relevant: https://github.com/openedx/enterprise-access/pull/833/files#r2328422191