### PR TITLE
feat: restrict checkout form to card payment only

### DIFF
--- a/enterprise_access/apps/customer_billing/stripe_api.py
+++ b/enterprise_access/apps/customer_billing/stripe_api.py
@@ -53,7 +53,7 @@ def create_subscription_checkout_session(input_data, lms_user_id, checkout_inten
         # creating a free trial plan because the amount is always zero.
         'payment_method_collection': 'always',
         # This restricts the output for the payment element to only show the card option
-        'payment_method_types':[
+        'payment_method_types': [
             'card'
         ]
 


### PR DESCRIPTION
**Description:**
This PR adds a field to the arguments passed to create the stripe checkout session api request with the intention of only displaying the card payment option during self service purchasing. 

**Jira:**
[ENT-10627](https://2u-internal.atlassian.net/browse/ENT-10627)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
