### PR TITLE
feat: SSP Teams plans should be provisioned with enable_analytics_screen=False

### DIFF
--- a/enterprise_access/apps/api_client/lms_client.py
+++ b/enterprise_access/apps/api_client/lms_client.py
@@ -204,6 +204,7 @@ class LmsApiClient(BaseOAuthClient):
             'name': name,
             'slug': slug,
             'country': country,
+            'enable_analytics_screen': False,
             'site': {
                 'domain': settings.PROVISIONING_DEFAULTS['customer']['site_domain'],
             },

--- a/enterprise_access/apps/api_client/tests/test_lms_client.py
+++ b/enterprise_access/apps/api_client/tests/test_lms_client.py
@@ -477,6 +477,7 @@ class TestLmsApiClient(TestCase):
             'name': 'New Customer',
             'slug': 'new-customer',
             'country': 'US',
+            'enable_analytics_screen': False,
             'other_field': True,
         }
 
@@ -484,6 +485,7 @@ class TestLmsApiClient(TestCase):
             'name': 'New Customer',
             'slug': 'new-customer',
             'country': 'US',
+            'enable_analytics_screen': False,
             'other_field': True,
         }
         mock_json.return_value = mock_created_customer_payload
@@ -625,6 +627,7 @@ class TestLmsApiClient(TestCase):
             'name': 'New Customer',
             'slug': 'new-customer',
             'country': 'US',
+            'enable_analytics_screen': False,
             'other_field': True,
         }
 


### PR DESCRIPTION

**Description:**
SSP Teams plans should be provisioned with enable_analytics_screen=False by default.

**Jira:**
[ENT-10727](https://2u-internal.atlassian.net/browse/ENT-10727)

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
