### PR TITLE
feat: Serialize `quantity` and send `admin_email` to stripe

### DIFF
--- a/enterprise_access/apps/bffs/checkout/serializers.py
+++ b/enterprise_access/apps/bffs/checkout/serializers.py
@@ -109,6 +109,9 @@ class CheckoutIntentMinimalResponseSerializer(serializers.Serializer):
     enterprise_slug = serializers.CharField(
         help_text='The enterprise slug associated with this record', required=False,
     )
+    quantity = serializers.IntegerField(
+        help_text='The amount of licences created with this checkout intent', required=False,
+    )
     stripe_checkout_session_id = serializers.CharField(
         help_text='The stripe checkout session id for this intent',
         required=False,

--- a/enterprise_access/apps/bffs/tests/test_checkout_response_builder.py
+++ b/enterprise_access/apps/bffs/tests/test_checkout_response_builder.py
@@ -43,6 +43,7 @@ class TestCheckoutContextResponseBuilder(APITest):
             'state': 'created',
             'enterprise_name': 'Test Enterprise',
             'enterprise_slug': 'test-enterprise',
+            'quantity': 5,
             'expires_at': timezone.now() + timedelta(hours=24),
             'stripe_checkout_session_id': 'cs_test_123abc',
             'last_checkout_error': '',
@@ -355,6 +356,7 @@ class TestCheckoutContextResponseBuilder(APITest):
         self.assertEqual(intent_data['enterprise_slug'], 'test-enterprise')
         self.assertEqual(intent_data['stripe_checkout_session_id'], 'cs_test_123abc')
         self.assertEqual(intent_data['admin_portal_url'], 'https://portal.edx.org/test-enterprise')
+        self.assertEqual(intent_data['quantity'], 5)
 
     def test_build_context_with_no_checkout_intent(self):
         """
@@ -637,6 +639,7 @@ class TestCheckoutSuccessResponseBuilder(APITest):
             'state': 'created',
             'enterprise_name': 'Test Enterprise',
             'enterprise_slug': 'test-enterprise',
+            'quantity': 5,
             'stripe_checkout_session_id': 'cs_test_123',
             'last_checkout_error': '',
             'last_provisioning_error': '',

--- a/enterprise_access/apps/customer_billing/stripe_api.py
+++ b/enterprise_access/apps/customer_billing/stripe_api.py
@@ -71,6 +71,8 @@ def create_subscription_checkout_session(input_data, lms_user_id, checkout_inten
     )
     if found_stripe_customer_by_email:
         create_kwargs['customer'] = found_stripe_customer_by_email['id']
+    else:
+        create_kwargs['customer_email'] = input_data['admin_email']
 
     return stripe.checkout.Session.create(**create_kwargs)
 


### PR DESCRIPTION
**Description:**
This pull request introduces a new field to the checkout intent serializer to track license quantity, improves the logic for Stripe checkout session creation by setting the customer email when a customer is not found, and includes a minor import addition. The most important changes are:

**Checkout Intent Serialization:**

* Added a new `quantity` field to the `CheckoutIntentMinimalResponseSerializer` to represent the number of licenses associated with a checkout intent.

**Stripe Checkout Session Logic:**

* Updated the `create_subscription_checkout_session` function to set the `customer_email` when a Stripe customer is not found by email, ensuring the session is associated with the correct email address.


**Jira:**
ENT-XXXX

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
