### PR TITLE
build: ensure to pull dev image on dev.up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,12 +175,15 @@ travis_docker_push: travis_docker_tag travis_docker_auth ## push to docker hub
 	docker push 'openedx/enterprise-access:latest-newrelic'
 	docker push "openedx/enterprise-access:$$TRAVIS_COMMIT-newrelic"
 
+dev.pull:
+	docker image pull edxops/enterprise-access-dev
+
 dev.provision:
 	bash ./provision-enterprise-access.sh
 
 # devstack-themed shortcuts
 # Starts all containers
-dev.up: dev.up.redis
+dev.up: dev.pull dev.up.redis
 	docker-compose up -d
 
 dev.up.with-events: dev.up.kafka-control-center dev.up


### PR DESCRIPTION
We need to pull the dev image sometimes, I don't wanna remember to do it manually.

**Merge checklist:**
- [ ] `./manage.py makemigrations` has been run
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.

**Post merge:**
- [ ] Ensure that your changes went out to the stage instance
- [ ] Deploy to prod instance
