### PR TITLE
fix: autocomplete checkoutintent user field correctly

### DIFF
--- a/enterprise_access/apps/core/admin.py
+++ b/enterprise_access/apps/core/admin.py
@@ -20,3 +20,8 @@ class CustomUserAdmin(DjangoQLSearchMixin, UserAdmin):
         (_('Important dates'), {'fields': ('last_login', 'date_joined')}),
     )
     readonly_fields = ('lms_user_id',)
+
+    search_fields = [
+        'email',
+        'username',
+    ]

--- a/enterprise_access/apps/customer_billing/admin.py
+++ b/enterprise_access/apps/customer_billing/admin.py
@@ -76,8 +76,6 @@ class CheckoutIntentAdmin(admin.ModelAdmin):
     search_fields = (
         'enterprise_slug',
         'enterprise_name',
-        'user__email',
-        'user__username',
         'stripe_checkout_session_id',
     )
 


### PR DESCRIPTION
Makes the user autocomplete search work on the CheckoutIntent admin form by adding search fields to the related `User` admin class.
<img width="643" height="640" alt="image" src="https://github.com/user-attachments/assets/aad7c76b-6b69-4495-93a9-03e4e4f5e354" />


**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
