### PR TITLE
fix: lookup keys should be singular

### DIFF
--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -619,12 +619,12 @@ SSP_TRIAL_PERIOD_DAYS = 14
 SSP_PRODUCTS = {
     'quarterly_license_plan': {
         'stripe_price_id': 'price_1234_replace-me',  # DEPRECATED: Use lookup_key instead
-        'lookup_key': 'teams_subscription_licenses_quarterly',
+        'lookup_key': 'teams_subscription_license_quarterly',
         'quantity_range': (5, 30),
     },
     'yearly_license_plan': {
         'stripe_price_id': 'price_9876_replace-me',  # DEPRECATED: Use lookup_key instead
-        'lookup_key': 'teams_subscription_licenses_yearly',
+        'lookup_key': 'teams_subscription_license_yearly',
         'quantity_range': (5, 30),
     },
 }
@@ -632,7 +632,7 @@ SSP_PRODUCTS = {
 # Enable the customer billing API endpoints under /api/v1/customer-billing/*
 ENABLE_CUSTOMER_BILLING_API = False
 
-DEFAULT_SSP_PRICE_LOOKUP_KEY = 'teams_subscription_licenses_yearly'
+DEFAULT_SSP_PRICE_LOOKUP_KEY = 'teams_subscription_license_yearly'
 
 DEFAULT_STRIPE_CACHE_TIMEOUT = 60
 


### PR DESCRIPTION
This was extremely difficult for me to root cause because they looked the same at a glance.  Here's how they're configured in terraform to prove they should be singular:

https://github.com/edx/terraform/blob/1c5b4c03d6dcc40b098d74901f64d236679bb009/plans/stripe/edxorg_enterprise/stage/prices.tf#L17

<img width="735" height="446" alt="Screenshot 2025-09-15 at 4 02 14 PM" src="https://github.com/user-attachments/assets/66796978-4583-4148-b882-63738424954f" />
