### PR TITLE
fix: add forward slash between slug and url for admin portal url

### DIFF
--- a/enterprise_access/apps/customer_billing/models.py
+++ b/enterprise_access/apps/customer_billing/models.py
@@ -256,7 +256,7 @@ class CheckoutIntent(TimeStampedModel):
     @property
     def admin_portal_url(self):
         if self.state == CheckoutIntentState.FULFILLED:
-            return f"{settings.ENTERPRISE_ADMIN_PORTAL_URL}{self.enterprise_slug}"
+            return f"{settings.ENTERPRISE_ADMIN_PORTAL_URL}/{self.enterprise_slug}"
         return None
 
     @classmethod

--- a/enterprise_access/apps/customer_billing/tests/test_models.py
+++ b/enterprise_access/apps/customer_billing/tests/test_models.py
@@ -356,7 +356,7 @@ class TestCheckoutIntentModel(TestCase):
         self.assertIsNone(intent.admin_portal_url)
 
         # Move to FULFILLED
-        with self.settings(ENTERPRISE_ADMIN_PORTAL_URL='https://admin.example.com/'):
+        with self.settings(ENTERPRISE_ADMIN_PORTAL_URL='https://admin.example.com'):
             intent.mark_as_fulfilled()
             self.assertEqual(
                 intent.admin_portal_url,


### PR DESCRIPTION
**Description:**
This pull request makes a small but important fix to the formatting of the admin portal URL for fulfilled checkout intents, ensuring a slash is present between the base URL and the enterprise slug. It also updates the related test to match the new URL formatting.

See the [prod and stage](https://github.com/search?q=repo%3Aedx%2Fedx-internal%20ENTERPRISE_ADMIN_PORTAL_URL&type=code) config files for validation. 

- URL formatting fix:
  * Updated the `admin_portal_url` property in `customer_billing/models.py` to include a slash (`/`) between `ENTERPRISE_ADMIN_PORTAL_URL` and `enterprise_slug`, ensuring correct URL construction.

- Test update:
  * Modified the test in `test_models.py` to use the base URL without a trailing slash, aligning the test with the new URL formatting logic.

**Jira:**
ENT-XXXX

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
