### PR TITLE
fix: adding learner profile permissions to operators

### DIFF
--- a/enterprise_access/settings/base.py
+++ b/enterprise_access/settings/base.py
@@ -343,6 +343,7 @@ SYSTEM_TO_FEATURE_ROLE_MAPPING = {
         BFF_OPERATOR_ROLE,
         PROVISIONING_ADMIN_ROLE,
         CUSTOMER_BILLING_OPERATOR_ROLE,
+        ADMIN_LEARNER_PROFILE_ADMIN_ROLE,
     ],
     SYSTEM_ENTERPRISE_ADMIN_ROLE: [
         # enterprise admins only need learner-level access to Subsidy Access Policy APIs since they aren't responsible


### PR DESCRIPTION
**Description:**
Continuation of this ticket, which provided permissions to view a learner detail page from admin-portal, but did not give those permissions to people with the edx-operator role, so some internal staff were having trouble viewing it. This PR retains admin access but given to operators as well. 

**Jira:**
[ENT-10917
](https://2u-internal.atlassian.net/browse/ENT-10917)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
