### PR TITLE
fix: allow stripe event to flip checkout intent to paid

### DIFF
--- a/enterprise_access/apps/customer_billing/stripe_event_handlers.py
+++ b/enterprise_access/apps/customer_billing/stripe_event_handlers.py
@@ -61,17 +61,18 @@ class StripeEventHandler:
         """
         Handle invoice.paid events.
         """
-        invoice = event.data.object
+        # Extract relevant metadata for logging
+        invoice_id = event.data.object.id
+        subscription_details = event.data.object.parent.subscription_details
+        subscription_id = subscription_details['subscription']
 
         # Extract the checkout_intent ID from the related subscription.
-        subscription_id = invoice['subscription']
-        subscription = get_stripe_subscription(subscription_id)
-        checkout_intent_id = int(subscription.metadata['checkout_intent_id'])
+        checkout_intent_id = int(subscription_details.metadata['checkout_intent_id'])
 
         logger.info(
             f'Found checkout_intent_id="{checkout_intent_id}" '
             f'stored on the Subscription <subscription_id="{subscription_id}"> '
-            f'related to Invoice <invoice_id="{invoice["id"]}">.'
+            f'related to Invoice <invoice_id="{invoice_id}">.'
         )
 
         checkout_intent = CheckoutIntent.objects.get(id=checkout_intent_id)


### PR DESCRIPTION
**Description:**
This pull request refactors how Stripe event data is accessed and improves the test suite for the `invoice_paid` event handler. The main focus is to make the event handler and its tests more robust by using an attribute-accessible dictionary for event data and simplifying the mocking of Stripe objects.

**Refactor of event data access and test improvements:**

* The `invoice_paid` handler now accesses invoice and subscription details using attribute access rather than dictionary access, reflecting a more realistic Stripe event object structure and improving code readability.

* A new `AttrDict` helper class is introduced in the test suite to allow both attribute and item access to mock event data, closely mimicking Stripe's actual event objects.

* The `_create_mock_stripe_event` test helper now wraps event data with `AttrDict`, ensuring consistency with the production code's expectations.

* The mock Stripe subscription in tests is now a simple dictionary rather than a `MagicMock`, and is embedded within the event's nested structure to match the new access pattern. [[1]](diffhunk://#diff-3b8a70c039f1237697ac401e728bc63829af8abdc89b77899b0f27e7f2491a72L48-L60) [[2]](diffhunk://#diff-3b8a70c039f1237697ac401e728bc63829af8abdc89b77899b0f27e7f2491a72R128-R137)

* Unused and now-unnecessary test code related to mocking the Stripe API and simulating API errors has been removed, simplifying the test logic.

**Jira:**
ENT-10976

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
